### PR TITLE
Add text-to-speech functionality across content viewers

### DIFF
--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import EntityHighlighter from './EntityHighlighter'
 import EntityArticlePanel from './EntityArticlePanel'
+import TTSButton from './TTSButton'
 
 // ── Badge sentiment ───────────────────────────────────────────────────────────
 const SENTIMENT_CFG = {
@@ -336,6 +337,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, annotation, onA
                 </button>
               </>
             )}
+            {resume && <TTSButton text={resume} size={13} />}
             {article['URL'] && (
               <a href={article['URL']} target="_blank" rel="noopener noreferrer"
                 className="p-1.5 text-slate-400 hover:text-blue-500 dark:hover:text-blue-400 transition-colors" title="Ouvrir l'article">

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import EntityGraph from './EntityGraph'
 import EntityCalendar from './EntityCalendar'
+import TTSButton from './TTSButton'
 
 // ── Composants Markdown ────────────────────────────────────────────────────────
 const MD = {
@@ -37,9 +38,16 @@ function EntityInfoView({ text, loading, error }) {
         </div>
       )}
       {text.length > 0 && (
-        <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD}>
-          {text}
-        </ReactMarkdown>
+        <>
+          {!loading && (
+            <div className="flex justify-end mb-2">
+              <TTSButton text={text} size={13} />
+            </div>
+          )}
+          <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD}>
+            {text}
+          </ReactMarkdown>
+        </>
       )}
       {loading && text.length > 0 && (
         <span className="inline-block w-1.5 h-4 bg-violet-400 dark:bg-violet-500 animate-pulse rounded-sm ml-0.5 align-middle" />
@@ -793,6 +801,11 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
             )}
             {ragText && (
               <div className="prose-sm dark:prose-invert max-w-none">
+                {!ragLoading && (
+                  <div className="flex justify-end mb-2">
+                    <TTSButton text={ragText} size={13} />
+                  </div>
+                )}
                 <ReactMarkdown remarkPlugins={[remarkGfm]} components={MD}>
                   {ragText}
                 </ReactMarkdown>
@@ -847,14 +860,17 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                       <><span>·</span><span className="font-medium text-slate-700 dark:text-slate-300">{art['Sources']}</span></>
                     )}
                   </div>
