### PR TITLE
feat: rapport entité en streaming, diagrammes Mermaid, export Obsidian

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,13 @@ NTFY_TOKEN=
 BACKUP_L1=
 # Backup L2 : copie secondaire (miroir de L1, effectuée avant la copie data→L1)
 BACKUP_L2=
+
+# ==============================================================================
+# Export Obsidian (optionnel)
+# ==============================================================================
+# Répertoire cible pour l'export des rapports vers Obsidian — chemin absolu
+# IMPORTANT (Docker) : montez ce répertoire comme volume dans docker-compose.yml
+#   volumes:
+#     - /votre/vault-obsidian:/obsidian
+# puis utilisez le chemin DANS le conteneur (/obsidian)
+OBSIDIAN_DIR=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,9 @@ services:
       # - /votre/chemin/backup-L1:/backup-L1
       # - /votre/chemin/backup-L2:/backup-L2
       - /Volumes/USB1/WUDD-Backup:/backup
+      # Obsidian — décommentez et adaptez le chemin si OBSIDIAN_DIR est défini dans .env
+      # Exemple : OBSIDIAN_DIR=/obsidian dans .env, puis décommentez la ligne ci-dessous
+      # - /votre/vault-obsidian:/obsidian
     ports:
       - "5050:5050"   # Viewer WUDD.ai → http://localhost:5050
     restart: unless-stopped

--- a/viewer/routes/export.py
+++ b/viewer/routes/export.py
@@ -627,6 +627,47 @@ def api_chat_stream():
     )
 
 
