### PR TITLE
feat: sélecteur de thème Jour/Nuit/Automatique dans le viewer

### DIFF
--- a/viewer/index.html
+++ b/viewer/index.html
@@ -4,6 +4,14 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WUDD.ai — Explorateur</title>
+    <script>
+      (function () {
+        var t = localStorage.getItem('wudd_theme') || 'auto';
+        if (t === 'nuit' || (t === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/viewer/src/App.jsx
+++ b/viewer/src/App.jsx
@@ -3,7 +3,24 @@ import Sidebar from './components/Sidebar'
 import FileViewer from './components/FileViewer'
 import SearchOverlay from './components/SearchOverlay'
 import SettingsPanel from './components/SettingsPanel'
-import { Search, Settings } from 'lucide-react'
+import { Search, Settings, Sun, Moon, Monitor } from 'lucide-react'
+
+const THEME_OPTIONS = [
+  { key: 'jour', Icon: Sun,     title: 'Jour' },
+  { key: 'auto', Icon: Monitor, title: 'Automatique' },
+  { key: 'nuit', Icon: Moon,    title: 'Nuit' },
+]
+
+function applyTheme(theme) {
+  const html = document.documentElement
+  if (theme === 'nuit') {
+    html.classList.add('dark')
+  } else if (theme === 'jour') {
+    html.classList.remove('dark')
+  } else {
+    html.classList.toggle('dark', window.matchMedia('(prefers-color-scheme: dark)').matches)
+  }
+}
 
 export default function App() {
   const [files, setFiles] = useState([])
@@ -15,7 +32,24 @@ export default function App() {
   const [typeFilter, setTypeFilter] = useState('all')
   const [nameSearch, setNameSearch] = useState('')
 
-  // Charger la liste des fichiers au démarrage
+  // ── Thème ──────────────────────────────────────────────────────────────────
+  const [theme, setTheme] = useState(() => localStorage.getItem('wudd_theme') || 'auto')
+
+  useEffect(() => {
+    localStorage.setItem('wudd_theme', theme)
+    applyTheme(theme)
+  }, [theme])
+
+  // En mode automatique, écouter les changements de préférence système
+  useEffect(() => {
+    if (theme !== 'auto') return
+    const mq = window.matchMedia('(prefers-color-scheme: dark)')
+    const handler = () => applyTheme('auto')
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [theme])
+
+  // ── Données ────────────────────────────────────────────────────────────────
   useEffect(() => {
     fetch('/api/files')
       .then(r => r.json())
@@ -68,7 +102,6 @@ export default function App() {
       const err = await r.json().catch(() => ({}))
       throw new Error(err.description || 'Erreur lors de la sauvegarde')
     }
-    // Mettre à jour le contenu affiché avec la version sauvegardée
     setFileContent(newContent)
   }, [])
 
@@ -79,23 +112,44 @@ export default function App() {
   })
 
   return (
-    <div className="h-screen flex flex-col bg-slate-900 text-slate-100 overflow-hidden">
+    <div className="h-screen flex flex-col bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 overflow-hidden">
       {/* ── Barre de navigation ── */}
-      <header className="flex items-center gap-3 px-4 py-2.5 bg-slate-800 border-b border-slate-700 shrink-0">
+      <header className="flex items-center gap-3 px-4 py-2.5 bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <div className="flex items-center gap-2">
           <div className="w-6 h-6 bg-blue-500 rounded-md flex items-center justify-center text-xs font-bold text-white select-none">
             W
           </div>
-          <span className="font-semibold text-slate-100">WUDD.ai</span>
-          <span className="text-slate-500 text-sm">/ Explorateur</span>
+          <span className="font-semibold text-slate-900 dark:text-slate-100">WUDD.ai</span>
+          <span className="text-slate-400 dark:text-slate-500 text-sm">/ Explorateur</span>
         </div>
 
         <div className="flex-1" />
 
+        {/* Sélecteur de thème */}
+        <div
+          className="flex items-center rounded-lg border border-slate-200 dark:border-slate-600 overflow-hidden shrink-0"
+          title="Thème d'affichage"
+        >
+          {THEME_OPTIONS.map(({ key, Icon, title }) => (
+            <button
+              key={key}
+              onClick={() => setTheme(key)}
+              title={title}
+              className={`px-2 py-1.5 transition-colors ${
+                theme === key
+                  ? 'bg-blue-600 text-white'
+                  : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-700 dark:hover:text-slate-200'
+              }`}
+            >
+              <Icon size={13} />
+            </button>
+          ))}
+        </div>
+
         {/* Réglages */}
         <button
           onClick={() => setSettingsOpen(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Réglages — planification, mots-clés, flux"
         >
           <Settings size={13} />
@@ -105,11 +159,11 @@ export default function App() {
         {/* Recherche plein texte */}
         <button
           onClick={() => setSearchOpen(true)}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-sm text-slate-400 hover:text-slate-200 transition-colors"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
         >
           <Search size={13} />
           <span className="hidden sm:inline">Recherche plein texte</span>
-          <kbd className="hidden md:inline-flex items-center gap-0.5 ml-1 text-xs bg-slate-900 text-slate-500 px-1.5 py-0.5 rounded border border-slate-700">
+          <kbd className="hidden md:inline-flex items-center gap-0.5 ml-1 text-xs bg-slate-200 dark:bg-slate-900 text-slate-400 dark:text-slate-500 px-1.5 py-0.5 rounded border border-slate-300 dark:border-slate-700">
             Ctrl K
           </kbd>
         </button>

--- a/viewer/src/components/FileViewer.jsx
+++ b/viewer/src/components/FileViewer.jsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react'
-import { Download, FileJson, FileText, Calendar, HardDrive, ChevronRight, Images } from 'lucide-react'
+import { Download, FileText, Calendar, HardDrive, ChevronRight, Images } from 'lucide-react'
 import JsonViewer from './JsonViewer'
 import MarkdownViewer from './MarkdownViewer'
 
@@ -57,11 +57,11 @@ function ImageGallery({ content }) {
     <div className="mt-6">
       {/* En-tête section */}
       <div className="flex items-center gap-2 mb-3">
-        <Images size={14} className="text-slate-400" />
-        <span className="text-sm font-semibold text-slate-300">
+        <Images size={14} className="text-slate-500 dark:text-slate-400" />
+        <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
           Images
         </span>
-        <span className="text-xs text-slate-600 bg-slate-800 px-1.5 py-0.5 rounded-full">
+        <span className="text-xs text-slate-500 dark:text-slate-600 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded-full">
           {visible.length}
         </span>
       </div>
@@ -72,10 +72,10 @@ function ImageGallery({ content }) {
           <button
             key={i}
             onClick={() => setLightbox(i)}
-            className="group text-left rounded-xl overflow-hidden bg-slate-800 border border-slate-700 hover:border-blue-500/60 transition-all hover:shadow-lg hover:shadow-blue-900/20 focus:outline-none focus:border-blue-500"
+            className="group text-left rounded-xl overflow-hidden bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 hover:border-blue-500/60 transition-all hover:shadow-lg hover:shadow-blue-500/10 dark:hover:shadow-blue-900/20 focus:outline-none focus:border-blue-500"
           >
             {/* Vignette */}
-            <div className="aspect-video overflow-hidden bg-slate-900 relative">
+            <div className="aspect-video overflow-hidden bg-slate-100 dark:bg-slate-900 relative">
               <img
                 src={img.url}
                 alt={img.source}
@@ -89,10 +89,10 @@ function ImageGallery({ content }) {
             {(img.source || img.date) && (
               <div className="px-2.5 py-2">
                 {img.source && (
-                  <div className="text-[11px] text-slate-300 truncate font-medium">{img.source}</div>
+                  <div className="text-[11px] text-slate-700 dark:text-slate-300 truncate font-medium">{img.source}</div>
                 )}
                 {img.date && (
-                  <div className="text-[10px] text-slate-500 mt-0.5">{img.date}</div>
+                  <div className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5">{img.date}</div>
                 )}
               </div>
             )}
@@ -194,13 +194,13 @@ function Lightbox({ images, index, onClose, onNav }) {
 export default function FileViewer({ file, content, loading, onDownload, onContentSaved }) {
   if (!file) {
     return (
-      <main className="flex-1 flex items-center justify-center bg-slate-900 select-none">
+      <main className="flex-1 flex items-center justify-center bg-slate-50 dark:bg-slate-900 select-none">
         <div className="text-center">
-          <div className="w-16 h-16 rounded-2xl bg-slate-800 flex items-center justify-center mx-auto mb-4 border border-slate-700">
-            <FileText size={28} className="text-slate-600" />
+          <div className="w-16 h-16 rounded-2xl bg-white dark:bg-slate-800 flex items-center justify-center mx-auto mb-4 border border-slate-200 dark:border-slate-700">
+            <FileText size={28} className="text-slate-400 dark:text-slate-600" />
           </div>
-          <p className="text-slate-400 font-medium mb-1">Aucun fichier sélectionné</p>
-          <p className="text-slate-600 text-sm">Choisissez un fichier dans la liste de gauche</p>
+          <p className="text-slate-500 dark:text-slate-400 font-medium mb-1">Aucun fichier sélectionné</p>
+          <p className="text-slate-400 dark:text-slate-600 text-sm">Choisissez un fichier dans la liste de gauche</p>
         </div>
       </main>
     )
@@ -209,15 +209,15 @@ export default function FileViewer({ file, content, loading, onDownload, onConte
   const pathParts = file.path.split('/')
 
   return (
-    <main className="flex-1 flex flex-col overflow-hidden bg-slate-900">
+    <main className="flex-1 flex flex-col overflow-hidden bg-slate-50 dark:bg-slate-900">
       {/* ── Barre de fichier ── */}
-      <div className="flex items-center gap-3 px-5 py-2.5 bg-slate-800/70 border-b border-slate-700 shrink-0">
+      <div className="flex items-center gap-3 px-5 py-2.5 bg-white/70 dark:bg-slate-800/70 border-b border-slate-200 dark:border-slate-700 shrink-0">
         {/* Fil d'Ariane */}
-        <div className="flex items-center gap-0.5 min-w-0 flex-1 text-xs text-slate-500 overflow-hidden">
+        <div className="flex items-center gap-0.5 min-w-0 flex-1 text-xs text-slate-400 dark:text-slate-500 overflow-hidden">
           {pathParts.map((part, i) => (
             <span key={i} className="flex items-center gap-0.5 shrink-0">
-              {i > 0 && <ChevronRight size={10} className="text-slate-700" />}
-              <span className={i === pathParts.length - 1 ? 'text-slate-300 font-medium' : ''}>
+              {i > 0 && <ChevronRight size={10} className="text-slate-300 dark:text-slate-700" />}
+              <span className={i === pathParts.length - 1 ? 'text-slate-700 dark:text-slate-300 font-medium' : ''}>
                 {part}
               </span>
             </span>
@@ -225,7 +225,7 @@ export default function FileViewer({ file, content, loading, onDownload, onConte
         </div>
 
         {/* Méta */}
-        <div className="hidden lg:flex items-center gap-4 text-xs text-slate-500 shrink-0">
+        <div className="hidden lg:flex items-center gap-4 text-xs text-slate-400 dark:text-slate-500 shrink-0">
           <span className="flex items-center gap-1">
             <Calendar size={11} />
             {formatDate(file.modified)}
@@ -236,8 +236,8 @@ export default function FileViewer({ file, content, loading, onDownload, onConte
           </span>
           <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${
             file.type === 'json'
-              ? 'bg-amber-900/40 text-amber-400'
-              : 'bg-blue-900/40 text-blue-400'
+              ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400'
+              : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
           }`}>
             {file.type === 'json' ? 'JSON' : 'Markdown'}
           </span>
@@ -256,15 +256,15 @@ export default function FileViewer({ file, content, loading, onDownload, onConte
       {/* ── Contenu ── */}
       <div className="flex-1 overflow-auto p-6">
         {loading ? (
-          <div className="flex flex-col items-center justify-center h-full gap-3 text-slate-500">
-            <div className="w-5 h-5 border-2 border-slate-600 border-t-blue-500 rounded-full animate-spin" />
+          <div className="flex flex-col items-center justify-center h-full gap-3 text-slate-400 dark:text-slate-500">
+            <div className="w-5 h-5 border-2 border-slate-300 dark:border-slate-600 border-t-blue-500 rounded-full animate-spin" />
             <span className="text-sm">Chargement…</span>
           </div>
         ) : content === null ? (
-          <div className="text-slate-500 text-sm">Contenu indisponible</div>
+          <div className="text-slate-400 dark:text-slate-500 text-sm">Contenu indisponible</div>
         ) : file.type === 'json' ? (
           <>
-            <div className="bg-slate-950 rounded-xl p-6 border border-slate-800/60">
+            <div className="bg-slate-100 dark:bg-slate-950 rounded-xl p-6 border border-slate-200 dark:border-slate-800/60">
               <JsonViewer
                 content={content}
                 onSave={onContentSaved ? (newContent) => onContentSaved(file.path, newContent) : undefined}

--- a/viewer/src/components/JsonViewer.jsx
+++ b/viewer/src/components/JsonViewer.jsx
@@ -10,7 +10,8 @@ function escapeHtml(str) {
 
 /**
  * Applique la coloration syntaxique JSON via du HTML inline.
- * On échappe d'abord le HTML pour éviter toute injection.
+ * Utilise des classes CSS (json-key, json-string, etc.) plutôt que des
+ * styles inline, afin que les couleurs s'adaptent au thème Jour/Nuit.
  */
 function highlightJson(code) {
   const safe = escapeHtml(code)
@@ -19,22 +20,22 @@ function highlightJson(code) {
     (match) => {
       // Clé d'objet : chaîne suivie de ":"
       if (/^".*"(\s*):$/.test(match) || /^".*":$/.test(match)) {
-        return `<span style="color:#f6c96c">${match}</span>`
+        return `<span class="json-key">${match}</span>`
       }
       // Valeur chaîne
       if (match.startsWith('"')) {
-        return `<span style="color:#86efac">${match}</span>`
+        return `<span class="json-string">${match}</span>`
       }
       // Booléen
       if (match === 'true' || match === 'false') {
-        return `<span style="color:#fb7185">${match}</span>`
+        return `<span class="json-bool">${match}</span>`
       }
       // Null
       if (match === 'null') {
-        return `<span style="color:#94a3b8">${match}</span>`
+        return `<span class="json-null">${match}</span>`
       }
       // Nombre
-      return `<span style="color:#93c5fd">${match}</span>`
+      return `<span class="json-number">${match}</span>`
     },
   )
 }
@@ -63,7 +64,6 @@ export default function JsonViewer({ content, onSave }) {
   }, [content])
 
   const handleEditStart = () => {
-    // Formater le JSON avant édition
     try {
       setEditContent(JSON.stringify(JSON.parse(content), null, 2))
     } catch {
@@ -104,11 +104,11 @@ export default function JsonViewer({ content, onSave }) {
         {/* Barre d'outils édition */}
         <div className="flex items-center gap-2 justify-end">
           {editError && (
-            <span className="text-xs text-red-400 flex-1">{editError}</span>
+            <span className="text-xs text-red-500 dark:text-red-400 flex-1">{editError}</span>
           )}
           <button
             onClick={handleCancel}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-xs text-slate-300 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-xs text-slate-700 dark:text-slate-300 transition-colors"
           >
             <X size={12} /> Annuler
           </button>
@@ -127,7 +127,7 @@ export default function JsonViewer({ content, onSave }) {
           value={editContent}
           onChange={e => { setEditContent(e.target.value); setEditError(null) }}
           spellCheck={false}
-          className="w-full min-h-[60vh] text-sm font-mono leading-relaxed text-slate-200 bg-slate-950 border border-blue-500/40 rounded-xl p-4 resize-y focus:outline-none focus:border-blue-400 transition-colors"
+          className="w-full min-h-[60vh] text-sm font-mono leading-relaxed text-slate-800 dark:text-slate-200 bg-white dark:bg-slate-950 border border-blue-500/40 rounded-xl p-4 resize-y focus:outline-none focus:border-blue-400 transition-colors"
         />
       </div>
     )
@@ -140,7 +140,7 @@ export default function JsonViewer({ content, onSave }) {
         <div className="flex justify-end mb-3">
           <button
             onClick={handleEditStart}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-xs text-slate-300 transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-xs text-slate-700 dark:text-slate-300 transition-colors"
           >
             <Pencil size={12} /> Modifier
           </button>
@@ -148,12 +148,12 @@ export default function JsonViewer({ content, onSave }) {
       )}
 
       {parseError && (
-        <div className="mb-3 px-3 py-2 bg-red-900/30 border border-red-700/50 rounded-lg text-xs text-red-400 font-mono">
+        <div className="mb-3 px-3 py-2 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-700/50 rounded-lg text-xs text-red-600 dark:text-red-400 font-mono">
           JSON invalide : {parseError}
         </div>
       )}
       <pre
-        className="text-sm font-mono leading-relaxed text-slate-300 whitespace-pre-wrap break-words"
+        className="text-sm font-mono leading-relaxed text-slate-700 dark:text-slate-300 whitespace-pre-wrap break-words"
         dangerouslySetInnerHTML={{ __html: highlighted }}
       />
     </div>

--- a/viewer/src/components/MarkdownViewer.jsx
+++ b/viewer/src/components/MarkdownViewer.jsx
@@ -4,7 +4,7 @@ import rehypeRaw from 'rehype-raw'
 import { useMemo, useEffect, useRef } from 'react'
 import mermaid from 'mermaid'
 
-mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'loose' })
+mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' })
 
 function MermaidBlock({ code }) {
   const ref = useRef(null)
@@ -55,15 +55,15 @@ export default function MarkdownViewer({ content }) {
     <div className="max-w-3xl mx-auto">
       {/* Métadonnées frontmatter */}
       {meta && (
-        <div className="mb-6 p-4 bg-slate-800/60 rounded-xl border border-slate-700 text-sm">
-          <div className="text-[10px] font-semibold text-slate-500 uppercase tracking-widest mb-3">
+        <div className="mb-6 p-4 bg-white/60 dark:bg-slate-800/60 rounded-xl border border-slate-200 dark:border-slate-700 text-sm">
+          <div className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-3">
             Métadonnées du rapport
           </div>
           <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5">
             {Object.entries(meta).map(([k, v]) => (
               <div key={k} className="contents">
-                <dt className="text-slate-500 text-xs">{k}</dt>
-                <dd className="text-slate-300 text-xs">{v}</dd>
+                <dt className="text-slate-400 dark:text-slate-500 text-xs">{k}</dt>
+                <dd className="text-slate-700 dark:text-slate-300 text-xs">{v}</dd>
               </div>
             ))}
           </dl>
@@ -76,28 +76,28 @@ export default function MarkdownViewer({ content }) {
         rehypePlugins={[rehypeRaw]}
         components={{
           h1: ({ children }) => (
-            <h1 className="text-2xl font-bold text-slate-100 mt-8 mb-4 pb-2 border-b border-slate-700 first:mt-0">
+            <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mt-8 mb-4 pb-2 border-b border-slate-200 dark:border-slate-700 first:mt-0">
               {children}
             </h1>
           ),
           h2: ({ children }) => (
-            <h2 className="text-xl font-semibold text-slate-100 mt-7 mb-3">{children}</h2>
+            <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mt-7 mb-3">{children}</h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-base font-semibold text-slate-200 mt-5 mb-2">{children}</h3>
+            <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200 mt-5 mb-2">{children}</h3>
           ),
           h4: ({ children }) => (
-            <h4 className="text-sm font-semibold text-slate-300 mt-4 mb-1">{children}</h4>
+            <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mt-4 mb-1">{children}</h4>
           ),
           p: ({ children }) => (
-            <p className="text-slate-300 mb-4 leading-7">{children}</p>
+            <p className="text-slate-700 dark:text-slate-300 mb-4 leading-7">{children}</p>
           ),
           a: ({ href, children }) => (
             <a
               href={href}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-blue-400 hover:text-blue-300 underline underline-offset-2"
+              className="text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 underline underline-offset-2"
             >
               {children}
             </a>
@@ -108,7 +108,7 @@ export default function MarkdownViewer({ content }) {
               return <>{children}</>
             }
             return (
-              <pre className="bg-slate-950 rounded-xl p-4 overflow-x-auto mb-4 border border-slate-800">
+              <pre className="bg-slate-100 dark:bg-slate-950 rounded-xl p-4 overflow-x-auto mb-4 border border-slate-200 dark:border-slate-800">
                 {children}
               </pre>
             )
@@ -120,63 +120,63 @@ export default function MarkdownViewer({ content }) {
             const isBlock = className || String(children).includes('\n')
             if (!isBlock) {
               return (
-                <code className="bg-slate-800 text-amber-300 px-1.5 py-0.5 rounded text-[0.85em] font-mono">
+                <code className="bg-slate-100 dark:bg-slate-800 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded text-[0.85em] font-mono">
                   {children}
                 </code>
               )
             }
             return (
-              <code className={`text-slate-300 text-sm font-mono leading-relaxed ${className || ''}`}>
+              <code className={`text-slate-700 dark:text-slate-300 text-sm font-mono leading-relaxed ${className || ''}`}>
                 {children}
               </code>
             )
           },
           ul: ({ children }) => (
-            <ul className="list-disc text-slate-300 mb-4 space-y-1 ml-5">{children}</ul>
+            <ul className="list-disc text-slate-700 dark:text-slate-300 mb-4 space-y-1 ml-5">{children}</ul>
           ),
           ol: ({ children }) => (
-            <ol className="list-decimal text-slate-300 mb-4 space-y-1 ml-5">{children}</ol>
+            <ol className="list-decimal text-slate-700 dark:text-slate-300 mb-4 space-y-1 ml-5">{children}</ol>
           ),
-          li: ({ children }) => <li className="text-slate-300 leading-relaxed">{children}</li>,
+          li: ({ children }) => <li className="text-slate-700 dark:text-slate-300 leading-relaxed">{children}</li>,
           blockquote: ({ children }) => (
-            <blockquote className="border-l-4 border-blue-500/60 pl-4 italic text-slate-400 my-4">
+            <blockquote className="border-l-4 border-blue-500/60 pl-4 italic text-slate-500 dark:text-slate-400 my-4">
               {children}
             </blockquote>
           ),
           table: ({ children }) => (
-            <div className="overflow-x-auto mb-4 rounded-lg border border-slate-700">
-              <table className="w-full text-sm text-slate-300">{children}</table>
+            <div className="overflow-x-auto mb-4 rounded-lg border border-slate-200 dark:border-slate-700">
+              <table className="w-full text-sm text-slate-700 dark:text-slate-300">{children}</table>
             </div>
           ),
           thead: ({ children }) => (
-            <thead className="bg-slate-800 text-slate-200">{children}</thead>
+            <thead className="bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200">{children}</thead>
           ),
           th: ({ children }) => (
-            <th className="border-b border-slate-700 px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider">
+            <th className="border-b border-slate-200 dark:border-slate-700 px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider">
               {children}
             </th>
           ),
           td: ({ children }) => (
-            <td className="border-b border-slate-700/50 px-4 py-2.5">{children}</td>
+            <td className="border-b border-slate-200/50 dark:border-slate-700/50 px-4 py-2.5">{children}</td>
           ),
           img: ({ src, alt }) => (
             <figure className="my-6">
               <img
                 src={src}
                 alt={alt}
-                className="max-w-full rounded-xl border border-slate-700"
+                className="max-w-full rounded-xl border border-slate-200 dark:border-slate-700"
                 loading="lazy"
               />
               {alt && (
-                <figcaption className="text-center text-slate-500 text-sm mt-2 italic">{alt}</figcaption>
+                <figcaption className="text-center text-slate-400 dark:text-slate-500 text-sm mt-2 italic">{alt}</figcaption>
               )}
             </figure>
           ),
-          hr: () => <hr className="border-slate-700 my-8" />,
+          hr: () => <hr className="border-slate-200 dark:border-slate-700 my-8" />,
           strong: ({ children }) => (
-            <strong className="text-slate-100 font-semibold">{children}</strong>
+            <strong className="text-slate-900 dark:text-slate-100 font-semibold">{children}</strong>
           ),
-          em: ({ children }) => <em className="text-slate-300 italic">{children}</em>,
+          em: ({ children }) => <em className="text-slate-700 dark:text-slate-300 italic">{children}</em>,
         }}
       >
         {body}

--- a/viewer/src/components/SearchOverlay.jsx
+++ b/viewer/src/components/SearchOverlay.jsx
@@ -12,7 +12,7 @@ function HighlightMatch({ text, query }) {
     <>
       {parts.map((part, i) =>
         part.toLowerCase() === query.toLowerCase()
-          ? <mark key={i} className="bg-yellow-500/30 text-yellow-200 rounded-sm">{part}</mark>
+          ? <mark key={i} className="bg-yellow-300/50 dark:bg-yellow-500/30 text-yellow-900 dark:text-yellow-200 rounded-sm">{part}</mark>
           : part
       )}
     </>
@@ -58,9 +58,9 @@ export default function SearchOverlay({ onClose, onSelect }) {
       className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-start justify-center pt-20 px-4"
       onClick={e => e.target === e.currentTarget && onClose()}
     >
-      <div className="w-full max-w-2xl bg-slate-800 rounded-2xl shadow-2xl border border-slate-700 overflow-hidden">
+      <div className="w-full max-w-2xl bg-white dark:bg-slate-800 rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700 overflow-hidden">
         {/* Input */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-700">
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
           <Search size={16} className="text-slate-400 shrink-0" />
           <input
             ref={inputRef}
@@ -69,10 +69,10 @@ export default function SearchOverlay({ onClose, onSelect }) {
             onChange={e => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Recherche dans tous les fichiers…"
-            className="flex-1 bg-transparent text-slate-100 placeholder-slate-500 text-sm focus:outline-none"
+            className="flex-1 bg-transparent text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:placeholder-slate-500 text-sm focus:outline-none"
           />
-          {loading && <span className="text-xs text-slate-500 animate-pulse shrink-0">Recherche…</span>}
-          <button onClick={onClose} className="text-slate-500 hover:text-slate-300 shrink-0">
+          {loading && <span className="text-xs text-slate-400 dark:text-slate-500 animate-pulse shrink-0">Recherche…</span>}
+          <button onClick={onClose} className="text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 shrink-0">
             <X size={14} />
           </button>
         </div>
@@ -80,12 +80,12 @@ export default function SearchOverlay({ onClose, onSelect }) {
         {/* Résultats */}
         <div className="max-h-[420px] overflow-y-auto">
           {query.length < 2 && (
-            <div className="p-6 text-center text-slate-500 text-sm">
+            <div className="p-6 text-center text-slate-400 dark:text-slate-500 text-sm">
               Tapez au moins 2 caractères pour rechercher
             </div>
           )}
           {query.length >= 2 && !loading && results.length === 0 && (
-            <div className="p-6 text-center text-slate-500 text-sm">
+            <div className="p-6 text-center text-slate-400 dark:text-slate-500 text-sm">
               Aucun résultat pour «&nbsp;{query}&nbsp;»
             </div>
           )}
@@ -93,20 +93,22 @@ export default function SearchOverlay({ onClose, onSelect }) {
             <button
               key={file.path}
               onClick={() => onSelect(file)}
-              className={`w-full text-left px-4 py-3 border-b border-slate-700/50 last:border-0 transition-colors ${
-                activeIdx === idx ? 'bg-slate-700' : 'hover:bg-slate-700/50'
+              className={`w-full text-left px-4 py-3 border-b border-slate-200/50 dark:border-slate-700/50 last:border-0 transition-colors ${
+                activeIdx === idx
+                  ? 'bg-slate-100 dark:bg-slate-700'
+                  : 'hover:bg-slate-50 dark:hover:bg-slate-700/50'
               }`}
             >
               <div className="flex items-center gap-2 mb-2">
                 {file.type === 'json'
-                  ? <FileJson size={13} className="text-amber-400 shrink-0" />
-                  : <FileText size={13} className="text-blue-400 shrink-0" />
+                  ? <FileJson size={13} className="text-amber-500 dark:text-amber-400 shrink-0" />
+                  : <FileText size={13} className="text-blue-500 dark:text-blue-400 shrink-0" />
                 }
-                <span className="text-sm font-medium text-slate-200 truncate">{file.name}</span>
+                <span className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">{file.name}</span>
                 {file.flux && (
-                  <span className="text-xs text-slate-500 bg-slate-700 px-1.5 rounded shrink-0">{file.flux}</span>
+                  <span className="text-xs text-slate-400 dark:text-slate-500 bg-slate-100 dark:bg-slate-700 px-1.5 rounded shrink-0">{file.flux}</span>
                 )}
-                <span className="ml-auto text-xs text-slate-500 flex items-center gap-1 shrink-0">
+                <span className="ml-auto text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1 shrink-0">
                   {file.matches.length} résultat{file.matches.length > 1 ? 's' : ''}
                   <ArrowRight size={9} />
                 </span>
@@ -115,9 +117,9 @@ export default function SearchOverlay({ onClose, onSelect }) {
                 {file.matches.slice(0, 3).map((m, i) => (
                   <div
                     key={i}
-                    className="text-[11px] text-slate-400 font-mono bg-slate-950/60 rounded px-2 py-1 truncate"
+                    className="text-[11px] text-slate-500 dark:text-slate-400 font-mono bg-slate-100/60 dark:bg-slate-950/60 rounded px-2 py-1 truncate"
                   >
-                    <span className="text-slate-600 mr-2 select-none">L{m.line}</span>
+                    <span className="text-slate-400 dark:text-slate-600 mr-2 select-none">L{m.line}</span>
                     <HighlightMatch text={m.text} query={query} />
                   </div>
                 ))}
@@ -127,7 +129,7 @@ export default function SearchOverlay({ onClose, onSelect }) {
         </div>
 
         {/* Pied */}
-        <div className="px-4 py-2 bg-slate-900/50 border-t border-slate-700 flex items-center gap-4 text-[10px] text-slate-600 select-none">
+        <div className="px-4 py-2 bg-slate-50/50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-700 flex items-center gap-4 text-[10px] text-slate-400 dark:text-slate-600 select-none">
           <span>↑↓ Naviguer</span>
           <span>↵ Ouvrir</span>
           <span>Échap Fermer</span>

--- a/viewer/src/components/SettingsPanel.jsx
+++ b/viewer/src/components/SettingsPanel.jsx
@@ -26,8 +26,8 @@ function formatRelative(isoStr) {
 
 function Spinner() {
   return (
-    <div className="flex items-center justify-center h-40 gap-3 text-slate-500">
-      <div className="w-4 h-4 border-2 border-slate-600 border-t-blue-500 rounded-full animate-spin" />
+    <div className="flex items-center justify-center h-40 gap-3 text-slate-400 dark:text-slate-500">
+      <div className="w-4 h-4 border-2 border-slate-300 dark:border-slate-600 border-t-blue-500 rounded-full animate-spin" />
       <span className="text-sm">Chargement…</span>
     </div>
   )
@@ -57,7 +57,7 @@ function SaveButton({ saving, saved, onClick }) {
 function ErrorBanner({ message }) {
   if (!message) return null
   return (
-    <div className="px-5 py-2 bg-red-900/20 border-b border-red-700/30 text-xs text-red-400 flex items-center gap-2 shrink-0">
+    <div className="px-5 py-2 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-700/30 text-xs text-red-600 dark:text-red-400 flex items-center gap-2 shrink-0">
       <AlertTriangle size={12} /> {message}
     </div>
   )
@@ -70,17 +70,17 @@ function StatusBadge({ task }) {
   const isSoon = nextMs !== null && nextMs > 0 && nextMs < 3_600_000
 
   if (!task.last_run) return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-slate-500">
+    <span className="inline-flex items-center gap-1.5 text-xs text-slate-400 dark:text-slate-500">
       <HelpCircle size={12} /> Jamais exécuté
     </span>
   )
   if (isSoon) return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-blue-400">
-      <span className="w-2 h-2 rounded-full bg-blue-400 animate-pulse" /> Bientôt
+    <span className="inline-flex items-center gap-1.5 text-xs text-blue-500 dark:text-blue-400">
+      <span className="w-2 h-2 rounded-full bg-blue-500 dark:bg-blue-400 animate-pulse" /> Bientôt
     </span>
   )
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-green-400">
+    <span className="inline-flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
       <CheckCircle2 size={12} /> Actif
     </span>
   )
@@ -90,12 +90,12 @@ function TaskTable({ title, tasks }) {
   if (!tasks.length) return null
   return (
     <div>
-      <div className="sticky top-0 bg-slate-900 px-5 py-2 border-b border-slate-700 text-xs font-semibold text-slate-400 uppercase tracking-wider">
+      <div className="sticky top-0 bg-slate-50 dark:bg-slate-900 px-5 py-2 border-b border-slate-200 dark:border-slate-700 text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
         {title}
       </div>
       <table className="w-full text-sm">
         <thead>
-          <tr className="text-[10px] font-medium text-slate-500 uppercase tracking-wider border-b border-slate-700/50">
+          <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
             <th className="text-left px-5 py-2.5">Tâche</th>
             <th className="text-left px-4 py-2.5">Fréquence</th>
             <th className="text-left px-4 py-2.5">Dernière exécution</th>
@@ -105,30 +105,30 @@ function TaskTable({ title, tasks }) {
         </thead>
         <tbody>
           {tasks.map((task, i) => (
-            <tr key={i} className="border-b border-slate-700/40 last:border-0 hover:bg-slate-700/20 transition-colors">
+            <tr key={i} className="border-b border-slate-200/40 dark:border-slate-700/40 last:border-0 hover:bg-slate-100/20 dark:hover:bg-slate-700/20 transition-colors">
               <td className="px-5 py-3">
-                <div className="font-medium text-slate-200 text-sm">{task.name}</div>
-                <div className="text-[11px] text-slate-500 font-mono mt-0.5">{task.script}</div>
+                <div className="font-medium text-slate-800 dark:text-slate-200 text-sm">{task.name}</div>
+                <div className="text-[11px] text-slate-400 dark:text-slate-500 font-mono mt-0.5">{task.script}</div>
               </td>
               <td className="px-4 py-3">
-                <div className="text-slate-300 text-sm">{task.label}</div>
-                <div className="text-[10px] text-slate-600 font-mono mt-0.5">{task.cron}</div>
+                <div className="text-slate-700 dark:text-slate-300 text-sm">{task.label}</div>
+                <div className="text-[10px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
               </td>
               <td className="px-4 py-3">
                 {task.last_run ? (
                   <>
-                    <div className="text-slate-300 text-sm">{formatDateTime(task.last_run)}</div>
-                    <div className="text-[11px] text-slate-500 mt-0.5">{formatRelative(task.last_run)}</div>
+                    <div className="text-slate-700 dark:text-slate-300 text-sm">{formatDateTime(task.last_run)}</div>
+                    <div className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">{formatRelative(task.last_run)}</div>
                   </>
-                ) : <span className="text-slate-600 italic text-sm">Jamais</span>}
+                ) : <span className="text-slate-400 dark:text-slate-600 italic text-sm">Jamais</span>}
               </td>
               <td className="px-4 py-3">
                 {task.next_run ? (
                   <>
-                    <div className="text-slate-300 text-sm">{formatDateTime(task.next_run)}</div>
-                    <div className="text-[11px] text-slate-500 mt-0.5">{formatRelative(task.next_run)}</div>
+                    <div className="text-slate-700 dark:text-slate-300 text-sm">{formatDateTime(task.next_run)}</div>
+                    <div className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">{formatRelative(task.next_run)}</div>
                   </>
-                ) : <span className="text-slate-600 text-sm">—</span>}
+                ) : <span className="text-slate-400 dark:text-slate-600 text-sm">—</span>}
               </td>
               <td className="px-4 py-3"><StatusBadge task={task} /></td>
             </tr>
@@ -164,15 +164,15 @@ function SchedulerTab() {
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* Prochaine tâche imminente */}
       {upcoming && (
-        <div className="px-5 py-2.5 bg-blue-600/10 border-b border-blue-500/20 shrink-0">
+        <div className="px-5 py-2.5 bg-blue-50 dark:bg-blue-600/10 border-b border-blue-200 dark:border-blue-500/20 shrink-0">
           <div className="flex items-center gap-2 text-sm">
-            <Calendar size={13} className="text-blue-400 shrink-0" />
-            <span className="text-blue-300">
+            <Calendar size={13} className="text-blue-500 dark:text-blue-400 shrink-0" />
+            <span className="text-blue-700 dark:text-blue-300">
               Prochaine tâche :{' '}
-              <span className="font-medium text-blue-200">{upcoming.name}</span>
+              <span className="font-medium text-blue-800 dark:text-blue-200">{upcoming.name}</span>
               {' — '}
-              <span className="text-blue-300">{formatRelative(upcoming.next_run)}</span>
-              <span className="text-blue-500 text-xs ml-2">({formatDateTime(upcoming.next_run)})</span>
+              <span className="text-blue-600 dark:text-blue-300">{formatRelative(upcoming.next_run)}</span>
+              <span className="text-blue-400 dark:text-blue-500 text-xs ml-2">({formatDateTime(upcoming.next_run)})</span>
             </span>
           </div>
         </div>
@@ -181,7 +181,7 @@ function SchedulerTab() {
       {/* Corps */}
       <div className="flex-1 overflow-auto">
         {loading ? <Spinner /> : !data?.tasks?.length ? (
-          <div className="flex items-center justify-center h-40 text-slate-500 text-sm">
+          <div className="flex items-center justify-center h-40 text-slate-400 dark:text-slate-500 text-sm">
             Aucune tâche planifiée trouvée
           </div>
         ) : (
@@ -194,14 +194,14 @@ function SchedulerTab() {
 
       {/* Pied */}
       {data && (
-        <div className="px-5 py-2 bg-slate-900/50 border-t border-slate-700 text-xs text-slate-600 shrink-0 flex items-center gap-2">
+        <div className="px-5 py-2 bg-slate-50/50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-700 text-xs text-slate-400 dark:text-slate-600 shrink-0 flex items-center gap-2">
           <span>
             {data.tasks.length} tâche{data.tasks.length !== 1 ? 's' : ''} planifiée{data.tasks.length !== 1 ? 's' : ''}
             {' · '}Actualisé à {new Date(data.now).toLocaleTimeString('fr-FR')}
           </span>
           <button
             onClick={load}
-            className="text-slate-500 hover:text-slate-300 transition-colors"
+            className="text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
             title="Actualiser"
           >
             <RefreshCw size={11} className={loading ? 'animate-spin' : ''} />
@@ -218,8 +218,8 @@ function TagInput({ tags, onChange, placeholder, color }) {
   const [input, setInput] = useState('')
 
   const styles = {
-    blue:  { tag: 'bg-blue-900/40 text-blue-300 border-blue-700/50',  btn: 'hover:text-blue-200 text-blue-400'  },
-    green: { tag: 'bg-green-900/40 text-green-300 border-green-700/50', btn: 'hover:text-green-200 text-green-400' },
+    blue:  { tag: 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-300 border-blue-300 dark:border-blue-700/50',  btn: 'hover:text-blue-600 dark:hover:text-blue-200 text-blue-500 dark:text-blue-400'  },
+    green: { tag: 'bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-300 border-green-300 dark:border-green-700/50', btn: 'hover:text-green-600 dark:hover:text-green-200 text-green-500 dark:text-green-400' },
   }
   const s = styles[color] || styles.blue
 
@@ -238,7 +238,7 @@ function TagInput({ tags, onChange, placeholder, color }) {
           {tag}
           <button
             onClick={() => remove(tag)}
-            className={`${s.btn} hover:text-red-300 transition-colors`}
+            className={`${s.btn} hover:text-red-500 dark:hover:text-red-300 transition-colors`}
             aria-label={`Supprimer ${tag}`}
           >
             <X size={10} />
@@ -254,11 +254,11 @@ function TagInput({ tags, onChange, placeholder, color }) {
             if (e.key === 'Enter' || e.key === ',') { e.preventDefault(); commit() }
           }}
           placeholder={placeholder}
-          className="text-xs bg-slate-900/50 border border-slate-600 rounded px-2 py-0.5 text-slate-300 placeholder-slate-600 focus:outline-none focus:border-blue-500 w-40 transition-colors"
+          className="text-xs bg-slate-100 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-600 rounded px-2 py-0.5 text-slate-700 dark:text-slate-300 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 w-40 transition-colors"
         />
         <button
           onClick={commit}
-          className="text-slate-400 hover:text-slate-200 transition-colors"
+          className="text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 transition-colors"
           aria-label="Ajouter"
         >
           <Plus size={13} />
@@ -312,16 +312,16 @@ function KeywordsTab() {
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* Barre d'outils */}
-      <div className="flex items-center gap-3 px-5 py-3 border-b border-slate-700 shrink-0">
-        <p className="text-xs text-slate-500 flex-1">
+      <div className="flex items-center gap-3 px-5 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        <p className="text-xs text-slate-400 dark:text-slate-500 flex-1">
           Mots-clés extraits des flux RSS.{' '}
-          <span className="text-blue-400 font-medium">OU</span> élargit la recherche,{' '}
-          <span className="text-green-400 font-medium">ET</span> la restreint.
-          Appuyez sur <kbd className="bg-slate-700 text-slate-400 px-1 rounded text-[10px]">Entrée</kbd> pour valider un terme.
+          <span className="text-blue-600 dark:text-blue-400 font-medium">OU</span> élargit la recherche,{' '}
+          <span className="text-green-600 dark:text-green-400 font-medium">ET</span> la restreint.
+          Appuyez sur <kbd className="bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 px-1 rounded text-[10px]">Entrée</kbd> pour valider un terme.
         </p>
         <button
           onClick={add}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-xs text-slate-300 transition-colors shrink-0"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-xs text-slate-700 dark:text-slate-300 transition-colors shrink-0"
         >
           <Plus size={12} /> Ajouter
         </button>
@@ -333,19 +333,19 @@ function KeywordsTab() {
       {/* Liste */}
       <div className="flex-1 overflow-y-auto p-5 space-y-3">
         {!keywords?.length ? (
-          <div className="text-center py-16 text-slate-500 text-sm">
+          <div className="text-center py-16 text-slate-400 dark:text-slate-500 text-sm">
             Aucun mot-clé configuré.{' '}
-            <button onClick={add} className="text-blue-400 hover:text-blue-300 underline">
+            <button onClick={add} className="text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 underline">
               Ajouter le premier
             </button>
           </div>
         ) : keywords.map((kw, idx) => (
-          <div key={idx} className="bg-slate-900/50 border border-slate-700 rounded-xl p-4 space-y-3">
+          <div key={idx} className="bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-700 rounded-xl p-4 space-y-3">
 
             {/* Mot-clé principal */}
             <div className="flex items-center gap-3">
               <div className="flex-1">
-                <label className="text-[10px] text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                   Mot-clé principal
                 </label>
                 <input
@@ -353,12 +353,12 @@ function KeywordsTab() {
                   value={kw.keyword}
                   onChange={e => update(idx, 'keyword', e.target.value)}
                   placeholder="ex. Intelligence Artificielle"
-                  className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
+                  className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
                 />
               </div>
               <button
                 onClick={() => remove(idx)}
-                className="mt-5 p-1.5 text-slate-600 hover:text-red-400 hover:bg-red-900/20 rounded-lg transition-colors"
+                className="mt-5 p-1.5 text-slate-400 dark:text-slate-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors"
                 title="Supprimer ce mot-clé"
               >
                 <Trash2 size={14} />
@@ -368,8 +368,8 @@ function KeywordsTab() {
             {/* Termes OU */}
             <div>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[10px] bg-blue-900/40 text-blue-400 border border-blue-700/50 rounded px-1.5 py-0.5 font-bold">OU</span>
-                <span className="text-[10px] text-slate-500 uppercase tracking-wider">
+                <span className="text-[10px] bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-300 dark:border-blue-700/50 rounded px-1.5 py-0.5 font-bold">OU</span>
+                <span className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                   correspond si l'un de ces termes est présent
                 </span>
               </div>
@@ -384,8 +384,8 @@ function KeywordsTab() {
             {/* Termes ET */}
             <div>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[10px] bg-green-900/40 text-green-400 border border-green-700/50 rounded px-1.5 py-0.5 font-bold">ET</span>
-                <span className="text-[10px] text-slate-500 uppercase tracking-wider">
+                <span className="text-[10px] bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 border border-green-300 dark:border-green-700/50 rounded px-1.5 py-0.5 font-bold">ET</span>
+                <span className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                   doit aussi contenir au moins un de ces termes
                 </span>
               </div>
@@ -479,13 +479,13 @@ function FluxTab() {
   return (
     <div className="flex flex-col flex-1 overflow-hidden">
       {/* Barre d'outils */}
-      <div className="flex items-center gap-3 px-5 py-3 border-b border-slate-700 shrink-0">
-        <p className="text-xs text-slate-500 flex-1">
+      <div className="flex items-center gap-3 px-5 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        <p className="text-xs text-slate-400 dark:text-slate-500 flex-1">
           Sources de flux JSON Reeder. Chaque flux est traité indépendamment avec son propre planning cron.
         </p>
         <button
           onClick={add}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-700 hover:bg-slate-600 border border-slate-600 rounded-lg text-xs text-slate-300 transition-colors shrink-0"
+          className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-xs text-slate-700 dark:text-slate-300 transition-colors shrink-0"
         >
           <Plus size={12} /> Ajouter
         </button>
@@ -497,9 +497,9 @@ function FluxTab() {
       {/* Liste */}
       <div className="flex-1 overflow-y-auto p-5 space-y-3">
         {!sources?.length ? (
-          <div className="text-center py-16 text-slate-500 text-sm">
+          <div className="text-center py-16 text-slate-400 dark:text-slate-500 text-sm">
             Aucun flux configuré.{' '}
-            <button onClick={add} className="text-blue-400 hover:text-blue-300 underline">
+            <button onClick={add} className="text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 underline">
               Ajouter le premier flux
             </button>
           </div>
@@ -509,12 +509,12 @@ function FluxTab() {
           const label = cronLabel(cron)
 
           return (
-            <div key={idx} className="bg-slate-900/50 border border-slate-700 rounded-xl p-4 space-y-3">
+            <div key={idx} className="bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-700 rounded-xl p-4 space-y-3">
               {/* Titre + URL + Supprimer */}
               <div className="flex items-start gap-3">
                 <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="text-[10px] text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                    <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                       Titre du flux
                     </label>
                     <input
@@ -522,11 +522,11 @@ function FluxTab() {
                       value={src.title}
                       onChange={e => updateField(idx, 'title', e.target.value)}
                       placeholder="ex. Intelligence-artificielle"
-                      className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
+                      className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
                     />
                   </div>
                   <div>
-                    <label className="text-[10px] text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                    <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                       URL du flux JSON
                     </label>
                     <input
@@ -534,13 +534,13 @@ function FluxTab() {
                       value={src.url}
                       onChange={e => updateField(idx, 'url', e.target.value)}
                       placeholder="https://…/feed.json"
-                      className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors"
+                      className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-600 font-mono focus:outline-none focus:border-blue-500 transition-colors"
                     />
                   </div>
                 </div>
                 <button
                   onClick={() => remove(idx)}
-                  className="mt-5 p-1.5 text-slate-600 hover:text-red-400 hover:bg-red-900/20 rounded-lg transition-colors shrink-0"
+                  className="mt-5 p-1.5 text-slate-400 dark:text-slate-600 hover:text-red-500 dark:hover:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 rounded-lg transition-colors shrink-0"
                   title="Supprimer ce flux"
                 >
                   <Trash2 size={14} />
@@ -550,8 +550,8 @@ function FluxTab() {
               {/* Planning + Timeout */}
               <div className="flex items-end gap-3">
                 <div className="flex-1">
-                  <label className="text-[10px] text-slate-500 uppercase tracking-wider font-medium mb-1 block">
-                    Planning (cron){label && <span className="text-slate-400 normal-case ml-2 font-normal">→ {label}</span>}
+                  <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                    Planning (cron){label && <span className="text-slate-500 dark:text-slate-400 normal-case ml-2 font-normal">→ {label}</span>}
                   </label>
                   <div className="flex gap-2">
                     <input
@@ -559,12 +559,12 @@ function FluxTab() {
                       value={cron}
                       onChange={e => updateScheduler(idx, 'cron', e.target.value)}
                       placeholder="0 6 * * 1"
-                      className="flex-1 bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm font-mono text-slate-200 placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
+                      className="flex-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm font-mono text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-600 focus:outline-none focus:border-blue-500 transition-colors"
                     />
                     <select
                       value=""
                       onChange={e => e.target.value && updateScheduler(idx, 'cron', e.target.value)}
-                      className="bg-slate-800 border border-slate-600 rounded-lg px-2 py-1.5 text-xs text-slate-400 focus:outline-none focus:border-blue-500 transition-colors"
+                      className="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-2 py-1.5 text-xs text-slate-500 dark:text-slate-400 focus:outline-none focus:border-blue-500 transition-colors"
                     >
                       <option value="">Préréglage…</option>
                       {CRON_PRESETS.map(p => (
@@ -574,7 +574,7 @@ function FluxTab() {
                   </div>
                 </div>
                 <div className="w-32 shrink-0">
-                  <label className="text-[10px] text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                  <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                     Timeout (s)
                   </label>
                   <input
@@ -583,7 +583,7 @@ function FluxTab() {
                     onChange={e => updateScheduler(idx, 'timeout', parseInt(e.target.value) || 60)}
                     min={10}
                     max={600}
-                    className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-200 focus:outline-none focus:border-blue-500 transition-colors"
+                    className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-lg px-3 py-1.5 text-sm text-slate-800 dark:text-slate-200 focus:outline-none focus:border-blue-500 transition-colors"
                   />
                 </div>
               </div>
@@ -617,12 +617,12 @@ export default function SettingsPanel({ onClose }) {
       className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-start justify-center pt-10 px-4 pb-4"
       onClick={e => e.target === e.currentTarget && onClose()}
     >
-      <div className="w-full max-w-5xl max-h-[88vh] bg-slate-800 rounded-2xl shadow-2xl border border-slate-700 flex flex-col overflow-hidden">
+      <div className="w-full max-w-5xl max-h-[88vh] bg-white dark:bg-slate-800 rounded-2xl shadow-2xl border border-slate-200 dark:border-slate-700 flex flex-col overflow-hidden">
 
         {/* ── En-tête ── */}
-        <div className="flex items-center gap-2 px-5 py-3 border-b border-slate-700 shrink-0">
-          <Settings size={15} className="text-slate-400" />
-          <h2 className="text-sm font-semibold text-slate-200 mr-3">Réglages</h2>
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0">
+          <Settings size={15} className="text-slate-400 dark:text-slate-400" />
+          <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200 mr-3">Réglages</h2>
 
           {/* Onglets */}
           <div className="flex items-center gap-1 flex-1">
@@ -632,8 +632,8 @@ export default function SettingsPanel({ onClose }) {
                 onClick={() => setActiveTab(id)}
                 className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
                   activeTab === id
-                    ? 'bg-blue-600/20 text-blue-300 border border-blue-500/40'
-                    : 'text-slate-400 hover:text-slate-200 hover:bg-slate-700'
+                    ? 'bg-blue-600/20 text-blue-700 dark:text-blue-300 border border-blue-400/40 dark:border-blue-500/40'
+                    : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700'
                 }`}
               >
                 <Icon size={12} />
@@ -644,7 +644,7 @@ export default function SettingsPanel({ onClose }) {
 
           <button
             onClick={onClose}
-            className="p-1.5 text-slate-400 hover:text-slate-200 hover:bg-slate-700 rounded-lg transition-colors"
+            className="p-1.5 text-slate-400 hover:text-slate-600 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors"
             aria-label="Fermer"
           >
             <X size={14} />

--- a/viewer/src/components/Sidebar.jsx
+++ b/viewer/src/components/Sidebar.jsx
@@ -30,9 +30,9 @@ export default function Sidebar({
   }, [files])
 
   return (
-    <aside className="w-72 flex flex-col bg-slate-800 border-r border-slate-700 shrink-0">
+    <aside className="w-72 flex flex-col bg-white dark:bg-slate-800 border-r border-slate-200 dark:border-slate-700 shrink-0">
       {/* ── Filtres ── */}
-      <div className="p-3 border-b border-slate-700 space-y-2.5">
+      <div className="p-3 border-b border-slate-200 dark:border-slate-700 space-y-2.5">
         {/* Boutons type */}
         <div className="flex gap-1">
           {[
@@ -46,7 +46,7 @@ export default function Sidebar({
               className={`flex-1 py-1.5 text-xs font-medium rounded transition-colors ${
                 typeFilter === key
                   ? 'bg-blue-600 text-white'
-                  : 'bg-slate-700 text-slate-400 hover:bg-slate-600 hover:text-slate-200'
+                  : 'bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600 hover:text-slate-700 dark:hover:text-slate-200'
               }`}
             >
               {label}
@@ -62,19 +62,19 @@ export default function Sidebar({
             value={nameSearch}
             onChange={e => onNameSearchChange(e.target.value)}
             placeholder="Filtrer par nom…"
-            className="w-full pl-8 pr-7 py-1.5 bg-slate-700 border border-slate-600 rounded text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:border-blue-500 transition-colors"
+            className="w-full pl-8 pr-7 py-1.5 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-blue-500 transition-colors"
           />
           {nameSearch && (
             <button
               onClick={() => onNameSearchChange('')}
-              className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 dark:text-slate-500 hover:text-slate-600 dark:hover:text-slate-300"
             >
               <X size={12} />
             </button>
           )}
         </div>
 
-        <div className="text-xs text-slate-600">
+        <div className="text-xs text-slate-400 dark:text-slate-600">
           {files.length} fichier{files.length !== 1 ? 's' : ''}
         </div>
       </div>
@@ -84,12 +84,12 @@ export default function Sidebar({
         {grouped.map(([flux, fluxFiles]) => (
           <div key={flux}>
             {/* En-tête de groupe */}
-            <div className="sticky top-0 z-10 bg-slate-800/95 px-3 py-1.5 flex items-center gap-1.5 border-b border-slate-700/60 backdrop-blur-sm">
-              <Folder size={11} className="text-slate-500" />
-              <span className="text-xs font-medium text-slate-500 uppercase tracking-wider truncate">
+            <div className="sticky top-0 z-10 bg-white/95 dark:bg-slate-800/95 px-3 py-1.5 flex items-center gap-1.5 border-b border-slate-200/60 dark:border-slate-700/60 backdrop-blur-sm">
+              <Folder size={11} className="text-slate-400 dark:text-slate-500" />
+              <span className="text-xs font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider truncate">
                 {flux}
               </span>
-              <span className="ml-auto text-xs text-slate-700 shrink-0">{fluxFiles.length}</span>
+              <span className="ml-auto text-xs text-slate-300 dark:text-slate-700 shrink-0">{fluxFiles.length}</span>
             </div>
 
             {/* Items */}
@@ -99,30 +99,30 @@ export default function Sidebar({
                 <button
                   key={file.path}
                   onClick={() => onSelect(file)}
-                  className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 border-b border-slate-700/30 transition-colors ${
+                  className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 border-b border-slate-200/30 dark:border-slate-700/30 transition-colors ${
                     isSelected
                       ? 'bg-blue-600/20 border-l-2 border-l-blue-500 pl-[10px]'
-                      : 'hover:bg-slate-700/50'
+                      : 'hover:bg-slate-100/50 dark:hover:bg-slate-700/50'
                   }`}
                 >
                   {file.type === 'json'
-                    ? <FileJson size={14} className="shrink-0 mt-0.5 text-amber-400" />
-                    : <FileText size={14} className="shrink-0 mt-0.5 text-blue-400" />
+                    ? <FileJson size={14} className="shrink-0 mt-0.5 text-amber-500 dark:text-amber-400" />
+                    : <FileText size={14} className="shrink-0 mt-0.5 text-blue-500 dark:text-blue-400" />
                   }
                   <div className="min-w-0 flex-1">
-                    <div className="text-xs font-medium text-slate-200 truncate leading-snug">
+                    <div className="text-xs font-medium text-slate-800 dark:text-slate-200 truncate leading-snug">
                       {file.name}
                     </div>
                     <div className="flex items-center gap-2 mt-1">
                       <span className={`text-[10px] px-1.5 rounded font-mono leading-4 ${
                         file.type === 'json'
-                          ? 'bg-amber-900/40 text-amber-400'
-                          : 'bg-blue-900/40 text-blue-400'
+                          ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400'
+                          : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
                       }`}>
                         {file.type === 'json' ? 'JSON' : 'MD'}
                       </span>
-                      <span className="text-[10px] text-slate-500">{formatSize(file.size)}</span>
-                      <span className="text-[10px] text-slate-600 ml-auto">{formatDate(file.modified)}</span>
+                      <span className="text-[10px] text-slate-400 dark:text-slate-500">{formatSize(file.size)}</span>
+                      <span className="text-[10px] text-slate-400 dark:text-slate-600 ml-auto">{formatDate(file.modified)}</span>
                     </div>
                   </div>
                 </button>
@@ -132,7 +132,7 @@ export default function Sidebar({
         ))}
 
         {files.length === 0 && (
-          <div className="p-8 text-center text-slate-500 text-sm">
+          <div className="p-8 text-center text-slate-400 dark:text-slate-500 text-sm">
             Aucun fichier trouvé
           </div>
         )}

--- a/viewer/src/index.css
+++ b/viewer/src/index.css
@@ -8,4 +8,21 @@
 ::-webkit-scrollbar-thumb { background: #334155; border-radius: 9999px; }
 ::-webkit-scrollbar-thumb:hover { background: #475569; }
 
+html:not(.dark) ::-webkit-scrollbar-thumb { background: #cbd5e1; }
+html:not(.dark) ::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
+
 body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; }
+
+/* Coloration syntaxique JSON — thème Nuit */
+.json-key    { color: #f6c96c; }
+.json-string { color: #86efac; }
+.json-bool   { color: #fb7185; }
+.json-null   { color: #94a3b8; }
+.json-number { color: #93c5fd; }
+
+/* Coloration syntaxique JSON — thème Jour */
+html:not(.dark) .json-key    { color: #92400e; }
+html:not(.dark) .json-string { color: #166534; }
+html:not(.dark) .json-bool   { color: #be123c; }
+html:not(.dark) .json-null   { color: #475569; }
+html:not(.dark) .json-number { color: #1d4ed8; }

--- a/viewer/tailwind.config.js
+++ b/viewer/tailwind.config.js
@@ -1,6 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  darkMode: 'class',
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Ajoute un toggle ☀/⊙/☽ dans la barre de navigation du viewer. Le choix est sauvegardé dans localStorage (clé wudd_theme) et appliqué immédiatement via un script inline dans index.html pour éviter le flash au chargement. Tous les composants ont été mis à jour avec des classes Tailwind dark: pour un rendu cohérent dans les deux modes.