### PR TITLE
fix(report): terminal IA z-index + silent mermaid errors

### DIFF
--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -26,15 +26,19 @@ mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose
 // ── Mermaid block ─────────────────────────────────────────────────────────────
 
 function MermaidBlock({ code }) {
-  const ref = useRef(null)
-  const id  = useRef(`mermaid-rpt-${Math.random().toString(36).slice(2)}`)
+  const ref    = useRef(null)
+  const id     = useRef(`mermaid-rpt-${Math.random().toString(36).slice(2)}`)
+  const [err, setErr] = useState(null)
 
   useEffect(() => {
     if (!ref.current) return
+    setErr(null)
     mermaid.render(id.current, code)
       .then(({ svg }) => { if (ref.current) ref.current.innerHTML = svg })
-      .catch(err => { if (ref.current) ref.current.textContent = `Erreur Mermaid : ${err.message}` })
+      .catch(() => { setErr(true) })
   }, [code])
+
+  if (err) return null   // Diagramme invalide : on masque silencieusement
 
   return <div ref={ref} className="my-6 flex justify-center overflow-x-auto" />
 }

--- a/viewer/src/components/ChatbotPanel.jsx
+++ b/viewer/src/components/ChatbotPanel.jsx
@@ -584,10 +584,10 @@ Voici ce que je peux faire pour vous :
   return (
     <>
       {/* Fond semi-transparent */}
-      <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[80]" onClick={onClose} />
+      <div className="fixed inset-0 bg-black/80 backdrop-blur-sm z-[220]" onClick={onClose} />
 
-      {/* Panneau principal */}
-      <div className="fixed inset-0 z-[81] flex items-stretch md:items-center justify-center md:p-4 pointer-events-none" style={{ height: '100dvh' }}>
+      {/* Panneau principal — z-[221] pour passer au-dessus de tous les modals (rapport z-[200]) */}
+      <div className="fixed inset-0 z-[221] flex items-stretch md:items-center justify-center md:p-4 pointer-events-none" style={{ height: '100dvh' }}>
         <div
           className={`pointer-events-auto w-full h-full md:h-auto md:max-h-[92vh] relative flex flex-col overflow-hidden shadow-2xl border border-green-900/40 ${
             fullscreen


### PR DESCRIPTION
- ChatbotPanel: raise z-[80/81] → z-[220/221] so it overlays the report dialog (z-[200]) when opened from "Terminal IA"
- MermaidBlock: catch render errors silently (return null) instead of displaying raw error text; also adds local useState for error state

https://claude.ai/code/session_01ChuDoEwwAsFqJNmQExHNB5