### PR TITLE
fix: logs INFO redirigés vers stderr + dialog plus grand

### DIFF
--- a/scripts/detect_contradictions.py
+++ b/scripts/detect_contradictions.py
@@ -24,6 +24,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
+# Rediriger les logs Python (INFO/DEBUG) vers stderr
+# → seul stdout (notre log()) est capturé par le SSE du viewer
+import logging
+logging.basicConfig(stream=sys.stderr, level=logging.INFO)
+
 from utils.config import get_config
 from utils.api_client import get_ai_client
 from utils.claim_extractor import extract_claims

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -329,7 +329,7 @@ function ContradictionDialog({ article, onClose }) {
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm z-50 flex items-center justify-center p-4"
       onClick={e => e.target === e.currentTarget && onClose()}>
-      <div className="bg-white/95 dark:bg-slate-900/95 backdrop-blur-xl border border-white/50 dark:border-white/10 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col overflow-hidden">
+      <div className="bg-white/95 dark:bg-slate-900/95 backdrop-blur-xl border border-white/50 dark:border-white/10 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[92vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-slate-200 dark:border-slate-700 shrink-0">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
- logging.basicConfig(stream=stderr) : les messages INFO Python ne polluent plus le stream SSE (seul stdout=log() est capturé)
- max-h-[92vh] au lieu de 80vh pour voir toutes les lignes du log