### PR TITLE
feat: synchronisation automatique du registre des sources surveillées

### DIFF
--- a/archives/crontab
+++ b/archives/crontab
@@ -46,9 +46,13 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Réparation des résumés en erreur : chaque dimanche à 4h00 (maintenance hebdomadaire)
 # Régénère les articles dont le Résumé contient un message d'erreur API EurIA
 0 4 * * 0 root cd /app && python3 scripts/repair_failed_summaries.py 2>&1 | tee -a /app/rapports/cron_repair.log
+# Synchronisation du registre des sources : chaque dimanche à 3h30
+# Ajoute dans sources_credibility.json les nouvelles sources détectées dans OPML, web_sources.json
+# et les articles existants — aucun appel HTTP externe, exécution rapide (< 10 s)
+30 3 * * 0 root cd /app && python3 scripts/enrich_source_credibility.py --sync-only 2>&1 | tee -a /app/rapports/cron_enrich_credibility.log
 # Enrichissement crédibilité sources (WHOIS + transparence + MBFC) : mensuel, 1er du mois à 4h30
-# Mode incrémental : enrichit uniquement les nouvelles sources sans données v2
-30 4 1 * * root cd /app && python3 scripts/enrich_source_credibility.py 2>&1 | tee -a /app/rapports/cron_enrich_credibility.log
+# --sync : synchronise d'abord le registre, puis enrichit les sources manquantes de données v2
+30 4 1 * * root cd /app && python3 scripts/enrich_source_credibility.py --sync 2>&1 | tee -a /app/rapports/cron_enrich_credibility.log
 # Briefing exécutif hebdomadaire : chaque lundi à 6h30 (après trend_detector du lundi matin)
 # Synthèse IA : top entités, articles scorés, tendances — rapports/markdown/_BRIEFING_/
 30 6 * * 1 root cd /app && python3 scripts/generate_briefing.py --period weekly 2>&1 | tee -a /app/rapports/cron_briefing.log

--- a/scripts/enrich_source_credibility.py
+++ b/scripts/enrich_source_credibility.py
@@ -7,20 +7,35 @@ signaux automatisés :
   - Transparence éditoriale (scraping HTTP)
   - Rating MBFC          (mediabiasfactcheck.com)
 
-Il est conçu pour fonctionner en deux modes :
-  1. Mode incrémental (défaut) — enrichit uniquement les sources manquantes
-  2. Mode force (--force)     — ré-enrichit toutes les sources
+Il peut également synchroniser automatiquement les nouvelles sources depuis
+les configurations surveillées (OPML, web_sources.json, articles existants)
+avant de lancer l'enrichissement.
+
+Modes de fonctionnement :
+  1. Mode sync + incrémental (recommandé) — ajoute les nouvelles sources puis
+     enrichit celles qui manquent de données v2
+  2. Mode incrémental seul (défaut sans --sync) — enrichit uniquement les
+     sources manquantes dans la base actuelle
+  3. Mode force (--force) — ré-enrichit toutes les sources
+  4. Mode sync seul (--sync --dry-run) — affiche les nouvelles sources sans
+     rien écrire ni appeler d'API externe
 
 Migration initiale :
-  Lors du premier déploiement, lancez avec --force pour enrichir les 40 sources
-  existantes en une seule passe.
+  Lors du premier déploiement, lancez avec --sync --force pour synchroniser
+  les sources et enrichir toutes les entrées en une seule passe.
 
 Usage :
-  # Sources non encore enrichies uniquement
-  python3 scripts/enrich_source_credibility.py
+  # Synchroniser les nouvelles sources puis enrichir les manquantes
+  python3 scripts/enrich_source_credibility.py --sync
 
-  # Toutes les sources (re-calcul complet)
-  python3 scripts/enrich_source_credibility.py --force
+  # Synchronisation seule (pas d'appel HTTP externe)
+  python3 scripts/enrich_source_credibility.py --sync --dry-run
+
+  # Toutes les sources (re-calcul complet) avec synchronisation préalable
+  python3 scripts/enrich_source_credibility.py --sync --force
+
+  # Sources non encore enrichies uniquement (sans synchronisation)
+  python3 scripts/enrich_source_credibility.py
 
   # Une source spécifique
   python3 scripts/enrich_source_credibility.py --source "Le Monde"
