### PR TITLE
feat: ajouter frontmatter Obsidian lors de l'export vers Obsidian

### DIFF
--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -153,6 +153,27 @@ const CHIP_STYLE = {
 }
 const FALLBACK_CHIP = 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600'
 
+// ── Frontmatter Obsidian ──────────────────────────────────────────────────────
+function buildObsidianFrontmatter(title, tags) {
+  const date      = new Date().toISOString().slice(0, 10)
+  const dedupTags = [...new Set(
+    tags.filter(t => t && typeof t === 'string' && t.trim().length > 0)
+  )].slice(0, 30)
+  const tagLines  = dedupTags
+    .map(t => `  - "${t.trim().replace(/"/g, "'")}"`)
+    .join('\n')
+  return (
+    `---\n` +
+    `title: "${title.replace(/"/g, "'")}"\n` +
+    `date: ${date}\n` +
+    `version: "1.0"\n` +
+    `tags:\n${tagLines || '  - rapport'}\n` +
+    `type: Rapport\n` +
+    `statut: generated\n` +
+    `---\n\n`
+  )
+}
+
 // ── Composant principal ───────────────────────────────────────────────────────
 
 export default function ArticleFullReportDialog({ article, onClose }) {
@@ -425,11 +446,25 @@ ${contentEl.innerHTML}
     setExportState(prev => ({ ...prev, [target]: 'saving' }))
     const filename = `rapport_${sources || 'article'}_${date || new Date().toISOString().slice(0, 10)}`
       .replace(/[/\\: ]/g, '-')
+
+    // Pour l'export Obsidian : remplacer le frontmatter existant par un frontmatter Obsidian
+    let markdown = cleanMd
+    if (target === 'obsidian') {
+      // Collecter toutes les entités nommées de l'article comme tags
+      const entityTags = Object.values(entities)
+        .flat()
+        .filter(v => v && typeof v === 'string' && v.trim())
+      const tags  = [sources, ...entityTags].filter(Boolean)
+      const front = buildObsidianFrontmatter(titre, tags)
+      // Supprimer le frontmatter existant (bloc --- … ---) s'il est présent
+      markdown = front + cleanMd.replace(/^---[\s\S]*?---\n\n?/, '')
+    }
+
     try {
       const r = await fetch('/api/export/report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ markdown: cleanMd, filename, target }),
+        body: JSON.stringify({ markdown, filename, target }),
       })
       const d = await r.json()
       if (d.ok) {

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -200,6 +200,27 @@ function buildPieMd(articles) {
   return `\`\`\`mermaid\n${diagram}\`\`\``
 }
 
+// ── Frontmatter Obsidian ───────────────────────────────────────────────────────
+function buildObsidianFrontmatter(title, tags) {
+  const date     = new Date().toISOString().slice(0, 10)
+  const dedupTags = [...new Set(
+    tags.filter(t => t && typeof t === 'string' && t.trim().length > 0)
+  )].slice(0, 30)
+  const tagLines = dedupTags
+    .map(t => `  - "${t.trim().replace(/"/g, "'")}"`)
+    .join('\n')
+  return (
+    `---\n` +
+    `title: "${title.replace(/"/g, "'")}"\n` +
+    `date: ${date}\n` +
+    `version: "1.0"\n` +
+    `tags:\n${tagLines || '  - rapport'}\n` +
+    `type: Rapport\n` +
+    `statut: generated\n` +
+    `---\n\n`
+  )
+}
+
 // ── Composant principal ────────────────────────────────────────────────────────
 
 export default function EntityFullReportDialog({
@@ -217,7 +238,8 @@ export default function EntityFullReportDialog({
   const [exportState, setExportState]   = useState({ local: null, obsidian: null })
   const [frozenMd, setFrozenMd]         = useState(null)
   const frozenComponentsRef             = useRef(null)
-  const abortRef = useRef(null)
+  const abortRef    = useRef(null)
+  const l1NodesRef  = useRef([])   // co-occurrences L1, conservées pour l'export Obsidian
 
   // ── Dérivé : markdown nettoyé ──────────────────────────────────────────────
   const cleanMd = reportMd
@@ -278,6 +300,7 @@ export default function EntityFullReportDialog({
           l1Nodes = gData.nodes.filter(n => n.level === 1).sort((a, b) => b.count - a.count)
         }
       } catch (_) {}
+      l1NodesRef.current = l1Nodes  // conserver pour l'export Obsidian
 
       if (l1Nodes.length > 0) {
         append(`## Cartographie des acteurs — Co-occurrences directes (L1)\n\n`)
@@ -388,11 +411,23 @@ export default function EntityFullReportDialog({
 
   const handleExport = async (target) => {
     setExportState(prev => ({ ...prev, [target]: 'saving' }))
+
+    // Pour l'export Obsidian : remplacer le frontmatter iA Writer par un frontmatter Obsidian
+    let markdown = cleanMd
+    if (target === 'obsidian') {
+      const title   = `Rapport — ${entityType} : ${entityValue}`
+      const l1Tags  = l1NodesRef.current.map(n => String(n.value ?? '')).filter(Boolean)
+      const tags    = [entityValue, ...l1Tags]
+      const front   = buildObsidianFrontmatter(title, tags)
+      // Supprimer le frontmatter iA Writer existant (bloc --- … ---)
+      markdown = front + cleanMd.replace(/^---[\s\S]*?---\n\n?/, '')
+    }
+
     try {
       const r = await fetch('/api/export/report', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ markdown: cleanMd, filename: getFilename(), target }),
+        body: JSON.stringify({ markdown, filename: getFilename(), target }),
       })
       const d = await r.json()
       if (d.ok) {


### PR DESCRIPTION
Lors d'un export Obsidian (bouton "Export Obsidian"), le fichier Markdown est enrichi d'un frontmatter YAML compatible Obsidian Properties :

  title  — titre du rapport (entité ou article)
  date   — date du jour (ISO 8601)
  version — "1.0"
  tags   — entité principale + co-occurrences L1 (rapport entité)
           ou source + entités NER de l'article (rapport article)
  type   — Rapport
  statut — generated

Le frontmatter iA Writer existant est remplacé (pas dupliqué). Le frontmatter Obsidian n'est ajouté que pour l'export Obsidian, pas pour l'export local ni le téléchargement .md.