### PR TITLE
fix: logs INFO redirigés vers stderr + dialog plus grand

### DIFF
--- a/viewer/routes/contradictions.py
+++ b/viewer/routes/contradictions.py
@@ -75,7 +75,7 @@ def stream_contradiction_analysis():
             proc = subprocess.Popen(
                 ["python3", str(script), "--article", article_url],
                 stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+                stderr=subprocess.DEVNULL,
                 text=True,
                 bufsize=1,
                 cwd=str(PROJECT_ROOT),


### PR DESCRIPTION
stderr=DEVNULL sépare les logs système du stream SSE