@@ -41,12 +56,32 @@ PROJECT_ROOT = Path(__file__).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.logging import default_logger
-from utils.source_enricher import run_enrichment
+from utils.source_enricher import run_enrichment, sync_new_sources
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Enrichit sources_credibility.json avec âge domaine, transparence et MBFC."
+        description=(
+            "Enrichit sources_credibility.json avec âge domaine, transparence et MBFC. "
+            "Avec --sync, synchronise d'abord les nouvelles sources depuis OPML et web_sources.json."
+        )
+    )
+    parser.add_argument(
+        "--sync",
+        action="store_true",
+        help=(
+            "Synchroniser d'abord les nouvelles sources depuis OPML, web_sources.json "
+            "et les articles existants (sans appel API externe)"
+        ),
+    )
+    parser.add_argument(
+        "--sync-only",
+        action="store_true",
+        dest="sync_only",
+        help=(
+            "Synchroniser le registre uniquement, sans lancer l'enrichissement "
+            "WHOIS/transparence/MBFC. Rapide, aucun appel HTTP externe."
+        ),
     )
     parser.add_argument(
         "--force",
@@ -69,7 +104,7 @@ def main():
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Simuler l'enrichissement sans écrire dans sources_credibility.json",
+        help="Simuler sans écrire dans sources_credibility.json",
     )
     args = parser.parse_args()
 
@@ -77,12 +112,44 @@ def main():
     default_logger.info("Enrichissement crédibilité sources — WUDD.ai v2.3")
     if args.dry_run:
         default_logger.info("MODE DRY-RUN — aucune écriture")
+    if args.sync_only:
+        default_logger.info("MODE SYNC-ONLY — registre uniquement, pas d'enrichissement HTTP")
+    if args.sync:
+        default_logger.info("MODE SYNC — synchronisation du registre activée")
     if args.force:
         default_logger.info("MODE FORCE — toutes les sources seront ré-enrichies")
     if args.source:
         default_logger.info(f"Source ciblée : {args.source}")
     default_logger.info("═" * 60)
 
