### PR TITLE
Correction graph entités : normalisation casse insensible après index v2

### DIFF
--- a/utils/entity_index.py
+++ b/utils/entity_index.py
@@ -402,12 +402,25 @@ class EntityIndex:
     def get_all_entries(self) -> dict[str, list[dict]]:
         """Retourne une copie de l'index complet {entity_key: [{file, idx, date}]}.
 
-        Utilisé par entity_timeline.py et cross_flux_analysis.py pour construire
-        leurs agrégats sans scan rglob.
+        Les clés utilisent la forme d'affichage canonique (caps) pour la valeur,
+        afin que les appelants obtiennent "ORG:OpenAI" et non "ORG:openai".
+
+        Utilisé par entity_timeline.py, cross_flux_analysis.py et le viewer
+        pour construire leurs agrégats sans scan rglob.
         """
         with self._lock:
             self._load()
-        return {k: list(v) for k, v in self._data.get("index", {}).items()}
+        caps = self._data.get("caps", {})
+        result = {}
+        for k, v in self._data.get("index", {}).items():
+            if ":" in k:
+                etype, _, name_lower = k.partition(":")
+                display = caps.get(k, name_lower)
+                display_key = f"{etype}:{display}"
+            else:
+                display_key = k
+            result[display_key] = list(v)
+        return result
 
     def count_entities(self) -> int:
         """Retourne le nombre d'entités distinctes indexées."""

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -1393,7 +1393,10 @@ def api_entities_articles():
                     if not isinstance(entities, dict):
                         continue
                     values = entities.get(entity_type, [])
-                    if not (isinstance(values, list) and entity_value in values):
+                    ev_lower = entity_value.lower()
+                    if not (isinstance(values, list) and any(
+                        isinstance(v, str) and v.lower() == ev_lower for v in values
+                    )):
                         continue
                     url = (article.get("URL") or "").strip()
                     resume_key = article.get("Résumé", "")[:150].strip()
@@ -1541,7 +1544,10 @@ def api_entity_context():
                         if not isinstance(ents, dict):
                             continue
                         values = ents.get(entity_type, [])
-                        if not (isinstance(values, list) and entity_value in values):
+                        _ev_lower = entity_value.lower()
+                        if not (isinstance(values, list) and any(
+                            isinstance(v, str) and v.lower() == _ev_lower for v in values
+                        )):
                             continue
                         url = (article.get("URL") or "").strip()
                         if url and url in seen_urls:
@@ -1802,19 +1808,23 @@ def api_entities_cooccurrences():
                 continue
 
     # ── Passe 1 : co-occurrences L1 ──────────────────────────────────────────
+    entity_value_lower = entity_value.lower()
     cooc_l1: dict[tuple[str, str], int] = {}
     for article in all_articles:
         entities = article.get("entities", {})
         if not isinstance(entities, dict):
             continue
         values = entities.get(entity_type, [])
-        if not isinstance(values, list) or entity_value not in values:
+        # Comparaison insensible à la casse pour robustesse vis-à-vis de la normalisation
+        if not isinstance(values, list) or not any(
+            v.lower() == entity_value_lower for v in values if isinstance(v, str)
+        ):
             continue
         for etype, evals in entities.items():
             if not isinstance(evals, list):
                 continue
             for ev in evals:
-                if etype == entity_type and ev == entity_value:
+                if etype == entity_type and ev.lower() == entity_value_lower:
                     continue
                 key = (etype, ev)
                 cooc_l1[key] = cooc_l1.get(key, 0) + 1
@@ -1861,7 +1871,7 @@ def api_entities_cooccurrences():
                         co_key = (etype, ev)
                         if co_key == l1_key:
                             continue
-                        if co_key == (entity_type, entity_value):
+                        if etype == entity_type and ev.lower() == entity_value_lower:
                             continue  # évite l'arête de retour vers le centre
                         cooc_l2[(l1_key, co_key)] = cooc_l2.get((l1_key, co_key), 0) + 1
 
@@ -2841,7 +2851,10 @@ def api_synthesize_topic():
                     entity_match = False
                     if entity_type and entity_value:
                         values = entities.get(entity_type, []) if isinstance(entities, dict) else []
-                        entity_match = entity_value in values
+                        _ev_l = entity_value.lower()
+                        entity_match = any(
+                            isinstance(v, str) and v.lower() == _ev_l for v in values
+                        )
                     text_match = search_term in resume
                     if entity_match or text_match:
                         matching_articles.append(article)
@@ -3504,7 +3517,10 @@ def api_watched_get():
 
                 for w in watched:
                     vals = entities.get(w["type"], [])
-                    if isinstance(vals, list) and w["value"] in vals:
+                    _wv_lower = w["value"].lower()
+                    if isinstance(vals, list) and any(
+                        isinstance(v, str) and v.lower() == _wv_lower for v in vals
+                    ):
                         key = f"{w['type']}:{w['value']}"
                         if art_dt and art_dt >= cutoff_7d:
                             counts_7d[key] = counts_7d.get(key, 0) + 1


### PR DESCRIPTION
Problème : l'index v2 stocke les clés en minuscules (ex. "ORG:openai"), mais les endpoints du viewer faisaient des comparaisons exactes contre les données des articles (qui ont "OpenAI") → aucun article retourné dans le graph et l'EntityArticlePanel.

Correctifs :
- entity_index.get_all_entries() retourne désormais les clés avec la forme d'affichage canonique (caps) : "ORG:OpenAI" et non "ORG:openai" → le dashboard et les URLs passées au frontend utilisent la bonne casse
- api_entities_cooccurrences (L1 + L2) : comparaison case-insensitive
- api_entities_articles fallback rglob : comparaison case-insensitive
- entities/info SSE fallback : comparaison case-insensitive
- api_watched_entities matching : comparaison case-insensitive
- RAG/synthesis entity filter : comparaison case-insensitive

175/178 tests passants (3 pre-existants : test_multi_flux sans .env)

https://claude.ai/code/session_016Wt7D8aQ3L8pw7cLiKmUxD