### PR TITLE
fix: affichage des métadonnées de rapport dans le GUI

### DIFF
--- a/viewer/routes/export.py
+++ b/viewer/routes/export.py
@@ -726,7 +726,12 @@ def api_article_set_report_meta():
     if not file_path or not article_url or not rapport:
         return jsonify({"error": "file_path, article_url et rapport sont requis"}), 400
 
+    # Résolution : chemin relatif à PROJECT_ROOT ou chemin absolu
     fp = Path(file_path)
+    if not fp.is_absolute():
+        fp = PROJECT_ROOT / fp
+    fp = fp.resolve()
+
     if not fp.exists() or not fp.is_file():
         return jsonify({"error": "Fichier introuvable"}), 404
 

--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -305,14 +305,14 @@ function buildObsidianNoteBody(article, geoData = {}) {
 
 // ── Composant principal ───────────────────────────────────────────────────────
 
-export default function ArticleFullReportDialog({ article, filePath, onClose }) {
+export default function ArticleFullReportDialog({ article, filePath, obsidianVaultProp, onClose }) {
   const [isFullscreen, setIsFullscreen] = useState(false)
   const [reportMd, setReportMd]         = useState('')
   const [isLoading, setIsLoading]       = useState(true)
   const [error, setError]               = useState(null)
   const [copied, setCopied]             = useState(false)
   const [exportState, setExportState]   = useState({ local: null, obsidian: null })
-  const [obsidianVault, setObsidianVault] = useState(null)
+  const [obsidianVault, setObsidianVault] = useState(obsidianVaultProp ?? null)
   // frozenMd : snapshot du markdown au moment où le stream se termine.
   // La FinalReportView est montée avec ce snapshot et ne change plus jamais.
   const [frozenMd,  setFrozenMd]        = useState(null)
@@ -935,6 +935,32 @@ ${contentEl.innerHTML}
           </div>
         )}
 
+
+        {/* ── Rapports précédemment générés ─────────────────────────────────── */}
+        {Array.isArray(article['rapports']) && article['rapports'].length > 0 && (
+          <div className="no-print flex items-center gap-2 px-5 py-2 bg-violet-50/60 dark:bg-violet-900/20 border-b border-violet-100 dark:border-violet-800/40 overflow-x-auto shrink-0 flex-wrap">
+            <BookOpen size={11} className="text-violet-500 shrink-0" />
+            <span className="text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0">Rapports générés :</span>
+            {article['rapports'].map((rap, idx) => (
+              <span
+                key={idx}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-white dark:bg-slate-800 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700 shrink-0"
+                title={`${rap.chemin ?? ''}`}
+              >
+                {rap.cible === 'obsidian' ? 'Obsidian' : 'Local'}
+                {rap.date_creation && <span className="opacity-60">{' '}{rap.date_creation.slice(0, 16).replace('T', ' ')}</span>}
+                <span className="opacity-50 max-w-[120px] truncate">{rap.fichier}</span>
+                {rap.cible === 'obsidian' && obsidianVault && rap.fichier && (
+                  <button
+                    onClick={() => window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(rap.fichier.replace(/\.md$/i, ''))}`, '_blank')}
+                    className="ml-0.5 underline underline-offset-1 text-violet-600 dark:text-violet-400 hover:text-violet-900 dark:hover:text-violet-100"
+                    title="Ouvrir dans Obsidian"
+                  >↗</button>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
 
         {/* ── Report content ────────────────────────────────────────────────── */}
         <div className="flex-1 overflow-y-auto px-10 py-6 bg-white dark:bg-slate-900">

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -3,7 +3,7 @@ import {
   ExternalLink, ChevronDown, ChevronUp, Tag, X,
   Filter, Search, ArrowUpDown, Newspaper,
   Download, LayoutGrid, AlignLeft, LayoutList, Maximize2, Clock,
-  Star, Eye, Pencil, Check, RefreshCw, FileText, Scale,
+  Star, Eye, Pencil, Check, RefreshCw, FileText, Scale, BookOpen,
 } from 'lucide-react'
 import EntityHighlighter from './EntityHighlighter'
 import EntityArticlePanel from './EntityArticlePanel'
@@ -413,7 +413,7 @@ function IAPickerModal({ providers, onPick, onClose }) {
 }
 
 /** Carte article complète (vue grille / large) — style Liquid Glass. */
-function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, annotation, onAnnotate, filePath, availableProviders, isFirstUnread, isLarge }) {
+function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, annotation, onAnnotate, filePath, availableProviders, isFirstUnread, isLarge, obsidianVault }) {
   const [expanded, setExpanded]                   = useState(index < 3)
   const [lightbox, setLightbox]                   = useState(false)
   const [noteOpen, setNoteOpen]                   = useState(false)
@@ -617,6 +617,35 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
             </p>
           </div>
         )}
+
+        {/* Badges rapports exportés */}
+        {Array.isArray(article['rapports']) && article['rapports'].length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {article['rapports'].map((rap, idx) => (
+              <span
+                key={idx}
+                title={`${rap.cible === 'obsidian' ? 'Obsidian' : 'Local'} · ${rap.date_creation ?? ''}\n${rap.chemin ?? ''}`}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700"
+              >
+                <BookOpen size={9} />
+                Rapport {rap.cible === 'obsidian' ? 'Obsidian' : 'local'}
+                {rap.date_creation && (
+                  <span className="opacity-60">{rap.date_creation.slice(0, 10)}</span>
+                )}
+                {rap.cible === 'obsidian' && obsidianVault && rap.fichier && (
+                  <button
+                    onClick={e => {
+                      e.stopPropagation()
+                      window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(rap.fichier.replace(/\.md$/i, ''))}`, '_blank')
+                    }}
+                    className="ml-0.5 underline underline-offset-1 hover:text-violet-900 dark:hover:text-violet-100 transition-colors"
+                    title="Ouvrir dans Obsidian"
+                  >↗</button>
+                )}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </article>
   )
@@ -691,8 +720,17 @@ export default function ArticleListViewer({ content, annotations, onAnnotate, fi
   const [typesOpen, setTypesOpen]             = useState(false)
   const [sourcesOpen, setSourcesOpen]         = useState(false)
   const [annotFilter, setAnnotFilter]         = useState('tous') // 'tous' | 'importants' | 'non-lus'
+  const [obsidianVault, setObsidianVault]     = useState(null)
   const searchRef = useRef(null)
   const mobileSearchRef = useRef(null)
+
+  // Nom du vault Obsidian — chargé une seule fois pour tous les ArticleCard
+  useEffect(() => {
+    fetch('/api/config/obsidian')
+      .then(r => r.ok ? r.json() : null)
+      .then(d => { if (d?.vault_name) setObsidianVault(d.vault_name) })
+      .catch(() => {})
+  }, [])
 
   // ── Injection de la query externe (depuis SearchOverlay) ─────────────────
   useEffect(() => {
@@ -1141,6 +1179,7 @@ export default function ArticleListViewer({ content, annotations, onAnnotate, fi
                 filePath={filePath}
                 availableProviders={availableProviders}
                 isFirstUnread={!hasScrolledRef.current && article['URL'] === firstUnreadUrl}
+                obsidianVault={obsidianVault}
                 isLarge
               />
             </div>
@@ -1158,6 +1197,7 @@ export default function ArticleListViewer({ content, annotations, onAnnotate, fi
               filePath={filePath}
               availableProviders={availableProviders}
               isFirstUnread={!hasScrolledRef.current && article['URL'] === firstUnreadUrl}
+              obsidianVault={obsidianVault}
             />
           ))}
         </div>
@@ -1175,6 +1215,7 @@ export default function ArticleListViewer({ content, annotations, onAnnotate, fi
         <ArticleFullReportDialog
           article={reportArticle}
           filePath={filePath}
+          obsidianVaultProp={obsidianVault}
           onClose={() => setReportArticle(null)}
         />
       )}


### PR DESCRIPTION
Quatre corrections pour rendre les informations de rapport visibles :

1. Backend (export.py) :
   - /api/article/set-report-meta : résolution correcte des chemins relatifs (PROJECT_ROOT / file_path au lieu de Path(file_path) nu)

2. ArticleCard (ArticleListViewer.jsx) :
   - Ajout des badges « Rapport Obsidian/local » sous chaque article
   - Bouton ↗ pour ouvrir directement dans Obsidian via URI obsidian://
   - Import de BookOpen (lucide-react)

3. ArticleListViewer.jsx :
   - Fetch du vault Obsidian (/api/config/obsidian) une seule fois
   - Prop obsidianVault transmise à ArticleCard et ArticleFullReportDialog

4. ArticleFullReportDialog.jsx :
   - Bandeau violet permanent listant tous les rapports déjà générés pour cet article (champ article['rapports'])
   - Chaque entrée affiche : cible, date/heure, nom de fichier tronqué
   - Bouton ↗ pour ouvrir dans Obsidian quand vault configuré
   - Accepte obsidianVaultProp du parent pour éviter un fetch redondant

https://claude.ai/code/session_01S9gwHLSe3BgaGupHGnRJb8