-                  {art['URL'] && (
-                    <a
-                      href={art['URL']} target="_blank" rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline shrink-0"
-                    >
-                      Lire <ExternalLink size={11} />
-                    </a>
-                  )}
+                  <div className="flex items-center gap-1 shrink-0">
+                    {art['Résumé'] && <TTSButton text={art['Résumé']} size={12} />}
+                    {art['URL'] && (
+                      <a
+                        href={art['URL']} target="_blank" rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
+                      >
+                        Lire <ExternalLink size={11} />
+                      </a>
+                    )}
+                  </div>
                 </div>
                 {art['Résumé'] && (
                   <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed line-clamp-4">

--- a/viewer/src/components/MarkdownViewer.jsx
+++ b/viewer/src/components/MarkdownViewer.jsx
@@ -3,6 +3,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import { useMemo, useEffect, useRef } from 'react'
 import mermaid from 'mermaid'
+import TTSButton from './TTSButton'
 
 mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' })
 
@@ -53,6 +54,11 @@ export default function MarkdownViewer({ content }) {
 
   return (
     <div className="max-w-3xl mx-auto">
+      {/* Bouton lecture à voix haute */}
+      <div className="flex justify-end mb-2">
+        <TTSButton text={body} size={14} />
+      </div>
+
       {/* Métadonnées frontmatter */}
       {meta && (
         <div className="mb-6 p-4 bg-white/60 dark:bg-slate-800/60 rounded-xl border border-slate-200 dark:border-slate-700 text-sm">

--- a/viewer/src/components/TTSButton.jsx
+++ b/viewer/src/components/TTSButton.jsx
@@ -1,0 +1,112 @@
+import { useState, useEffect, useCallback } from 'react'
+import { Volume2, VolumeX } from 'lucide-react'
+
+// Singleton global : une seule instance TTS active à la fois
+let _setActive = null
+
+/** Nettoie le Markdown pour produire du texte brut lisible à voix haute. */
+function stripMarkdown(text) {
+  if (!text) return ''
+  return text
+    .replace(/^---[\s\S]*?---\n?/, '')        // frontmatter YAML
+    .replace(/#{1,6}\s+/g, '')                // titres
+    .replace(/\*\*([^*\n]+)\*\*/g, '$1')      // gras
+    .replace(/\*([^*\n]+)\*/g, '$1')          // italique
+    .replace(/__([^_\n]+)__/g, '$1')
+    .replace(/_([^_\n]+)_/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')  // liens Markdown
+    .replace(/`{1,3}[^`]*`{1,3}/g, '')        // code inline / bloc
+    .replace(/^[-*+]\s+/gm, '')               // listes à puces
+    .replace(/^\d+\.\s+/gm, '')               // listes numérotées
+    .replace(/^>\s+/gm, '')                   // blockquotes
+    .replace(/---+/g, '. ')                   // séparateurs horizontaux
+    .replace(/\n{2,}/g, '. ')
+    .replace(/\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+/**
+ * Hook TTS partagé.
+ * Garantit qu'une seule synthèse vocale est active à la fois.
+ * @param {string} text — texte brut ou Markdown à lire
+ */
+export function useTTS(text) {
+  const [speaking, setSpeaking] = useState(false)
+
+  const toggle = useCallback(() => {
+    if (!window.speechSynthesis) return
+
+    // Arrête toujours la synthèse en cours
+    window.speechSynthesis.cancel()
+
+    if (speaking) {
+      // L'utilisateur voulait stopper — c'est fait
+      if (_setActive === setSpeaking) _setActive = null
+      setSpeaking(false)
+      return
+    }
+
+    // Réinitialise l'état de l'instance précédente
+    if (_setActive && _setActive !== setSpeaking) {
+      _setActive(false)
+    }
+    _setActive = setSpeaking
+
+    const clean = stripMarkdown(text)
+    if (!clean) return
+
+    const utt = new SpeechSynthesisUtterance(clean)
+    utt.lang  = 'fr-FR'
+    utt.rate  = 0.92
+
+    const onDone = () => {
+      setSpeaking(false)
+      if (_setActive === setSpeaking) _setActive = null
+    }
+    utt.onend   = onDone
+    utt.onerror = onDone
+
+    setSpeaking(true)
+    window.speechSynthesis.speak(utt)
+  }, [speaking, text])
+
+  // Nettoyage si le composant est démonté pendant la lecture
+  useEffect(() => () => {
+    if (_setActive === setSpeaking) {
+      window.speechSynthesis?.cancel()
+      _setActive = null
+    }
+  }, [])
+
+  return { speaking, toggle }
+}
+
+/**
+ * Bouton icône pour activer / arrêter la lecture à voix haute.
+ *
+ * Props :
+ *   text      — texte à lire (Markdown accepté, sera nettoyé)
+ *   size      — taille de l'icône (défaut 13)
+ *   className — classes Tailwind supplémentaires
+ */
+export default function TTSButton({ text, size = 13, className = '' }) {
+  const { speaking, toggle } = useTTS(text)
+
+  if (typeof window === 'undefined' || !window.speechSynthesis || !text) return null
+
+  return (
+    <button
+      onClick={toggle}
+      title={speaking ? 'Arrêter la lecture' : 'Lire à voix haute'}
+      aria-label={speaking ? 'Arrêter la lecture' : 'Lire à voix haute'}
+      className={`p-1.5 rounded-lg transition-colors cursor-pointer ${
+        speaking
+          ? 'text-blue-500 dark:text-blue-400 bg-blue-50 dark:bg-blue-900/30'
+          : 'text-slate-300 dark:text-slate-600 hover:text-blue-500 dark:hover:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20'
+      } ${className}`}
+    >
+      {speaking ? <VolumeX size={size} /> : <Volume2 size={size} />}
+    </button>
+  )
+}


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive text-to-speech (TTS) feature that allows users to listen to content across multiple viewers in the application. A new `TTSButton` component provides an intuitive interface for toggling audio playback, with intelligent markdown stripping to ensure clean, readable audio output.

## Key Changes

- **New `TTSButton` component** (`viewer/src/components/TTSButton.jsx`):
  - Exports a reusable `useTTS` hook that manages speech synthesis state
  - Implements a singleton pattern to ensure only one TTS instance is active at a time
  - Includes `stripMarkdown()` utility to clean markdown syntax before audio playback
  - Provides an icon button with visual feedback (Volume2/VolumeX icons from lucide-react)
  - Supports French language (`fr-FR`) with configurable speech rate (0.92x)
  - Handles cleanup on component unmount to prevent orphaned audio playback

- **Integrated TTS buttons across multiple viewers**:
  - `EntityArticlePanel.jsx`: Added TTS buttons for entity info text, RAG-generated content, and article summaries
  - `MarkdownViewer.jsx`: Added TTS button for full markdown document body
  - `ArticleListViewer.jsx`: Added TTS button for article summaries in the list view

## Implementation Details

- The `useTTS` hook uses a global `_setActive` reference to track the currently active TTS instance, preventing multiple simultaneous playbacks
- Markdown stripping removes frontmatter, headers, formatting, links, code blocks, lists, and blockquotes while preserving readable text
- TTS buttons are conditionally rendered only when content exists and the Web Speech API is available
- Buttons feature responsive styling with hover states and dark mode support
- All buttons include proper ARIA labels for accessibility

https://claude.ai/code/session_019MZV1iCexFS2nVX8Fsff2Z