### PR TITLE
feat(report): add "Terminal IA" button after report generation

### DIFF
--- a/viewer/src/App.jsx
+++ b/viewer/src/App.jsx
@@ -231,7 +231,8 @@ export default function App() {
   const [watchOpen, setWatchOpen]         = useState(false)
   const [clusterOpen, setClusterOpen]     = useState(false)
   const [chatOpen, setChatOpen]           = useState(false)
-  const [chatEntityContext, setChatEntityContext] = useState(null) // { type, value } | null
+  const [chatEntityContext, setChatEntityContext]   = useState(null) // { type, value } | null
+  const [chatArticleContext, setChatArticleContext] = useState(null) // { titre, sources, date, url, entities, resume, reportMd } | null
   const [outilsOpen, setOutilsOpen]       = useState(false)
   const outilsMenuRef                     = useRef(null)
   const [sidebarOpen, setSidebarOpen]     = useState(() => window.innerWidth >= 768)
@@ -363,6 +364,19 @@ export default function App() {
     }
     window.addEventListener('wudd:openEntityChatbot', handler)
     return () => window.removeEventListener('wudd:openEntityChatbot', handler)
+  }, [])
+
+  // ── Terminal IA depuis un rapport d'article ───────────────────────────────────
+  useEffect(() => {
+    const handler = (e) => {
+      const ctx = e.detail || {}
+      if (!ctx.reportMd) return
+      setChatArticleContext(ctx)
+      setChatEntityContext(null)
+      setChatOpen(true)
+    }
+    window.addEventListener('wudd:openArticleChatbot', handler)
+    return () => window.removeEventListener('wudd:openArticleChatbot', handler)
   }, [])
 
   // Callback : crée ou met à jour l'annotation d'un article (optimistic update)
