### PR TITLE
feat: masquer la sidebar contexte fichiers dans le Terminal IA quand …

### DIFF
--- a/viewer/src/components/ChatbotPanel.jsx
+++ b/viewer/src/components/ChatbotPanel.jsx
@@ -737,9 +737,9 @@ Voici ce que je peux faire pour vous :
           {/* ── Corps : sidebar contexte + zone chat ────────────────── */}
           <div className="flex flex-1 min-h-0 overflow-hidden">
 
-            {/* Sidebar sélection de fichiers (desktop) */}
+            {/* Sidebar sélection de fichiers (desktop) — masquée si contexte entité */}
             <div
-              className="hidden lg:flex flex-col w-64 shrink-0 border-r border-green-900/30 overflow-hidden"
+              className={`${entityContext ? 'hidden' : 'hidden lg:flex'} flex-col w-64 shrink-0 border-r border-green-900/30 overflow-hidden`}
               style={{ background: '#0d1117' }}
             >
               <div className="px-3 py-2 border-b border-green-900/30">


### PR DESCRIPTION
…ouvert depuis une entité

La colonne gauche de sélection des fichiers de contexte est désormais masquée lorsque le Terminal IA est ouvert avec un contexte entité (depuis EntityArticlePanel). La zone de chat occupe toute la largeur du dialogue.

https://claude.ai/code/session_01QJLBdq5XgwVQtabMuxSCo6