+@export_bp.route("/api/export/report", methods=["POST"])
+def api_export_report():
+    """Sauvegarde un rapport Markdown sur le filesystem local ou dans le répertoire Obsidian.
+
+    Body JSON :
+      markdown  (str)  — contenu Markdown du rapport
+      filename  (str)  — nom de fichier suggéré (sans extension)
+      target    (str)  — 'local' (rapports/markdown/_WUDD.AI_/) ou 'obsidian' (OBSIDIAN_DIR)
+
+    Retourne : { ok: bool, path: str }
+    """
+    body = request.get_json(force=True, silent=True) or {}
+    markdown = (body.get("markdown") or "").strip()
+    filename = (body.get("filename") or "rapport").strip()
+    target   = (body.get("target") or "local").strip().lower()
+
+    if not markdown:
+        return jsonify({"error": "markdown est requis"}), 400
+
+    # Sanitiser le nom de fichier
+    filename = re.sub(r"[^\w\-]", "_", filename)[:80]
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_name = f"{filename}_{ts}.md"
+
+    if target == "obsidian":
+        obsidian_dir = os.environ.get("OBSIDIAN_DIR", "").strip()
+        if not obsidian_dir:
+            return jsonify({"error": "OBSIDIAN_DIR non configuré dans .env"}), 400
+        save_dir = Path(obsidian_dir)
+    else:
+        save_dir = PROJECT_ROOT / "rapports" / "markdown" / "_WUDD.AI_"
+
+    try:
+        save_dir.mkdir(parents=True, exist_ok=True)
+        out_path = save_dir / safe_name
+        out_path.write_text(markdown, encoding="utf-8")
+        return jsonify({"ok": True, "path": str(out_path)})
+    except OSError as e:
+        return jsonify({"error": f"Erreur écriture : {e}"}), 500
+
+
 @export_bp.route("/api/chat/save", methods=["POST"])
 def api_chat_save():
     """Sauvegarde une conversation ou une réponse IA en Markdown dans rapports/.

--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -13,7 +13,7 @@ import { useState, useEffect, useRef, useCallback, memo } from 'react'
 import { createPortal } from 'react-dom'
 import {
   X, Maximize2, Minimize2, Copy, Download, Printer,
-  RefreshCw, FileText, Check, Terminal,
+  RefreshCw, FileText, Check, Terminal, BookOpen, Loader2,
 } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -161,6 +161,7 @@ export default function ArticleFullReportDialog({ article, onClose }) {
   const [isLoading, setIsLoading]       = useState(true)
   const [error, setError]               = useState(null)
   const [copied, setCopied]             = useState(false)
+  const [exportState, setExportState]   = useState({ local: null, obsidian: null })
   // frozenMd : snapshot du markdown au moment où le stream se termine.
   // La FinalReportView est montée avec ce snapshot et ne change plus jamais.
   const [frozenMd,  setFrozenMd]        = useState(null)
@@ -420,6 +421,28 @@ ${contentEl.innerHTML}
     a.click()
   }
 
+  const handleExport = async (target) => {
+    setExportState(prev => ({ ...prev, [target]: 'saving' }))
+    const filename = `rapport_${sources || 'article'}_${date || new Date().toISOString().slice(0, 10)}`
+      .replace(/[/\\: ]/g, '-')
+    try {
+      const r = await fetch('/api/export/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ markdown: cleanMd, filename, target }),
+      })
+      const d = await r.json()
+      if (d.ok) {
+        setExportState(prev => ({ ...prev, [target]: { ok: true, path: d.path } }))
+      } else {
+        setExportState(prev => ({ ...prev, [target]: { ok: false, error: d.error } }))
+      }
+    } catch (e) {
+      setExportState(prev => ({ ...prev, [target]: { ok: false, error: String(e) } }))
+    }
+    setTimeout(() => setExportState(prev => ({ ...prev, [target]: null })), 4000)
+  }
+
   // ── Shared button class ───────────────────────────────────────────────────────
   const btnCls = 'p-1.5 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors'
 
@@ -569,16 +592,60 @@ ${contentEl.innerHTML}
               {[sources, date, sentiment].filter(Boolean).join(' · ')}
             </p>
           </div>
-          <div className="flex items-center gap-0.5 shrink-0">
+          <div className="flex items-center gap-0.5 shrink-0 flex-wrap justify-end">
             {!isLoading && cleanMd && (
-              <button
-                onClick={handleOpenChatbot}
-                className="flex items-center gap-1 px-2 py-1 mr-1 rounded-lg text-xs font-medium text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-800/40 transition-colors"
-                title="Ouvrir le Terminal IA avec ce rapport en contexte"
-              >
-                <Terminal size={12} />
-                Terminal IA
-              </button>
+              <>
+                <button
+                  onClick={handleOpenChatbot}
+                  className="flex items-center gap-1 px-2 py-1 mr-1 rounded-lg text-xs font-medium text-emerald-700 dark:text-emerald-400 bg-emerald-50 dark:bg-emerald-900/30 border border-emerald-200 dark:border-emerald-700 hover:bg-emerald-100 dark:hover:bg-emerald-800/40 transition-colors"
+                  title="Ouvrir le Terminal IA avec ce rapport en contexte"
+                >
+                  <Terminal size={12} />
+                  Terminal IA
+                </button>
+                {/* Export local */}
+                <div className="relative group mr-0.5">
+                  <button
+                    onClick={() => handleExport('local')}
+                    disabled={exportState.local === 'saving'}
+                    title={exportState.local?.ok ? `Enregistré : ${exportState.local.path}` : exportState.local?.error ? `Erreur : ${exportState.local.error}` : 'Sauvegarder dans rapports/'}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border transition-colors disabled:opacity-40 ${
+                      exportState.local?.ok    ? 'bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700 text-green-700 dark:text-green-300' :
+                      exportState.local?.error ? 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-600 dark:text-red-400' :
+                      'bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400 hover:border-slate-400'
+                    }`}
+                  >
+                    {exportState.local === 'saving' ? <Loader2 size={12} className="animate-spin" /> : exportState.local?.ok ? <Check size={12} /> : <Download size={12} />}
+                    Export
+                  </button>
+                  {(exportState.local?.ok || exportState.local?.error) && (
+                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+                      {exportState.local?.ok ? exportState.local.path : exportState.local?.error}
+                    </div>
+                  )}
+                </div>
+                {/* Export Obsidian */}
+                <div className="relative group mr-0.5">
+                  <button
+                    onClick={() => handleExport('obsidian')}
+                    disabled={exportState.obsidian === 'saving'}
+                    title={exportState.obsidian?.ok ? `Enregistré : ${exportState.obsidian.path}` : exportState.obsidian?.error ? `Erreur : ${exportState.obsidian.error}` : 'Exporter vers Obsidian (OBSIDIAN_DIR)'}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border transition-colors disabled:opacity-40 ${
+                      exportState.obsidian?.ok    ? 'bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700 text-green-700 dark:text-green-300' :
+                      exportState.obsidian?.error ? 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-600 dark:text-red-400' :
+                      'bg-violet-50 dark:bg-violet-900/30 border-violet-200 dark:border-violet-700 text-violet-700 dark:text-violet-300 hover:bg-violet-100 dark:hover:bg-violet-900/50'
+                    }`}
+                  >
+                    {exportState.obsidian === 'saving' ? <Loader2 size={12} className="animate-spin" /> : exportState.obsidian?.ok ? <Check size={12} /> : <BookOpen size={12} />}
+                    Export Obsidian
+                  </button>
+                  {(exportState.obsidian?.ok || exportState.obsidian?.error) && (
+                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+                      {exportState.obsidian?.ok ? exportState.obsidian.path : exportState.obsidian?.error}
+                    </div>
+                  )}
+                </div>
+              </>
             )}
             <button onClick={handleCopy} className={btnCls} title="Copier le Markdown">
               {copied

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -5,6 +5,7 @@ import remarkGfm from 'remark-gfm'
 import EntityGraph from './EntityGraph'
 import EntityCalendar from './EntityCalendar'
 import TTSButton from './TTSButton'
+import EntityFullReportDialog from './EntityFullReportDialog'
 
 // ── Composants Markdown ────────────────────────────────────────────────────────
 const MD = {
@@ -415,191 +416,11 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
   }, [])
 
   // ── Exports ────────────────────────────────────────────────────────────────
-  const [reportGenerating, setReportGenerating] = useState(false)
+  const [showReportDialog, setShowReportDialog] = useState(false)
 
-  const handleGenerateReport = async () => {
-    if (reportGenerating) return
-    setReportGenerating(true)
-
-    const today = new Date().toISOString().slice(0, 10)
-    const safe  = current.value.replace(/[^a-zA-Z0-9_\-]/g, '_')
-
-    // 1. Récupérer les nœuds L1 du graphe de co-occurrences
-    let l1Nodes = []
-    try {
-      const gParams = new URLSearchParams({
-        type: current.type, value: current.value, depth: 1, limit: 40, limit_l2: 0,
-      })
-      const gRes = await fetch(`/api/entities/cooccurrences?${gParams}`)
-      const gData = await gRes.json()
-      if (!gData.error && Array.isArray(gData.nodes)) {
-        l1Nodes = gData.nodes.filter(n => n.level === 1).sort((a, b) => b.count - a.count)
-      }
-    } catch (_) {}
-
-    // 2. Helper — consomme un stream SSE et retourne le texte complet (filtre <think>)
-    const fetchSseText = async (url) => {
-      let text = ''
-      let inThink = false
-      const res = await fetch(url)
-      if (!res.ok) throw new Error(`Erreur serveur ${res.status}`)
-      const reader  = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buf = ''
-      while (true) {
-        const { value, done } = await reader.read()
-        if (done) break
-        buf += decoder.decode(value, { stream: true })
-        const lines = buf.split('\n')
-        buf = lines.pop()
-        for (const line of lines) {
-          let raw
-          if (line.startsWith('data: ')) raw = line.slice(6).trim()
-          else if (line.startsWith('{')) raw = line.trim()
-          else continue
-          if (!raw || raw === '[DONE]') continue
-          let chunk
-          try {
-            const parsed = JSON.parse(raw)
-            if (parsed.error) throw new Error(parsed.error)
-            chunk = parsed.choices?.[0]?.delta?.content ?? ''
-          } catch (e) { if (e.message?.startsWith('Erreur')) throw e; continue }
-          if (!chunk) continue
-          let rem = chunk
-          while (rem.length > 0) {
-            if (!inThink) {
-              const s = rem.indexOf('<think>')
-              if (s === -1) { text += rem; break }
-              text += rem.slice(0, s)
-              rem = rem.slice(s + 7)
-              inThink = true
-            } else {
-              const e = rem.indexOf('</think>')
-              if (e === -1) break
-              rem = rem.slice(e + 8)
-              inThink = false
-            }
-          }
-        }
-      }
-      return text
-    }
-
-    // 3. Générer Info si non disponible
-    let currentInfoText = infoText
-    if (!currentInfoText) {
-      try {
-        const p = new URLSearchParams({ type: current.type, value: current.value })
-        currentInfoText = await fetchSseText(`/api/entities/info?${p}`)
-        setInfoText(currentInfoText)
-        setInfoLoading(false)
-        infoStarted.current = true
-      } catch (_) { currentInfoText = '' }
-    }
-
-    // 4. Générer RAG si non disponible
-    let currentRagText = ragText
-    if (!currentRagText) {
-      try {
-        const p = new URLSearchParams({ entity_type: current.type, entity_value: current.value, n: 15 })
-        currentRagText = await fetchSseText(`/api/synthesize-topic?${p}`)
-        setRagText(currentRagText)
-        setRagLoading(false)
-        ragStarted.current = true
-      } catch (_) { currentRagText = '' }
-    }
-
-    // 5. Construire le document Markdown selon le modèle habituel
-    const CARTO_TYPES = new Set(['EVENT', 'GPE', 'LOC', 'NORP', 'ORG', 'PERSON'])
-    let md = ''
-
-    // Frontmatter iA Writer
-    md += `---\n`
-    md += `Auteur: Patrick Ostertag\n`
-    md += `Titre: Rapport — ${current.type} : ${current.value}\n`
-    md += `AuteurAdresse: patrick.ostertag@gmail.com\n`
-    md += `AuteurSite: http://patrickostertag.ch\n`
-    md += `Date: ${today}\n`
-    md += `IAEngine: WUDD.ai\n`
-    md += `---\n\n`
-
-    // Titre
-    md += `# Rapport — ${current.value}\n\n`
-
-    // Encadré de résumé
-    md += `---\n`
-    md += `Synthèse des articles et analyses pour l'entité **${current.value}** (${current.type})`
-    md += ` — ${articles.length} source${articles.length !== 1 ? 's' : ''} — *${today}*`
-    if (l1Nodes.length > 0) {
-      const top5 = l1Nodes.filter(n => CARTO_TYPES.has(n.type)).slice(0, 5).map(n => `${n.value} (${n.type})`).join(', ')
-      md += `. Principales co-occurrences L1 : ${top5}.`
-    }
-    md += `\n---\n\n`
-
-    md += `{{TOC}}\n\n===\n\n`
-
-    // Section 1 : Cartographie des acteurs (graphe L1)
-    const cartoNodes = l1Nodes.filter(n => CARTO_TYPES.has(n.type))
-    if (cartoNodes.length > 0) {
-      md += `## Cartographie des acteurs — Co-occurrences directes (L1)\n\n`
-      const byType = {}
-      for (const n of cartoNodes) {
-        if (!byType[n.type]) byType[n.type] = []
-        byType[n.type].push(n)
-      }
-      for (const type of ['PERSON', 'ORG', 'GPE', 'LOC', 'NORP', 'EVENT'].filter(t => byType[t])) {
-        const line = byType[type].map(n => n.value).join(', ')
-        md += `**${type}** — ${line}\n\n`
-      }
-    }
-
-    // Section 2 : Informations — Synthèse IA
-    if (currentInfoText) {
-      md += `## Informations — Synthèse IA\n\n`
-      md += `${currentInfoText}\n\n`
-    }
-
-    // Section 3 : Analyse comparative RAG
-    if (currentRagText) {
-      md += `## Analyse comparative — Synthèse RAG\n\n`
-      md += `${currentRagText}\n\n`
-    }
-
-    // Section 4 : Articles avec images
-    md += `## Articles — ${articles.length} source${articles.length !== 1 ? 's' : ''}\n\n`
-    for (const art of articles) {
-      const header = [art['Date de publication'], art['Sources']].filter(Boolean).join(' — ')
-      if (header) md += `### ${header}\n\n`
-      if (art['Résumé']) md += `${art['Résumé']}\n\n`
-      const imgs = art['Images'] || []
-      for (const img of imgs.slice(0, 3)) {
-        const imgUrl = img?.URL || img?.url || ''
-        const imgAlt = img?.alt || img?.title || current.value
-        if (imgUrl) md += `![${imgAlt}](${imgUrl})\n*Source : ${art['Sources'] ?? ''}*\n\n`
-      }
-      if (art['URL']) md += `[Lire l'article](${art['URL']})\n\n`
-      md += `---\n\n`
-    }
-
-    // Tableau des références
-    md += `===\n\n`
-    md += `# Tableau des références\n\n`
-    md += `| # | Date | Source | URL |\n|---|---|---|---|\n`
-    articles.forEach((art, i) => {
-      const date   = art['Date de publication'] ?? ''
-      const source = art['Sources'] ?? ''
-      const url    = art['URL'] ?? ''
-      md += `| ${i + 1} | ${date} | ${source} | [↗](${url}) |\n`
-    })
-    md += `\n---\n*Rapport préparé avec [WUDD.ai](https://github.com/pat-the-geek/WUDD.ai) et produit par [iA Writer](https://ia.net/writer) — ${today}*\n`
-
-    // Téléchargement
-    const blob = new Blob([md], { type: 'text/markdown' })
-    const url  = URL.createObjectURL(blob)
-    Object.assign(document.createElement('a'), { href: url, download: `rapport_${current.type}_${safe}_${today}.md` }).click()
-    URL.revokeObjectURL(url)
-
-    setReportGenerating(false)
+  const handleGenerateReport = () => {
+    if (!articles.length) return
+    setShowReportDialog(true)
   }
 
   const handleExportJSON = () => {
@@ -759,15 +580,13 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
             </button>
             <button
               onClick={handleGenerateReport}
-              disabled={loading || articles.length === 0 || reportGenerating}
-              title="Générer un rapport Markdown (articles + graphe L1 + infos + RAG)"
+              disabled={loading || articles.length === 0}
+              title="Générer un rapport Markdown complet (streaming, Mermaid, Export Obsidian)"
               className="inline-flex items-center gap-1 px-3 py-3 md:px-2.5 md:py-1.5 rounded-lg text-xs font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 hover:bg-violet-200 dark:hover:bg-violet-900/70 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
-              {reportGenerating
-                ? <><Loader2 size={18} className="md:hidden animate-spin" /><Loader2 size={12} className="hidden md:block animate-spin" /></>
-                : <><FileText size={18} className="md:hidden" /><FileText size={12} className="hidden md:block" /></>
-              }
-              <span className="hidden sm:inline">{reportGenerating ? 'Rapport…' : 'Rapport'}</span>
+              <FileText size={18} className="md:hidden" />
+              <FileText size={12} className="hidden md:block" />
+              <span className="hidden sm:inline">Rapport</span>
             </button>
             <button
               onClick={handleExportJSON}
@@ -901,6 +720,16 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
         {/* ── Poignée de redimensionnement (masquée en plein écran et sur mobile) ── */}
         {!isMaximized && !isMobileFullscreen && <ResizeHandle onMouseDown={handleResizeMouseDown} />}
       </div>
+
+      {/* ── Dialogue rapport complet ── */}
+      {showReportDialog && (
+        <EntityFullReportDialog
+          entityType={current.type}
+          entityValue={current.value}
+          articles={articles}
+          onClose={() => setShowReportDialog(false)}
+        />
+      )}
     </>
   )
 }

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -1,0 +1,641 @@
+/**
+ * EntityFullReportDialog — génère et affiche un rapport complet d'une entité.
+ *
+ * - Modal centré similaire à ArticleFullReportDialog
+ * - Corps en Markdown streamé progressivement (Info SSE → RAG SSE → articles)
+ * - Diagrammes Mermaid : mindmap co-occurrences L1, camembert sources
+ * - Actions : copier, Export local, Export Obsidian, régénérer, plein écran, fermer
+ */
+
+import { useState, useEffect, useRef, useCallback, memo } from 'react'
+import { createPortal } from 'react-dom'
+import {
+  X, Maximize2, Minimize2, Copy, Download, RefreshCw,
+  FileText, Check, BookOpen, Loader2,
+} from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import rehypeRaw from 'rehype-raw'
+import mermaid from 'mermaid'
+
+mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' })
+
+// ── Mermaid block ──────────────────────────────────────────────────────────────
+
+function sanitizeMermaidCode(raw) {
+  return raw
+    .replace(/^```mermaid\s*/i, '')
+    .replace(/```\s*$/, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/\r\n/g, '\n')
+    .trim()
+}
+
+function MermaidBlock({ code, isStreaming }) {
+  const containerRef = useRef(null)
+  const id = useRef(`mermaid-ent-${Math.random().toString(36).slice(2)}`)
+  const [errMsg, setErrMsg] = useState(null)
+  const [rendered, setRendered] = useState(false)
+
+  const clean = sanitizeMermaidCode(code)
+
+  useEffect(() => {
+    if (isStreaming) return
+    if (!containerRef.current) return
+    setErrMsg(null)
+    let cancelled = false
+    mermaid.parse(clean)
+      .then(() => mermaid.render(id.current, clean))
+      .then(({ svg }) => {
+        if (!cancelled && containerRef.current) {
+          const responsiveSvg = svg.replace(/<svg([^>]*)>/i, (_, attrs) => {
+            const vbMatch = attrs.match(/viewBox="([^"]*)"/i)
+            const wMatch  = attrs.match(/width="([^"]*)"/i)
+            const hMatch  = attrs.match(/height="([^"]*)"/i)
+            let extra = ''
+            if (!vbMatch && wMatch && hMatch) {
+              extra = ` viewBox="0 0 ${parseFloat(wMatch[1])} ${parseFloat(hMatch[1])}"`
+            }
+            const cleaned = attrs
+              .replace(/\s+width="[^"]*"/gi, '')
+              .replace(/\s+height="[^"]*"/gi, '')
+              .replace(/\s+style="[^"]*"/gi, '')
+            return `<svg${cleaned}${extra} width="100%" style="width:100%;height:auto;max-width:100%;display:block;">`
+          })
+          containerRef.current.innerHTML = responsiveSvg
+          setRendered(true)
+        }
+      })
+      .catch(e => {
+        if (cancelled) return
+        const msg = e?.message ?? 'Syntaxe invalide'
+        const firstLine = msg.split('\n').find(l => l.trim()) ?? msg
+        setErrMsg(firstLine.length > 120 ? firstLine.slice(0, 120) + '…' : firstLine)
+      })
+    return () => { cancelled = true }
+  }, [clean, isStreaming])
+
+  if (isStreaming) {
+    return <div className="my-6 h-10 rounded-xl bg-slate-100 dark:bg-slate-800 animate-pulse" />
+  }
+  if (errMsg) {
+    return (
+      <div className="my-6 rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-4">
+        <p className="text-xs font-semibold text-amber-700 dark:text-amber-400 mb-2">
+          ⚠ Diagramme Mermaid non rendu
+        </p>
+        <pre className="text-xs text-slate-600 dark:text-slate-400 font-mono whitespace-pre-wrap bg-white dark:bg-slate-900 rounded-lg p-3 border border-amber-100 dark:border-amber-900 overflow-x-auto">
+          {clean}
+        </pre>
+      </div>
+    )
+  }
+  return (
+    <div
+      ref={containerRef}
+      className={`my-6 w-full overflow-x-auto ${rendered ? '' : 'h-10 bg-slate-100 dark:bg-slate-800 rounded-xl animate-pulse'}`}
+    />
+  )
+}
+
+// ── Vue finale gelée ───────────────────────────────────────────────────────────
+const FinalReportView = memo(function FinalReportView({ md, components }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} components={components}>
+      {md}
+    </ReactMarkdown>
+  )
+})
+
+// ── Helper: stream SSE et filtre <think> ───────────────────────────────────────
+async function consumeSse(url, onChunk, signal) {
+  const res = await fetch(url, { signal })
+  if (!res.ok) throw new Error(`Erreur serveur ${res.status}`)
+  const reader  = res.body.getReader()
+  const decoder = new TextDecoder()
+  let buf = ''
+  let inThink = false
+  while (true) {
+    const { value, done } = await reader.read()
+    if (done) break
+    buf += decoder.decode(value, { stream: true })
+    const lines = buf.split('\n')
+    buf = lines.pop() ?? ''
+    for (const line of lines) {
+      let raw
+      if (line.startsWith('data: ')) raw = line.slice(6).trim()
+      else if (line.startsWith('{')) raw = line.trim()
+      else continue
+      if (!raw || raw === '[DONE]') continue
+      let chunk
+      try {
+        const parsed = JSON.parse(raw)
+        if (parsed.error) throw new Error(parsed.error)
+        chunk = parsed.choices?.[0]?.delta?.content ?? ''
+      } catch (e) { if (e.message?.startsWith('Erreur')) throw e; continue }
+      if (!chunk) continue
+      let rem = chunk
+      while (rem.length > 0) {
+        if (!inThink) {
+          const s = rem.indexOf('<think>')
+          if (s === -1) { onChunk(rem); break }
+          onChunk(rem.slice(0, s))
+          rem = rem.slice(s + 7)
+          inThink = true
+        } else {
+          const e = rem.indexOf('</think>')
+          if (e === -1) break
+          rem = rem.slice(e + 8)
+          inThink = false
+        }
+      }
+    }
+  }
+}
+
+// ── Générateur Mermaid mindmap pour co-occurrences ─────────────────────────────
+function buildMindmapMd(entityValue, l1Nodes) {
+  if (!l1Nodes || l1Nodes.length === 0) return ''
+  const CARTO_TYPES = ['PERSON', 'ORG', 'GPE', 'LOC', 'NORP', 'EVENT']
+  const byType = {}
+  for (const n of l1Nodes) {
+    if (!CARTO_TYPES.includes(n.type)) continue
+    if (!byType[n.type]) byType[n.type] = []
+    // Limiter à 6 entités par type pour garder le diagramme lisible
+    if (byType[n.type].length < 6) byType[n.type].push(n.value)
+  }
+  const types = CARTO_TYPES.filter(t => byType[t]?.length > 0)
+  if (types.length === 0) return ''
+
+  // Nettoyer les valeurs pour Mermaid (éviter les guillemets/parenthèses problématiques)
+  const esc = v => v.replace(/[()[\]"']/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 40)
+
+  let diagram = `mindmap\n  root(${esc(entityValue)})\n`
+  for (const type of types) {
+    diagram += `    **${type}**\n`
+    for (const val of byType[type]) {
+      diagram += `      ${esc(val)}\n`
+    }
+  }
+  return `\`\`\`mermaid\n${diagram}\`\`\``
+}
+
+// ── Générateur Mermaid camembert sources ───────────────────────────────────────
+function buildPieMd(articles) {
+  if (!articles || articles.length === 0) return ''
+  const counts = {}
+  for (const art of articles) {
+    const src = art['Sources'] || 'Inconnu'
+    counts[src] = (counts[src] || 0) + 1
+  }
+  const entries = Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 10)
+  if (entries.length < 2) return ''
+  const esc = v => v.replace(/"/g, "'").slice(0, 35)
+  let diagram = `pie title Distribution des sources (${articles.length} articles)\n`
+  for (const [src, count] of entries) {
+    diagram += `    "${esc(src)}" : ${count}\n`
+  }
+  return `\`\`\`mermaid\n${diagram}\`\`\``
+}
+
+// ── Composant principal ────────────────────────────────────────────────────────
+
+export default function EntityFullReportDialog({
+  entityType,
+  entityValue,
+  articles,
+  onClose,
+}) {
+  const [isFullscreen, setIsFullscreen] = useState(false)
+  const [reportMd, setReportMd]         = useState('')
+  const [isLoading, setIsLoading]       = useState(true)
+  const [phase, setPhase]               = useState('init')
+  const [error, setError]               = useState(null)
+  const [copied, setCopied]             = useState(false)
+  const [exportState, setExportState]   = useState({ local: null, obsidian: null })
+  const [frozenMd, setFrozenMd]         = useState(null)
+  const frozenComponentsRef             = useRef(null)
+  const abortRef = useRef(null)
+
+  // ── Dérivé : markdown nettoyé ──────────────────────────────────────────────
+  const cleanMd = reportMd
+    .replace(/<think>[\s\S]*?<\/think>/g, '')
+    .replace(/<think>[\s\S]*/g, '')
+    .trim()
+
+  // ── Gel au moment où le stream se termine ─────────────────────────────────
+  useEffect(() => {
+    if (!isLoading && cleanMd && !frozenMd) {
+      frozenComponentsRef.current = mdComponents
+      setFrozenMd(cleanMd)
+    }
+  }, [isLoading]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Escape key ────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const h = e => { if (e.key === 'Escape' && !isFullscreen) onClose() }
+    document.addEventListener('keydown', h)
+    return () => document.removeEventListener('keydown', h)
+  }, [onClose, isFullscreen])
+
+  // ── Génération progressive du rapport ─────────────────────────────────────
+  const buildReport = useCallback(async () => {
+    abortRef.current?.abort()
+    const ac = new AbortController()
+    abortRef.current = ac
+
+    setReportMd('')
+    setFrozenMd(null)
+    setIsLoading(true)
+    setError(null)
+    setExportState({ local: null, obsidian: null })
+
+    const today = new Date().toISOString().slice(0, 10)
+    const safe  = entityValue.replace(/[^a-zA-Z0-9_\-]/g, '_')
+    const append = (text) => setReportMd(prev => prev + text)
+
+    try {
+      // ── Phase 1 : Frontmatter + titre + co-occurrences (synchrone) ────────
+      setPhase('init')
+
+      // Frontmatter iA Writer
+      append(`---\nAuteur: Patrick Ostertag\nTitre: Rapport — ${entityType} : ${entityValue}\nAuteurAdresse: patrick.ostertag@gmail.com\nAuteurSite: http://patrickostertag.ch\nDate: ${today}\nIAEngine: WUDD.ai\n---\n\n`)
+      append(`# Rapport — ${entityValue}\n\n`)
+      append(`---\nSynthèse des articles et analyses pour l'entité **${entityValue}** (${entityType}) — ${articles.length} source${articles.length !== 1 ? 's' : ''} — *${today}*\n---\n\n`)
+      append(`{{TOC}}\n\n===\n\n`)
+
+      // Co-occurrences L1
+      let l1Nodes = []
+      try {
+        const gParams = new URLSearchParams({
+          type: entityType, value: entityValue, depth: 1, limit: 40, limit_l2: 0,
+        })
+        const gRes = await fetch(`/api/entities/cooccurrences?${gParams}`, { signal: ac.signal })
+        const gData = await gRes.json()
+        if (!gData.error && Array.isArray(gData.nodes)) {
+          l1Nodes = gData.nodes.filter(n => n.level === 1).sort((a, b) => b.count - a.count)
+        }
+      } catch (_) {}
+
+      if (l1Nodes.length > 0) {
+        append(`## Cartographie des acteurs — Co-occurrences directes (L1)\n\n`)
+        const mindmap = buildMindmapMd(entityValue, l1Nodes)
+        if (mindmap) append(`${mindmap}\n\n`)
+        // Liste textuelle complémentaire
+        const CARTO_TYPES = new Set(['EVENT', 'GPE', 'LOC', 'NORP', 'ORG', 'PERSON'])
+        const byType = {}
+        for (const n of l1Nodes.filter(n => CARTO_TYPES.has(n.type))) {
+          if (!byType[n.type]) byType[n.type] = []
+          byType[n.type].push(n.value)
+        }
+        for (const type of ['PERSON', 'ORG', 'GPE', 'LOC', 'NORP', 'EVENT'].filter(t => byType[t])) {
+          append(`**${type}** — ${byType[type].join(', ')}\n\n`)
+        }
+      }
+
+      // Camembert sources
+      const pieMd = buildPieMd(articles)
+      if (pieMd) {
+        append(`## Répartition des sources\n\n${pieMd}\n\n`)
+      }
+
+      // ── Phase 2 : Synthèse IA encyclopédique (SSE streaming) ───────────────
+      setPhase('info')
+      append(`## Informations — Synthèse IA\n\n`)
+      try {
+        const infoParams = new URLSearchParams({ type: entityType, value: entityValue })
+        await consumeSse(`/api/entities/info?${infoParams}`, chunk => append(chunk), ac.signal)
+      } catch (e) {
+        if (e.name === 'AbortError') return
+        append(`*Erreur lors de la génération de la synthèse encyclopédique.*\n\n`)
+      }
+      append(`\n\n`)
+
+      // ── Phase 3 : Analyse RAG multi-sources (SSE streaming) ─────────────────
+      setPhase('rag')
+      append(`## Analyse comparative — Synthèse RAG\n\n`)
+      try {
+        const ragParams = new URLSearchParams({ entity_type: entityType, entity_value: entityValue, n: 15 })
+        await consumeSse(`/api/synthesize-topic?${ragParams}`, chunk => append(chunk), ac.signal)
+      } catch (e) {
+        if (e.name === 'AbortError') return
+        append(`*Erreur lors de la génération de la synthèse RAG.*\n\n`)
+      }
+      append(`\n\n`)
+
+      // ── Phase 4 : Articles + tableau des références (synchrone) ─────────────
+      setPhase('articles')
+      append(`## Articles — ${articles.length} source${articles.length !== 1 ? 's' : ''}\n\n`)
+      for (const art of articles) {
+        const header = [art['Date de publication'], art['Sources']].filter(Boolean).join(' — ')
+        if (header) append(`### ${header}\n\n`)
+        if (art['Résumé']) append(`${art['Résumé']}\n\n`)
+        const imgs = art['Images'] || []
+        for (const img of imgs.slice(0, 2)) {
+          const imgUrl = img?.URL || img?.url || ''
+          const imgAlt = img?.alt || img?.title || entityValue
+          if (imgUrl) append(`![${imgAlt}](${imgUrl})\n*Source : ${art['Sources'] ?? ''}*\n\n`)
+        }
+        if (art['URL']) append(`[Lire l'article](${art['URL']})\n\n`)
+        append(`---\n\n`)
+      }
+
+      append(`===\n\n# Tableau des références\n\n| # | Date | Source | URL |\n|---|---|---|---|\n`)
+      articles.forEach((art, i) => {
+        const date   = art['Date de publication'] ?? ''
+        const source = (art['Sources'] ?? '').replace(/\|/g, '\\|')
+        const url    = art['URL'] ?? ''
+        append(`| ${i + 1} | ${date} | ${source} | [↗](${url}) |\n`)
+      })
+      append(`\n---\n*Rapport préparé avec [WUDD.ai](https://github.com/pat-the-geek/WUDD.ai) — ${today}*\n`)
+
+      setPhase('done')
+      setIsLoading(false)
+    } catch (e) {
+      if (e.name !== 'AbortError') {
+        setError(e.message)
+        setIsLoading(false)
+      }
+    }
+  }, [entityType, entityValue, articles])
+
+  useEffect(() => {
+    buildReport()
+    return () => abortRef.current?.abort()
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ── Actions ────────────────────────────────────────────────────────────────
+  const getFilename = () => {
+    const safe = entityValue.replace(/[^a-zA-Z0-9_\-]/g, '_')
+    const today = new Date().toISOString().slice(0, 10)
+    return `rapport_${entityType}_${safe}_${today}`
+  }
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(cleanMd).catch(() => {})
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleDownload = () => {
+    const a = document.createElement('a')
+    a.href = URL.createObjectURL(new Blob([cleanMd], { type: 'text/markdown' }))
+    a.download = `${getFilename()}.md`
+    a.click()
+  }
+
+  const handleExport = async (target) => {
+    setExportState(prev => ({ ...prev, [target]: 'saving' }))
+    try {
+      const r = await fetch('/api/export/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ markdown: cleanMd, filename: getFilename(), target }),
+      })
+      const d = await r.json()
+      if (d.ok) {
+        setExportState(prev => ({ ...prev, [target]: { ok: true, path: d.path } }))
+      } else {
+        setExportState(prev => ({ ...prev, [target]: { ok: false, error: d.error } }))
+      }
+    } catch (e) {
+      setExportState(prev => ({ ...prev, [target]: { ok: false, error: String(e) } }))
+    }
+    setTimeout(() => setExportState(prev => ({ ...prev, [target]: null })), 4000)
+  }
+
+  // ── Phase label ────────────────────────────────────────────────────────────
+  const phaseLabel = {
+    init:     'Initialisation…',
+    info:     'Synthèse encyclopédique en cours…',
+    rag:      'Analyse comparative multi-sources…',
+    articles: 'Assemblage des articles…',
+    done:     '',
+  }[phase] ?? ''
+
+  // ── Styles boutons ─────────────────────────────────────────────────────────
+  const btnCls = 'p-1.5 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors'
+
+  // ── ReactMarkdown component overrides ─────────────────────────────────────
+  const mdComponents = {
+    h1: ({ children }) => (
+      <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100 mt-8 mb-4 pb-2 border-b border-slate-200 dark:border-slate-700 first:mt-0">{children}</h1>
+    ),
+    h2: ({ children }) => (
+      <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mt-7 mb-3">{children}</h2>
+    ),
+    h3: ({ children }) => (
+      <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200 mt-5 mb-2">{children}</h3>
+    ),
+    p: ({ children }) => (
+      <p className="text-base text-slate-700 dark:text-slate-300 mb-4 leading-7">{children}</p>
+    ),
+    pre: ({ children }) => {
+      const child = Array.isArray(children) ? children[0] : children
+      if (child?.props?.className === 'language-mermaid') return <>{children}</>
+      return (
+        <pre className="bg-slate-100 dark:bg-slate-950 rounded-xl p-4 overflow-x-auto mb-4 border border-slate-200 dark:border-slate-800">
+          {children}
+        </pre>
+      )
+    },
+    code: ({ className, children }) => {
+      if (className === 'language-mermaid') {
+        return <MermaidBlock code={String(children).trim()} isStreaming={isLoading} />
+      }
+      const isBlock = className || String(children).includes('\n')
+      if (!isBlock) {
+        return (
+          <code className="bg-slate-100 dark:bg-slate-800 text-amber-700 dark:text-amber-300 px-1.5 py-0.5 rounded text-[0.85em] font-mono">
+            {children}
+          </code>
+        )
+      }
+      return (
+        <code className={`text-slate-700 dark:text-slate-300 text-sm font-mono leading-relaxed ${className || ''}`}>
+          {children}
+        </code>
+      )
+    },
+    a: ({ href, children }) => (
+      <a href={href} target="_blank" rel="noopener noreferrer"
+        className="text-blue-600 dark:text-blue-400 hover:text-blue-500 dark:hover:text-blue-300 underline underline-offset-2">
+        {children}
+      </a>
+    ),
+    ul: ({ children }) => <ul className="list-disc text-slate-700 dark:text-slate-300 mb-4 space-y-1 ml-5">{children}</ul>,
+    ol: ({ children }) => <ol className="list-decimal text-slate-700 dark:text-slate-300 mb-4 space-y-1 ml-5">{children}</ol>,
+    li: ({ children }) => <li className="text-base text-slate-700 dark:text-slate-300 leading-relaxed">{children}</li>,
+    blockquote: ({ children }) => (
+      <blockquote className="border-l-4 border-violet-500/60 pl-4 italic text-slate-500 dark:text-slate-400 my-4">{children}</blockquote>
+    ),
+    table: ({ children }) => (
+      <div className="overflow-x-auto mb-4 rounded-lg border border-slate-200 dark:border-slate-700">
+        <table className="w-full text-sm text-slate-700 dark:text-slate-300">{children}</table>
+      </div>
+    ),
+    thead: ({ children }) => (
+      <thead className="bg-slate-100 dark:bg-slate-800 text-slate-800 dark:text-slate-200">{children}</thead>
+    ),
+    th: ({ children }) => (
+      <th className="border-b border-slate-200 dark:border-slate-700 px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider">{children}</th>
+    ),
+    td: ({ children }) => (
+      <td className="border-b border-slate-200/50 dark:border-slate-700/50 px-4 py-2.5">{children}</td>
+    ),
+    img: ({ src, alt }) => (
+      <figure className="my-6">
+        <img src={src} alt={alt} className="max-w-full rounded-xl border border-slate-200 dark:border-slate-700" loading="lazy" />
+        {alt && <figcaption className="text-center text-slate-400 dark:text-slate-500 text-sm mt-2 italic">{alt}</figcaption>}
+      </figure>
+    ),
+    hr: () => <hr className="border-slate-200 dark:border-slate-700 my-8" />,
+    strong: ({ children }) => <strong className="text-slate-900 dark:text-slate-100 font-semibold">{children}</strong>,
+    em: ({ children }) => <em className="text-slate-700 dark:text-slate-300 italic">{children}</em>,
+  }
+
+  // ── Export button helper ───────────────────────────────────────────────────
+  const ExportBtn = ({ target, label, icon: Icon, colors }) => {
+    const st = exportState[target]
+    const isSaving = st === 'saving'
+    const isDone   = st?.ok === true
+    const isFail   = st?.ok === false
+    return (
+      <div className="relative group">
+        <button
+          onClick={() => handleExport(target)}
+          disabled={isLoading || !cleanMd || isSaving}
+          title={isDone ? `Enregistré : ${st.path}` : isFail ? `Erreur : ${st.error}` : label}
+          className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border transition-colors disabled:opacity-40 ${
+            isDone  ? 'bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700 text-green-700 dark:text-green-300' :
+            isFail  ? 'bg-red-50 dark:bg-red-900/30 border-red-300 dark:border-red-700 text-red-700 dark:text-red-300' :
+            colors
+          }`}
+        >
+          {isSaving ? <Loader2 size={12} className="animate-spin" /> : isDone ? <Check size={12} /> : <Icon size={12} />}
+          {label}
+        </button>
+        {(isDone || isFail) && (
+          <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+            {isDone ? st.path : st.error}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[200] flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+      onClick={e => e.target === e.currentTarget && !isFullscreen && onClose()}
+    >
+      <div
+        className={`flex flex-col shadow-2xl bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 transition-all duration-200 ${
+          isFullscreen
+            ? 'fixed inset-0 rounded-none'
+            : 'w-[92vw] max-w-[1400px] h-[92vh] rounded-2xl'
+        } overflow-hidden`}
+      >
+        {/* ── Barre de titre ──────────────────────────────────────────────── */}
+        <div className="flex items-center gap-3 px-5 py-3 border-b border-slate-200 dark:border-slate-700 shrink-0 bg-white dark:bg-slate-900">
+          <FileText size={17} className="text-violet-500 shrink-0" />
+          <div className="flex-1 min-w-0">
+            <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">
+              Rapport — <span className="text-violet-600 dark:text-violet-400">{entityValue}</span>
+              <span className="ml-1.5 text-[10px] uppercase tracking-wider text-slate-400">{entityType}</span>
+            </h2>
+            <p className="text-[11px] text-slate-400 dark:text-slate-500 truncate">
+              {articles.length} article{articles.length !== 1 ? 's' : ''}
+              {isLoading && phaseLabel ? ` · ${phaseLabel}` : ''}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-1 shrink-0 flex-wrap justify-end">
+            {/* Export local */}
+            {!isLoading && cleanMd && (
+              <>
+                <ExportBtn
+                  target="local"
+                  label="Export"
+                  icon={Download}
+                  colors="bg-slate-50 dark:bg-slate-800 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400 hover:border-slate-400 hover:text-slate-700"
+                />
+                <ExportBtn
+                  target="obsidian"
+                  label="Export Obsidian"
+                  icon={BookOpen}
+                  colors="bg-violet-50 dark:bg-violet-900/30 border-violet-200 dark:border-violet-700 text-violet-700 dark:text-violet-300 hover:bg-violet-100 dark:hover:bg-violet-900/50"
+                />
+              </>
+            )}
+            <button onClick={handleCopy} className={btnCls} title="Copier le Markdown">
+              {copied ? <Check size={14} className="text-emerald-500" /> : <Copy size={14} />}
+            </button>
+            <button onClick={handleDownload} disabled={isLoading || !cleanMd} className={btnCls} title="Télécharger .md">
+              <Download size={14} />
+            </button>
+            <button onClick={buildReport} disabled={isLoading} className={btnCls} title="Régénérer le rapport">
+              <RefreshCw size={14} className={isLoading ? 'animate-spin text-violet-400' : ''} />
+            </button>
+            <button onClick={() => setIsFullscreen(v => !v)} className={btnCls} title={isFullscreen ? 'Quitter le plein écran' : 'Plein écran'}>
+              {isFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
+            </button>
+            <button onClick={onClose}
+              className="p-1.5 rounded-lg text-slate-400 hover:text-rose-500 dark:hover:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors"
+              title="Fermer">
+              <X size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* ── Indicateur de phase (pendant la génération) ────────────────── */}
+        {isLoading && (
+          <div className="flex items-center gap-2 px-5 py-2 bg-violet-50 dark:bg-violet-900/20 border-b border-violet-100 dark:border-violet-800/30 shrink-0">
+            <Loader2 size={12} className="animate-spin text-violet-500" />
+            <span className="text-xs text-violet-700 dark:text-violet-300">{phaseLabel || 'Génération en cours…'}</span>
+          </div>
+        )}
+
+        {/* ── Erreur ────────────────────────────────────────────────────────── */}
+        {error && (
+          <div className="px-5 py-3 bg-rose-50 dark:bg-rose-900/20 border-b border-rose-200 dark:border-rose-800 shrink-0">
+            <p className="text-sm text-rose-700 dark:text-rose-300">Erreur : {error}</p>
+          </div>
+        )}
+
+        {/* ── Contenu ──────────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto px-10 py-6 bg-white dark:bg-slate-900">
+          {isLoading && !cleanMd && (
+            <div className="flex items-center gap-3 text-slate-400 dark:text-slate-500 text-sm py-16 justify-center">
+              <Loader2 size={16} className="animate-spin" />
+              Génération du rapport en cours…
+            </div>
+          )}
+
+          {frozenMd ? (
+            <div key="final" className="w-full max-w-none">
+              <FinalReportView md={frozenMd} components={frozenComponentsRef.current} />
+            </div>
+          ) : cleanMd ? (
+            <div key="streaming" className="w-full max-w-none">
+              <ReactMarkdown
+                remarkPlugins={[remarkGfm]}
+                rehypePlugins={[rehypeRaw]}
+                components={mdComponents}
+              >
+                {cleanMd}
+              </ReactMarkdown>
+              {isLoading && (
+                <span className="inline-block w-1.5 h-4 bg-violet-500 dark:bg-violet-400 animate-pulse rounded-sm align-middle" />
+              )}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/viewer/src/components/SettingsPanel.jsx
+++ b/viewer/src/components/SettingsPanel.jsx
@@ -5,6 +5,7 @@ import {
   Maximize2, Minimize2, ExternalLink, Database, Clipboard, BarChart2,
   ToggleLeft, ToggleRight, RotateCcw,
   Sun, Moon, Monitor, Terminal, TrendingUp, Eye, Lock, EyeOff, Pencil,
+  BookOpen,
 } from 'lucide-react'
 
 // ─── Helpers partagés ────────────────────────────────────────────────────────
@@ -1632,6 +1633,11 @@ function EnvTab() {
   const [backupL2, setBackupL2]   = useState('')
   const [backupSaving, setBackupSaving] = useState({ l1: false, l2: false })
 
+  // Répertoire Obsidian
+  const [obsidianDir, setObsidianDir]       = useState('')
+  const [obsidianCheck, setObsidianCheck]   = useState(null) // null | 'checking' | {ok, message}
+  const [obsidianSaving, setObsidianSaving] = useState(false)
+
   const load = useCallback(() => {
     setLoading(true)
     fetch('/api/env')
@@ -1678,13 +1684,15 @@ function EnvTab() {
     setNewKey(''); setNewVal('')
   }
 
-  // Initialise les champs backup depuis les variables .env
+  // Initialise les champs backup + obsidian depuis les variables .env
   useEffect(() => {
     const v = entries.filter(e => e.type === 'var')
-    const l1 = v.find(e => e.key === 'BACKUP_L1')?.value || ''
-    const l2 = v.find(e => e.key === 'BACKUP_L2')?.value || ''
-    if (l1 !== '***') setBackupL1(l1)
-    if (l2 !== '***') setBackupL2(l2)
+    const l1  = v.find(e => e.key === 'BACKUP_L1')?.value || ''
+    const l2  = v.find(e => e.key === 'BACKUP_L2')?.value || ''
+    const obs = v.find(e => e.key === 'OBSIDIAN_DIR')?.value || ''
+    if (l1  !== '***') setBackupL1(l1)
+    if (l2  !== '***') setBackupL2(l2)
+    if (obs !== '***') setObsidianDir(obs)
   }, [entries])
 
   const checkAI = async (provider) => {
@@ -2020,6 +2028,85 @@ function EnvTab() {
             </div>
           )
         })}
+      </div>
+
+      {/* ── Section Obsidian ─────────────────────────────────────────────── */}
+      <div className="px-5 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 bg-violet-50/30 dark:bg-violet-900/10">
+        <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider flex items-center gap-1.5">
+          <BookOpen size={11} /> Export Obsidian
+        </p>
+        <p className="text-[11px] text-slate-500 dark:text-slate-400 mb-3 leading-relaxed">
+          Répertoire cible pour l'export des rapports vers Obsidian (<code className="text-xs bg-slate-100 dark:bg-slate-700 px-1 rounded">OBSIDIAN_DIR</code>).
+          En Docker, montez ce chemin comme volume supplémentaire.
+        </p>
+        <div className="mb-1">
+          <label className="text-[11px] text-slate-600 dark:text-slate-400 font-medium block mb-1">
+            Répertoire Obsidian
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={obsidianDir}
+              onChange={e => { setObsidianDir(e.target.value); setObsidianCheck(null) }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  setObsidianSaving(true)
+                  saveVar('OBSIDIAN_DIR', obsidianDir).finally(() => setObsidianSaving(false))
+                }
+              }}
+              placeholder="/chemin/absolu/vers/vault-obsidian"
+              className="flex-1 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded px-2.5 py-1.5 text-xs font-mono focus:outline-none focus:border-violet-400"
+            />
+            <button
+              onClick={async () => {
+                if (!obsidianDir.trim()) return
+                setObsidianCheck('checking')
+                try {
+                  const r = await fetch('/api/backup/check-dir', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ path: obsidianDir.trim() }),
+                  })
+                  setObsidianCheck(await r.json())
+                } catch (e) {
+                  setObsidianCheck({ ok: false, message: String(e) })
+                }
+              }}
+              disabled={!obsidianDir.trim() || obsidianCheck === 'checking'}
+              title="Vérifier l'accessibilité du répertoire"
+              className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-slate-200 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-violet-400 hover:text-violet-600 dark:hover:text-violet-400 disabled:opacity-40 transition-colors"
+            >
+              {obsidianCheck === 'checking'
+                ? <RefreshCw size={11} className="animate-spin" />
+                : <Check size={11} />
+              }
+              Check
+            </button>
+            <button
+              onClick={async () => {
+                if (!obsidianDir.trim()) return
+                setObsidianSaving(true)
+                await saveVar('OBSIDIAN_DIR', obsidianDir)
+                setObsidianSaving(false)
+              }}
+              disabled={!obsidianDir.trim() || obsidianSaving}
+              title="Sauvegarder dans .env"
+              className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-violet-600 text-white hover:bg-violet-500 disabled:opacity-40 transition-colors"
+            >
+              {obsidianSaving ? <RefreshCw size={11} className="animate-spin" /> : <Save size={11} />}
+            </button>
+          </div>
+          {obsidianCheck && obsidianCheck !== 'checking' && (
+            <p className={`text-[11px] mt-1 flex items-center gap-1 ${obsidianCheck.ok ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}>
+              {obsidianCheck.ok ? <CheckCircle2 size={11} /> : <AlertTriangle size={11} />}
+              {obsidianCheck.message}
+            </p>
+          )}
+        </div>
+        <p className="text-[10px] text-violet-600 dark:text-violet-400 mt-2 flex items-start gap-1">
+          <BookOpen size={10} className="mt-0.5 shrink-0" />
+          En Docker : ajoutez <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">- /votre/vault:/obsidian</code> dans <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">docker-compose.yml</code>, puis définissez <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">OBSIDIAN_DIR=/obsidian</code>.
+        </p>
       </div>
 
       {/* Footer */}


### PR DESCRIPTION
- EntityFullReportDialog : nouveau composant modal pour le rapport entité, généré progressivement en 4 phases (co-occurrences → synthèse IA SSE → analyse RAG SSE → articles). Diagrammes Mermaid automatiques : mindmap des co-occurrences L1 et camembert de répartition des sources. Rendu gelé après la fin du stream (même pattern qu'ArticleFullReportDialog).

- ArticleFullReportDialog : ajout des boutons "Export" (local) et "Export Obsidian" dans les deux types de rapport, avec feedback visuel (spinner, coche verte + chemin, rouge si erreur).

- EntityArticlePanel : le bouton "Rapport" ouvre désormais la dialog EntityFullReportDialog au lieu de générer silencieusement un téléchargement.

- backend /api/export/report : nouvel endpoint POST qui sauvegarde un rapport Markdown soit dans rapports/markdown/_WUDD.AI_/ (target=local) soit dans OBSIDIAN_DIR (target=obsidian).

- SettingsPanel / EnvTab : nouvelle section "Export Obsidian" avec champ OBSIDIAN_DIR, bouton Check (réutilise /api/backup/check-dir) et bouton Save, avec note d'aide Docker.

- docker-compose.yml : volume Obsidian commenté avec instructions.
- .env.example : variable OBSIDIAN_DIR documentée avec exemple Docker.