@@ -893,10 +907,11 @@ export default function App() {
       )}
       {chatOpen && (
         <ChatbotPanel
-          onClose={() => { setChatOpen(false); setChatEntityContext(null) }}
+          onClose={() => { setChatOpen(false); setChatEntityContext(null); setChatArticleContext(null) }}
           onFileSaved={refreshFiles}
-          initialFile={chatEntityContext ? null : selectedFile}
+          initialFile={(chatEntityContext || chatArticleContext) ? null : selectedFile}
           entityContext={chatEntityContext}
+          articleContext={chatArticleContext}
         />
       )}
       {entitySearch && (

--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -13,7 +13,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { createPortal } from 'react-dom'
 import {
   X, Maximize2, Minimize2, Copy, Download, Printer,
-  RefreshCw, FileText, Check,
+  RefreshCw, FileText, Check, Terminal,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -202,6 +202,12 @@ export default function ArticleFullReportDialog({ article, onClose }) {
     setTimeout(() => setCopied(false), 2000)
   }
 
+  const handleOpenChatbot = () => {
+    window.dispatchEvent(new CustomEvent('wudd:openArticleChatbot', {
+      detail: { titre, sources, date, url, entities, resume, reportMd: cleanMd },
+    }))
+  }
+
   const handleDownload = () => {
     const fname = `rapport_${sources || 'article'}_${date || new Date().toISOString().slice(0, 10)}.md`
       .replace(/[/\\: ]/g, '-')
@@ -360,6 +366,16 @@ export default function ArticleFullReportDialog({ article, onClose }) {
             </p>
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
+            {!isLoading && cleanMd && (
+              <button
+                onClick={handleOpenChatbot}
+                className="flex items-center gap-1 px-2 py-1 mr-1 rounded-lg text-xs font-medium text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-800/40 transition-colors"
+                title="Ouvrir le Terminal IA avec ce rapport en contexte"
+              >
+                <Terminal size={12} />
+                Terminal IA
+              </button>
+            )}
             <button onClick={handleCopy} className={btnCls} title="Copier le Markdown">
               {copied
                 ? <Check size={14} className="text-emerald-500" />

--- a/viewer/src/components/ChatbotPanel.jsx
+++ b/viewer/src/components/ChatbotPanel.jsx
@@ -87,14 +87,54 @@ const NER_LABELS = {
   LOC: 'Lieu', PRODUCT: 'Produit', EVENT: 'Événement',
 }
 
-export default function ChatbotPanel({ onClose, onFileSaved, initialFile, entityContext }) {
-  // entityContext : { type, value } | null — contexte entité pré-chargé depuis EntityArticlePanel
+export default function ChatbotPanel({ onClose, onFileSaved, initialFile, entityContext, articleContext }) {
+  // entityContext  : { type, value } | null — contexte entité pré-chargé depuis EntityArticlePanel
+  // articleContext : { titre, sources, date, url, entities, resume, reportMd } | null — rapport complet
 
   const entityLabel = entityContext
     ? `${entityContext.value} (${NER_LABELS[entityContext.type] ?? entityContext.type})`
     : null
 
-  const WELCOME_MSG = entityContext ? {
+  // Texte de contexte article injecté directement (pas de SSE serveur nécessaire)
+  const articleContextText = articleContext ? (() => {
+    const lines = [
+      `# Rapport complet : ${articleContext.titre || 'Article'}`,
+      `Source : ${articleContext.sources || '—'} | Date : ${articleContext.date || '—'}`,
+      articleContext.url ? `URL : ${articleContext.url}` : '',
+      '',
+    ]
+    if (articleContext.entities && Object.keys(articleContext.entities).length) {
+      lines.push('## Entités nommées')
+      for (const [type, vals] of Object.entries(articleContext.entities)) {
+        if (Array.isArray(vals) && vals.length) lines.push(`- ${type} : ${vals.join(', ')}`)
+      }
+      lines.push('')
+    }
+    if (articleContext.resume) {
+      lines.push('## Résumé original', articleContext.resume, '')
+    }
+    if (articleContext.reportMd) {
+      lines.push('## Rapport généré', articleContext.reportMd)
+    }
+    return lines.filter(l => l !== undefined).join('\n')
+  })() : ''
+
+  const WELCOME_MSG = articleContext ? {
+    role: 'assistant',
+    content: `**Terminal IA — Rapport article**
+
+Le rapport complet de l'article est chargé en contexte :
+- 📰 **${articleContext.titre || 'Article'}** — ${[articleContext.sources, articleContext.date].filter(Boolean).join(' · ')}
+- 📊 Entités nommées détectées
+- 📝 Rapport Markdown complet (analyse, diagrammes, acteurs)
+
+Exemples de questions :
+- _Quels sont les principaux acteurs mentionnés et leurs rôles ?_
+- _Quelle est la position éditoriale de la source ?_
+- _Résume les points clés en 5 bullets._
+- _Génère un tableau comparatif des entités._`,
+    welcome: true,
+  } : entityContext ? {
     role: 'assistant',
     content: `**Terminal IA — Entité : ${entityLabel}**
 
@@ -317,7 +357,7 @@ Voici ce que je peux faire pour vous :
           messages: newMessages.filter(m => !m.welcome),
           context_files: contextFiles,
           notes_period: overrideNotesPeriod || notesPeriod || undefined,
-          ...(entityContextText ? { entity_context: entityContextText } : {}),
+          ...(articleContextText ? { entity_context: articleContextText } : entityContextText ? { entity_context: entityContextText } : {}),
           ...(selectedProvider ? { provider: selectedProvider } : {}),
         }),
         signal: ctrl.signal,


### PR DESCRIPTION
Opens ChatbotPanel with the full article report as context, using the same pattern as the entity chatbot (wudd:openArticleChatbot event).

- ArticleFullReportDialog: Terminal IA button (emerald, lucide Terminal icon) appears in action bar once streaming is complete; dispatches wudd:openArticleChatbot with titre/sources/date/url/entities/resume/reportMd
- App.jsx: listens for wudd:openArticleChatbot, sets chatArticleContext state, resets entity context, opens ChatbotPanel
- ChatbotPanel: accepts articleContext prop; builds articleContextText (metadata + entities + résumé + rapport Markdown) injected as entity_context in the system prompt; dedicated welcome message with article-specific quick-start examples

https://claude.ai/code/session_01ChuDoEwwAsFqJNmQExHNB5