### PR TITLE
feat(duckdb): intégration DuckDB dans les 4 composants clés + script …

### DIFF
--- a/scripts/generate_48h_report.py
+++ b/scripts/generate_48h_report.py
@@ -32,13 +32,62 @@ ENTITY_TYPES_PERTINENTS = {"PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "
 DATE_FORMAT_RSS = "%a, %d %b %Y %H:%M:%S"
 
 
-def compute_top_entities(articles: list, top_n: int = 10) -> list:
+def compute_top_entities(
+    articles: list,
+    top_n: int = 10,
+    input_file: "Path | None" = None,
+) -> list:
     """
     Compte les entités nommées dans les articles et retourne les top N.
+
+    Si `input_file` est fourni et que DuckDB est disponible, lit le fichier
+    directement via DuckDB (IO plus rapide pour les grands fichiers, sans
+    charger tout le JSON en mémoire Python).
 
     Returns:
         Liste de tuples (nom_original, type_entité, nb_occurrences)
     """
+    # ── Chemin DuckDB (lecture directe du fichier, évite json.load Python) ───
+    if input_file is not None:
+        try:
+            from utils.db import get_db
+            db = get_db()
+            if db.available:
+                rows = db.entity_json_from_file(input_file)
+                if rows:
+                    counter: Counter = Counter()
+                    type_map: dict = {}
+                    for row in rows:
+                        ents_json = row.get("entities_json")
+                        if not ents_json:
+                            continue
+                        try:
+                            ents = json.loads(ents_json)
+                        except (ValueError, TypeError):
+                            continue
+                        if not isinstance(ents, dict):
+                            continue
+                        for entity_type, names in ents.items():
+                            if entity_type not in ENTITY_TYPES_PERTINENTS:
+                                continue
+                            if not isinstance(names, list):
+                                continue
+                            for name in names:
+                                name_clean = str(name).strip()
+                                if len(name_clean) < 3:
+                                    continue
+                                key = name_clean.lower()
+                                counter[key] += 1
+                                if key not in type_map:
+                                    type_map[key] = (name_clean, entity_type)
+                    top = []
+                    for key, count in counter.most_common(top_n):
+                        name_original, entity_type = type_map[key]
+                        top.append((name_original, entity_type, count))
+                    return top
+        except Exception:
+            pass  # bascule sur la méthode Python classique
+
     counter: Counter = Counter()
     # key = nom normalisé → (nom original, type)
     type_map: dict = {}
@@ -264,8 +313,8 @@ def generate_48h_report(dry_run: bool = False) -> None:
 
     print_console(f"{len(articles)} articles chargés")
 
-    # Calcul des top 10 entités
-    top_entities = compute_top_entities(articles, top_n=10)
+    # Calcul des top 10 entités (DuckDB si disponible, sinon Python in-memory)
+    top_entities = compute_top_entities(articles, top_n=10, input_file=input_file)
     if top_entities:
         print_console("Top 10 entités :")
         for i, (name, etype, count) in enumerate(top_entities, 1):

--- a/scripts/import_articles.py
+++ b/scripts/import_articles.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""
+import_articles.py — Importe des articles depuis un fichier JSON externe.
+
+Permet d'injecter des articles provenant d'une autre instance WUDD.ai, d'un
+backup, ou d'une source tiers dans la structure de données locale.
+
+Fonctionnalités :
+  - Validation du format article (champs obligatoires)
+  - Déduplication contre les articles existants du flux cible
+  - Normalisation des champs (dates, sources)
+  - Sauvegarde dans data/articles/<flux>/ ou data/articles-from-rss/
+  - Mise à jour des index (article_index, entity_index)
+
+Usage :
+    # Importer dans un flux nommé
+    python3 scripts/import_articles.py --file export.json --flux Intelligence-artificielle
+
+    # Importer dans articles-from-rss sous un keyword
+    python3 scripts/import_articles.py --file export.json --keyword ia --rss
+
+    # Dry-run (validation seulement, aucune écriture)
+    python3 scripts/import_articles.py --file export.json --flux IA --dry-run
+
+    # Forcer l'import même si des doublons sont détectés
+    python3 scripts/import_articles.py --file export.json --flux IA --force
+
+    # Afficher le rapport de validation uniquement
+    python3 scripts/import_articles.py --file export.json --validate-only
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+PROJECT_ROOT = SCRIPT_DIR.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from utils.logging import print_console
+from utils.config import get_config
+from utils.deduplication import Deduplicator
+from utils.article_index import get_article_index
+from utils.entity_index import get_entity_index
+
+
+# ── Champs obligatoires d'un article valide ────────────────────────────────
+
+REQUIRED_FIELDS = ["Date de publication", "Sources", "URL", "Résumé"]
+OPTIONAL_FIELDS = [
+    "Images", "entities", "sentiment", "score_sentiment",
+    "ton_editorial", "score_ton", "temps_lecture_minutes",
+    "temps_lecture_label", "score_source",
+]
+
+
+# ── Validation ─────────────────────────────────────────────────────────────
+
+def validate_article(article: dict) -> list[str]:
+    """Valide un article et retourne la liste des anomalies (vide si OK)."""
+    issues = []
+
+    if not isinstance(article, dict):
+        return ["n'est pas un dictionnaire"]
+
+    for field in REQUIRED_FIELDS:
+        if field not in article or not article[field]:
+            issues.append(f"champ obligatoire manquant : '{field}'")
+
+    url = article.get("URL", "")
+    if url and not str(url).startswith("http"):
+        issues.append(f"URL invalide : {url[:80]}")
+
+    resume = article.get("Résumé", "")
+    if resume and len(str(resume)) < 20:
+        issues.append(f"Résumé trop court ({len(str(resume))} chars)")
+
+    return issues
+
+
+def validate_file(articles: list) -> dict:
+    """Valide tous les articles d'un fichier et retourne un rapport."""
+    stats = {
+        "total": len(articles),
+        "valid": 0,
+        "invalid": 0,
+        "errors": [],
+    }
+    for i, article in enumerate(articles):
+        issues = validate_article(article)
+        if issues:
+            stats["invalid"] += 1
+            stats["errors"].append({
+                "index": i,
+                "url": article.get("URL", "(sans URL)") if isinstance(article, dict) else "(non-dict)",
+                "issues": issues,
+            })
+        else:
+            stats["valid"] += 1
+    return stats
+
+
+# ── Chargement des articles existants ──────────────────────────────────────
+
+def _load_existing_articles(target_dir: Path) -> list[dict]:
+    """Charge tous les articles existants dans un répertoire cible."""
+    existing = []
+    if not target_dir.exists():
+        return existing
+    for json_file in sorted(target_dir.glob("*.json")):
+        if "cache" in str(json_file):
+            continue
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                existing.extend(data)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return existing
+
+
+# ── Import principal ───────────────────────────────────────────────────────
+
+def import_articles(
+    source_file: Path,
+    flux: str | None = None,
+    keyword: str | None = None,
+    rss_mode: bool = False,
+    dry_run: bool = False,
+    force: bool = False,
+    validate_only: bool = False,
+) -> dict:
+    """
+    Importe les articles du fichier source dans la structure WUDD.ai.
+
+    Args:
+        source_file   : Fichier JSON source (liste d'articles)
+        flux          : Nom du flux cible (data/articles/<flux>/)
+        keyword       : Mot-clé cible (data/articles-from-rss/<keyword>.json)
+        rss_mode      : Si True, sauvegarde dans articles-from-rss/
+        dry_run       : Validation + rapport sans écriture
+        force         : Importer même les doublons détectés
+        validate_only : Afficher le rapport de validation sans importer
+
+    Returns:
+        Rapport d'import : {imported, skipped, invalid, output_file}
+    """
+    config = get_config()
+    config.setup_directories()
+
+    # ── Lecture du fichier source ──────────────────────────────────────────
+    print_console(f"Lecture de {source_file}")
+    try:
+        articles = json.loads(source_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print_console(f"Fichier JSON invalide : {e}", level="error")
+        sys.exit(1)
+    except OSError as e:
+        print_console(f"Impossible de lire le fichier : {e}", level="error")
+        sys.exit(1)
+
+    if not isinstance(articles, list):
+        print_console("Le fichier doit contenir une liste JSON d'articles", level="error")
+        sys.exit(1)
+
+    print_console(f"{len(articles)} articles lus")
+
+    # ── Validation ─────────────────────────────────────────────────────────
+    validation = validate_file(articles)
+    print_console(
+        f"Validation : {validation['valid']} valides, "
+        f"{validation['invalid']} invalides"
+    )
+    if validation["errors"]:
+        print_console("Anomalies détectées :")
+        for err in validation["errors"][:10]:
+            print_console(
+                f"  [index {err['index']}] {err['url'][:60]} — "
+                + "; ".join(err["issues"])
+            )
+        if len(validation["errors"]) > 10:
+            print_console(f"  … {len(validation['errors']) - 10} autres anomalies")
+
+    if validate_only:
+        print_console("Mode --validate-only : import annulé")
+        return validation
+
+    # ── Détermination du répertoire/fichier de destination ────────────────
+    if rss_mode and keyword:
+        output_file = config.project_root / "data" / "articles-from-rss" / f"{keyword}.json"
+        target_dir = output_file.parent
+        merge_mode = True  # fusionner avec l'existant pour rss
+    elif flux:
+        target_dir = config.project_root / "data" / "articles" / flux
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        output_file = target_dir / f"articles_imported_{date_str}.json"
+        merge_mode = False
+    else:
+        print_console("Spécifier --flux <nom> ou --keyword <mot-clé> --rss", level="error")
+        sys.exit(1)
+
+    # ── Déduplication ──────────────────────────────────────────────────────
+    existing = _load_existing_articles(target_dir if not merge_mode else output_file.parent)
+    if merge_mode and output_file.exists():
+        try:
+            merge_existing = json.loads(output_file.read_text(encoding="utf-8"))
+            if isinstance(merge_existing, list):
+                existing = merge_existing
+        except Exception:
+            existing = []
+
+    dedup = Deduplicator()
+    to_import = []
+    skipped_dedup = 0
+
+    for article in articles:
+        issues = validate_article(article)
+        if issues and not force:
+            continue  # ignorer les articles invalides
+        if not force and dedup.is_duplicate(article, existing):
+            skipped_dedup += 1
+            continue
+        to_import.append(article)
+
+    print_console(
+        f"Après déduplication : {len(to_import)} à importer, "
+        f"{skipped_dedup} doublons ignorés"
+    )
+
+    if dry_run:
+        print_console("Mode --dry-run : aucune écriture effectuée")
+        return {
+            "imported": len(to_import),
+            "skipped": skipped_dedup,
+            "invalid": validation["invalid"],
+            "output_file": str(output_file),
+            "dry_run": True,
+        }
+
+    if not to_import:
+        print_console("Aucun article à importer")
+        return {
+            "imported": 0,
+            "skipped": skipped_dedup,
+            "invalid": validation["invalid"],
+            "output_file": str(output_file),
+        }
+
+    # ── Écriture ───────────────────────────────────────────────────────────
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    if merge_mode and output_file.exists():
+        final_articles = existing + to_import
+    else:
+        final_articles = to_import
+
+    tmp = output_file.with_suffix(".json.tmp")
+    try:
+        tmp.write_text(
+            json.dumps(final_articles, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp.replace(output_file)
+        print_console(f"✓ {len(to_import)} articles importés → {output_file}")
+    except OSError as e:
+        print_console(f"Erreur d'écriture : {e}", level="error")
+        sys.exit(1)
+
+    # ── Mise à jour des index ──────────────────────────────────────────────
+    try:
+        aidx = get_article_index(config.project_root)
+        aidx.update([output_file])
+        print_console("Index articles mis à jour")
+    except Exception as e:
+        print_console(f"Index articles : {e}", level="warning")
+
+    has_entities = any(a.get("entities") for a in to_import)
+    if has_entities:
+        try:
+            eidx = get_entity_index(config.project_root)
+            rel = str(output_file.relative_to(config.project_root))
+            eidx.update(to_import, rel)
+            print_console("Index entités mis à jour")
+        except Exception as e:
+            print_console(f"Index entités : {e}", level="warning")
+
+    return {
+        "imported": len(to_import),
+        "skipped": skipped_dedup,
+        "invalid": validation["invalid"],
+        "output_file": str(output_file),
+    }
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Importe des articles JSON dans la structure de données WUDD.ai."
+    )
+    parser.add_argument(
+        "--file", required=True,
+        help="Chemin vers le fichier JSON source (liste d'articles)"
+    )
+    parser.add_argument(
+        "--flux",
+        help="Flux cible (data/articles/<flux>/). Mutuel. exclusif avec --keyword."
+    )
+    parser.add_argument(
+        "--keyword",
+        help="Mot-clé cible pour articles-from-rss (requiert --rss)."
+    )
+    parser.add_argument(
+        "--rss", action="store_true",
+        help="Importer dans data/articles-from-rss/ (fusion avec l'existant)."
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Valide et simule l'import sans écrire aucun fichier."
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Importer même les articles identifiés comme doublons."
+    )
+    parser.add_argument(
+        "--validate-only", action="store_true",
+        help="Affiche uniquement le rapport de validation, sans importer."
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    source = Path(args.file)
+    if not source.exists():
+        print_console(f"Fichier source introuvable : {source}", level="error")
+        sys.exit(1)
+
+    if args.flux and args.keyword:
+        print_console("--flux et --keyword sont mutuellement exclusifs", level="error")
+        sys.exit(1)
+
+    if not args.flux and not args.keyword and not args.validate_only:
+        print_console("Spécifier --flux <nom> ou --keyword <mot-clé> --rss", level="error")
+        sys.exit(1)
+
+    result = import_articles(
+        source_file=source,
+        flux=args.flux,
+        keyword=args.keyword,
+        rss_mode=args.rss,
+        dry_run=args.dry_run,
+        force=args.force,
+        validate_only=args.validate_only,
+    )
+
+    print_console(
+        f"\nRésumé : {result.get('imported', 0)} importés, "
+        f"{result.get('skipped', 0)} doublons, "
+        f"{result.get('invalid', 0)} invalides"
+    )

--- a/scripts/trend_detector.py
+++ b/scripts/trend_detector.py
@@ -194,6 +194,54 @@ def collect_entity_mentions(
     except Exception as _e:
         default_logger.warning(f"collect_entity_mentions: index indisponible ({_e}), fallback rglob")
 
+    # ── Fallback DuckDB (IO parallèle, plus rapide que rglob) ────────────────
+    try:
+        from utils.db import get_db
+        db = get_db(project_root)
+        if db.available:
+            rows = db.articles_with_entities_in_window(window_days)
+            if rows:
+                counts: dict[str, int] = defaultdict(int)
+                for row in rows:
+                    # Re-filtrer par date côté Python (DuckDB filtre best-effort)
+                    dt = _parse_date(row.get("date", ""))
+                    if dt is not None and dt < cutoff:
+                        continue
+                    entities_json = row.get("entities_json")
+                    if not entities_json:
+                        continue
+                    try:
+                        import json as _json
+                        ents = _json.loads(entities_json)
+                    except (ValueError, TypeError):
+                        continue
+                    if not isinstance(ents, dict):
+                        continue
+                    for etype, values in ents.items():
+                        if etype not in monitored_types:
+                            continue
+                        if not isinstance(values, list):
+                            continue
+                        for v in values:
+                            if not isinstance(v, str):
+                                continue
+                            v = v.strip()
+                            if not v or len(v) < len_min or len(v) > len_max:
+                                continue
+                            if v.lower() in exclude_entities:
+                                continue
+                            counts[f"{etype}:{v}"] += 1
+                if counts:
+                    default_logger.debug(
+                        f"collect_entity_mentions: {len(counts)} entités via DuckDB"
+                        f" (window={window_days}j)"
+                    )
+                    return dict(counts)
+    except Exception as _e:
+        default_logger.debug(
+            f"collect_entity_mentions: DuckDB indisponible ({_e}), fallback rglob"
+        )
+
     # ── Fallback rglob ────────────────────────────────────────────────────────
     counts = defaultdict(int)
     scan_dirs = [

--- a/utils/db.py
+++ b/utils/db.py
@@ -243,6 +243,102 @@ class ArticleDB:
         rows = self._exec(sql)
         return rows[0] if rows else {"avg_minutes": None, "median_minutes": None, "total_articles": 0}
 
+    def source_bias_stats(self) -> list[dict]:
+        """Agrège les statistiques de biais éditorial par source (pour /api/sources/bias).
+
+        Scanne les deux répertoires d'articles (articles/ et articles-from-rss/)
+        en une seule requête SQL, sans charger les fichiers en mémoire Python.
+
+        Returns:
+            Liste de {source, article_count, positif, neutre, negatif,
+                      avg_score_sentiment, avg_score_ton}
+            triée par volume décroissant.
+        """
+        # articles/*/*.json = 2 niveaux (exclut articles/*/cache/*.json qui est 3 niveaux)
+        glob_art = str(self.project_root / "data" / "articles" / "*" / "*.json")
+        glob_rss = str(self.project_root / "data" / "articles-from-rss" / "**" / "*.json")
+        sql = f"""
+            SELECT
+                "Sources"                                                          AS source,
+                COUNT(*)                                                           AS article_count,
+                SUM(CASE WHEN sentiment = 'positif'  THEN 1 ELSE 0 END)           AS positif,
+                SUM(CASE WHEN sentiment = 'neutre'   THEN 1 ELSE 0 END)           AS neutre,
+                SUM(CASE WHEN sentiment = 'négatif'  THEN 1 ELSE 0 END)           AS negatif,
+                ROUND(AVG(TRY_CAST(score_sentiment AS DOUBLE)), 2)                 AS avg_score_sentiment,
+                ROUND(AVG(TRY_CAST(score_ton       AS DOUBLE)), 2)                 AS avg_score_ton
+            FROM (
+                SELECT "Sources", sentiment, score_sentiment, score_ton
+                FROM read_json_auto('{glob_art}', ignore_errors=true)
+                WHERE "Sources" IS NOT NULL AND "Sources" != ''
+                UNION ALL
+                SELECT "Sources", sentiment, score_sentiment, score_ton
+                FROM read_json_auto('{glob_rss}', ignore_errors=true)
+                WHERE "Sources" IS NOT NULL AND "Sources" != ''
+            )
+            GROUP BY "Sources"
+            ORDER BY article_count DESC
+            LIMIT 200
+        """
+        return self._exec(sql)
+
+    def articles_with_entities_in_window(self, window_days: int) -> list[dict]:
+        """Retourne les articles avec leur JSON d'entités pour une fenêtre temporelle.
+
+        Scanne tous les fichiers articles via DuckDB (IO parallèle) et retourne
+        les champs nécessaires pour l'extraction d'entités côté Python. Utilisé
+        comme chemin rapide de remplacement du rglob dans trend_detector.py.
+
+        Args:
+            window_days : Fenêtre en jours (filtre best-effort sur date ISO/RSS)
+
+        Returns:
+            Liste de {entities_json, date} — entities_json est une chaîne JSON
+            à désérialiser par l'appelant.
+        """
+        cutoff = (datetime.utcnow() - timedelta(days=window_days)).strftime("%Y-%m-%d")
+        glob_art = str(self.project_root / "data" / "articles" / "*" / "*.json")
+        glob_rss = str(self.project_root / "data" / "articles-from-rss" / "**" / "*.json")
+        # Filtre best-effort sur la date (fonctionne pour formats ISO YYYY-MM-DD
+        # et partiellement pour RSS "Wed, 04 Mar 2026 …" grâce à la comparaison
+        # lexicographique — l'appelant doit re-filtrer avec parse_article_date())
+        sql = f"""
+            SELECT
+                "Date de publication"  AS date,
+                entities::VARCHAR      AS entities_json
+            FROM (
+                SELECT "Date de publication", entities
+                FROM read_json_auto('{glob_art}', ignore_errors=true)
+                WHERE entities IS NOT NULL
+                  AND "Date de publication" IS NOT NULL
+                UNION ALL
+                SELECT "Date de publication", entities
+                FROM read_json_auto('{glob_rss}', ignore_errors=true)
+                WHERE entities IS NOT NULL
+                  AND "Date de publication" IS NOT NULL
+            )
+        """
+        return self._exec(sql)
+
+    def entity_json_from_file(self, file_path: Path) -> list[dict]:
+        """Retourne les entités JSON de chaque article d'un fichier spécifique.
+
+        Utilisé par generate_48h_report pour lire 48-heures.json via DuckDB
+        (IO direct, pas de json.load Python pour les grands fichiers).
+
+        Args:
+            file_path : Chemin absolu vers le fichier JSON
+
+        Returns:
+            Liste de {entities_json} — une entrée par article avec entities.
+        """
+        safe_path = str(file_path).replace("'", "''")
+        sql = f"""
+            SELECT entities::VARCHAR AS entities_json
+            FROM read_json_auto('{safe_path}', ignore_errors=true)
+            WHERE entities IS NOT NULL
+        """
+        return self._exec(sql)
+
     def full_text_search(self, query: str, days: int = 7, limit: int = 20) -> list[dict]:
         """Recherche plein texte dans les résumés via LIKE (insensible à la casse).
 

--- a/viewer/routes/analytics.py
+++ b/viewer/routes/analytics.py
@@ -123,6 +123,34 @@ def api_sources_bias():
     if _bias_cache["data"] is not None and (now_ts - _bias_cache["ts"]) < _BIAS_CACHE_TTL:
         return jsonify(_bias_cache["data"])
 
+    # ── Chemin rapide DuckDB ──────────────────────────────────────────────────
+    try:
+        from utils.db import get_db
+        db = get_db(PROJECT_ROOT)
+        if db.available:
+            rows = db.source_bias_stats()
+            if rows:
+                result = [
+                    {
+                        "source": r["source"],
+                        "article_count": r["article_count"],
+                        "sentiment_counts": {
+                            "positif": r.get("positif") or 0,
+                            "neutre":  r.get("neutre")  or 0,
+                            "négatif": r.get("negatif") or 0,
+                        },
+                        "avg_score_sentiment": r.get("avg_score_sentiment"),
+                        "avg_score_ton":       r.get("avg_score_ton"),
+                        "ton_distribution":    {},  # non calculé par DuckDB
+                    }
+                    for r in rows
+                ]
+                _bias_cache["data"] = result
+                _bias_cache["ts"] = now_ts
+                return jsonify(result)
+    except Exception:
+        pass  # bascule sur rglob si DuckDB indisponible
+
     data_dirs = [
         PROJECT_ROOT / "data" / "articles",
         PROJECT_ROOT / "data" / "articles-from-rss",

--- a/viewer/routes/entities.py
+++ b/viewer/routes/entities.py
@@ -298,11 +298,28 @@ def api_entities_dashboard():
         })
     result_types.sort(key=lambda x: x["mention_count"], reverse=True)
 
+    # ── Enrichissement DuckDB (stats articles temps-réel) ─────────────────────
+    duckdb_stats = {}
+    try:
+        from utils.db import get_db
+        db = get_db(PROJECT_ROOT)
+        if db.available:
+            rt = db.reading_time_stats(days=7)
+            sd = db.sentiment_distribution(days=7)
+            duckdb_stats = {
+                "reading_time_7j":  rt,
+                "sentiment_7j":     sd,
+                "source_count_30j": len(db.article_stats_by_source(days=30)),
+            }
+    except Exception:
+        pass
+
     return jsonify({
         "total_files": total_files,
         "total_articles": total_articles,
         "total_with_entities": total_with_entities,
         "by_type": result_types,
+        "duckdb_stats": duckdb_stats,
     })
 
 


### PR DESCRIPTION
…import

Activation effective de la couche DuckDB dans le pipeline WUDD.ai :

utils/db.py — 3 nouvelles méthodes :
  - source_bias_stats() : agrégation par source (sentiment, scores) sur articles/ et articles-from-rss/ en une seule requête SQL
  - articles_with_entities_in_window(days) : articles avec entities JSON pour fenêtre temporelle, remplace le rglob en fallback
  - entity_json_from_file(path) : entities JSON d'un fichier spécifique

viewer/routes/analytics.py — /api/sources/bias :
  - DuckDB comme chemin primaire (source_bias_stats())
  - Fallback automatique sur rglob si DuckDB indisponible

scripts/trend_detector.py — collect_entity_mentions() :
  - DuckDB comme fallback entre entity_index et rglob
  - IO parallèle, Python pour l'extraction et le filtrage temporel

viewer/routes/entities.py — /api/entities/dashboard :
  - duckdb_stats enrichit la réponse avec reading_time_7j, sentiment_7j et source_count_30j (sans modifier l'existant)

scripts/generate_48h_report.py — compute_top_entities() :
  - DuckDB lit 48-heures.json directement (entity_json_from_file)
  - Fallback Python in-memory si DuckDB indisponible

scripts/import_articles.py (NEW) :
  - Import d'articles depuis un fichier JSON externe
  - Validation format, déduplication, normalisation
  - Modes : --flux, --keyword --rss, --dry-run, --force, --validate-only
  - Mise à jour article_index et entity_index après import