+    # ── Mode sync-only : synchroniser sans enrichir ───────────────────────────
+    if args.sync_only:
+        default_logger.info("─" * 60)
+        default_logger.info("Synchronisation du registre des sources")
+        sync_stats = sync_new_sources(project_root=PROJECT_ROOT, dry_run=args.dry_run)
+        default_logger.info(
+            f"Sync terminée : {sync_stats['added']} ajoutées, "
+            f"{sync_stats['already_known']} déjà connues "
+            f"(registre total : {sync_stats['total_registry']})"
+        )
+        sys.exit(0)
+
+    # ── Étape 1 : synchronisation du registre (optionnelle) ───────────────────
+    if args.sync:
+        default_logger.info("─" * 60)
+        default_logger.info("Étape 1/2 — Synchronisation du registre des sources")
+        sync_stats = sync_new_sources(project_root=PROJECT_ROOT, dry_run=args.dry_run)
+        default_logger.info(
+            f"Sync terminée : {sync_stats['added']} ajoutées, "
+            f"{sync_stats['already_known']} déjà connues "
+            f"(registre total : {sync_stats['total_registry']})"
+        )
+        default_logger.info("─" * 60)
+        default_logger.info("Étape 2/2 — Enrichissement WHOIS / transparence / MBFC")
+    else:
+        default_logger.info("Enrichissement WHOIS / transparence / MBFC")
+
+    # ── Étape 2 : enrichissement des données v2 ───────────────────────────────
     stats = run_enrichment(
         project_root=PROJECT_ROOT,
         force=args.force,

--- a/utils/source_enricher.py
+++ b/utils/source_enricher.py
@@ -336,6 +336,80 @@ def run_enrichment(
     return stats
 
 
+def sync_new_sources(
+    project_root: Path,
+    dry_run: bool = False,
+) -> dict:
+    """Synchronise sources_credibility.json avec les sources surveillées.
+
+    Collecte toutes les sources actives (OPML + web_sources.json + articles
+    existants) via ``utils.source_registry``, puis ajoute à
+    sources_credibility.json celles qui n'y figurent pas encore avec un score
+    par défaut de 50 (neutre — ni bonus ni malus sur le classement).
+
+    Cette fonction est conçue pour être appelée avant ``run_enrichment()`` :
+    elle ne fait aucune requête HTTP et s'exécute en quelques secondes.
+
+    Args:
+        project_root : racine du projet
+        dry_run      : afficher les nouvelles sources sans écrire
+
+    Returns:
+        {"added": N, "already_known": N, "total_registry": N}
+    """
+    import json as _json
+    from .source_registry import collect_sources
+
+    db_path = project_root / "config" / "sources_credibility.json"
+    if not db_path.exists():
+        default_logger.error(f"sources_credibility.json introuvable : {db_path}")
+        return {"added": 0, "already_known": 0, "total_registry": 0}
+
+    db = _json.loads(db_path.read_text(encoding="utf-8"))
+    registry = collect_sources(project_root)
+
+    stats = {"added": 0, "already_known": 0, "total_registry": len(registry)}
+
+    # Index normalisé des sources déjà présentes (insensible à la casse/accents)
+    known_normalized = {_normalize(k): k for k in db if k != "_comment"}
+
+    for source_name in sorted(registry):
+        if _normalize(source_name) in known_normalized:
+            stats["already_known"] += 1
+            continue
+
+        # Nouvelle source — entrée minimale, score neutre
+        default_entry = {
+            "score": 50,
+            "biais": "inconnu",
+            "type": "inconnu",
+            "pays": "inconnu",
+            "fiabilite": "non évaluée",
+            "fact_checking": False,
+        }
+        default_logger.info(f"  [sync] Nouvelle source : {source_name}")
+        if not dry_run:
+            db[source_name] = default_entry
+        stats["added"] += 1
+
+    if not dry_run and stats["added"] > 0:
+        db_path.write_text(
+            _json.dumps(db, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        default_logger.info(
+            f"[sync] sources_credibility.json : "
+            f"{stats['added']} ajoutées, {stats['already_known']} déjà connues "
+            f"(registre : {stats['total_registry']})"
+        )
+    elif stats["added"] == 0:
+        default_logger.info(
+            f"[sync] Aucune nouvelle source — {stats['already_known']} déjà connues"
+        )
+
+    return stats
+
+
 def _build_domain_hints(project_root: Path) -> dict:
     """Construit un index source normalisée → domaine depuis les articles existants."""
     import json

--- a/utils/source_registry.py
+++ b/utils/source_registry.py
@@ -1,0 +1,160 @@
+"""Registre des sources surveillées — WUDD.ai.
+
+Collecte l'ensemble des noms de sources actives depuis :
+  1. data/WUDD.opml          — flux RSS (attribut ``title``/``text`` des <outline>)
+  2. config/web_sources.json — sources web sans RSS (champ ``title``, sources actives uniquement)
+  3. data/articles/          — champ ``"Sources"`` des articles existants
+  4. data/articles-from-rss/ — champ ``"Sources"`` des articles keyword existants
+
+Les sources des articles existants sont la source la plus fiable car elles
+reflètent le nom exact tel qu'il apparaît dans le pipeline de collecte.
+
+Usage :
+    from utils.source_registry import collect_sources
+
+    sources = collect_sources(project_root)   # set[str]
+    for name in sorted(sources):
+        print(name)
+"""
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from .logging import default_logger
+
+
+# ── Parseurs par source ────────────────────────────────────────────────────────
+
+def _sources_from_opml(opml_path: Path) -> set[str]:
+    """Extrait les titres des flux RSS depuis un fichier OPML.
+
+    Utilise l'attribut ``title`` en priorité (standard OPML), puis ``text``
+    comme fallback (variante courante).
+    """
+    sources: set[str] = set()
+    if not opml_path.exists():
+        default_logger.debug(f"[source_registry] OPML introuvable : {opml_path}")
+        return sources
+    try:
+        tree = ET.parse(opml_path)
+        root = tree.getroot()
+        for outline in root.findall(".//outline[@type='rss']"):
+            title = (
+                outline.get("title")
+                or outline.get("text")
+                or ""
+            ).strip()
+            if title:
+                sources.add(title)
+        default_logger.debug(
+            f"[source_registry] OPML : {len(sources)} flux trouvés"
+        )
+    except Exception as exc:
+        default_logger.warning(f"[source_registry] Erreur lecture OPML : {exc}")
+    return sources
+
+
+def _sources_from_web_config(config_path: Path) -> set[str]:
+    """Extrait les titres des sources web depuis web_sources.json.
+
+    Ignore les entrées avec ``"actif": false``.
+    """
+    sources: set[str] = set()
+    if not config_path.exists():
+        default_logger.debug(
+            f"[source_registry] web_sources.json introuvable : {config_path}"
+        )
+        return sources
+    try:
+        entries = json.loads(config_path.read_text(encoding="utf-8"))
+        if not isinstance(entries, list):
+            return sources
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if not entry.get("actif", True):
+                continue
+            title = (entry.get("title") or entry.get("name") or "").strip()
+            if title:
+                sources.add(title)
+        default_logger.debug(
+            f"[source_registry] web_sources.json : {len(sources)} sources actives"
+        )
+    except Exception as exc:
+        default_logger.warning(
+            f"[source_registry] Erreur lecture web_sources.json : {exc}"
+        )
+    return sources
+
+
+def _sources_from_articles(data_dirs: list[Path]) -> set[str]:
+    """Collecte les valeurs du champ ``"Sources"`` dans les articles existants.
+
+    Parcourt tous les fichiers JSON (hors cache) dans les répertoires fournis.
+    Ce scan est limité à 20 articles par fichier pour rester performant.
+    """
+    sources: set[str] = set()
+    for data_dir in data_dirs:
+        if not data_dir.exists():
+            continue
+        for json_file in data_dir.rglob("*.json"):
+            if "cache" in json_file.parts:
+                continue
+            try:
+                articles = json.loads(
+                    json_file.read_text(encoding="utf-8", errors="replace")
+                )
+                if not isinstance(articles, list):
+                    continue
+                for article in articles[:20]:
+                    if not isinstance(article, dict):
+                        continue
+                    source = (
+                        article.get("Sources") or article.get("source") or ""
+                    ).strip()
+                    if source:
+                        sources.add(source)
+            except Exception:
+                continue
+    default_logger.debug(
+        f"[source_registry] Articles existants : {len(sources)} sources vues"
+    )
+    return sources
+
+
+# ── Point d'entrée public ─────────────────────────────────────────────────────
+
+def collect_sources(project_root: Path) -> set[str]:
+    """Collecte l'ensemble des sources surveillées depuis toutes les configurations.
+
+    Args:
+        project_root : racine du projet WUDD.ai
+
+    Returns:
+        Ensemble de noms de sources (str), dédupliqués, longueur ≥ 2 caractères.
+    """
+    all_sources: set[str] = set()
+
+    # 1. Flux RSS depuis OPML
+    all_sources |= _sources_from_opml(project_root / "data" / "WUDD.opml")
+
+    # 2. Sources web sans RSS
+    all_sources |= _sources_from_web_config(
+        project_root / "config" / "web_sources.json"
+    )
+
+    # 3. Sources vues dans les articles existants (valeur réelle du pipeline)
+    all_sources |= _sources_from_articles([
+        project_root / "data" / "articles",
+        project_root / "data" / "articles-from-rss",
+    ])
+
+    # Éliminer les chaînes vides ou trop courtes
+    all_sources = {s for s in all_sources if len(s) >= 2}
+
+    default_logger.info(
+        f"[source_registry] {len(all_sources)} sources uniques collectées "
+        f"(OPML + web_sources + articles)"
+    )
+    return all_sources


### PR DESCRIPTION
Génère automatiquement la liste des sources dans sources_credibility.json depuis les configurations réelles (OPML, web_sources.json, articles existants) plutôt qu'une liste statique maintenue à la main.

- utils/source_registry.py : nouveau module qui collecte les noms de sources depuis data/WUDD.opml (flux RSS), config/web_sources.json (sources web actives) et les champs "Sources" des articles existants

- utils/source_enricher.py : ajout de sync_new_sources() qui ajoute dans sources_credibility.json toute source absente avec score neutre 50/100, sans aucun appel HTTP externe (opération locale uniquement)

- scripts/enrich_source_credibility.py : ajout des flags --sync (synchronise le registre puis enrichit) et --sync-only (synchronise uniquement, rapide)

https://claude.ai/code/session_01URtwh1tXAsXFeiWon6pG1J