### PR TITLE
fix: vault not found — suppression de la dérivation automatique du no…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -90,3 +90,9 @@ BACKUP_L2=
 #     - /votre/vault-obsidian:/obsidian
 # puis utilisez le chemin DANS le conteneur (/obsidian)
 OBSIDIAN_DIR=
+# Nom exact du vault Obsidian tel qu'il apparaît dans l'interface Obsidian.
+# Utilisé pour construire les liens obsidian://open?vault=...&file=...
+# Si laissé vide, les liens s'ouvrent dans le dernier vault actif (recommandé
+# si vous n'avez qu'un seul vault ou si OBSIDIAN_DIR pointe vers sa racine).
+# Attention : le nom du vault peut différer du nom du répertoire.
+OBSIDIAN_VAULT_NAME=

--- a/viewer/routes/export.py
+++ b/viewer/routes/export.py
@@ -846,14 +846,14 @@ def api_entity_get_report_meta():
 def api_config_obsidian():
     """Retourne la configuration Obsidian pour construire les liens obsidian://.
 
+    vault_name est retourné uniquement si OBSIDIAN_VAULT_NAME est explicitement
+    défini dans .env. Ne pas le dériver automatiquement depuis le chemin :
+    le nom Obsidian peut différer du nom de répertoire (accents, espaces, etc.)
+
     Retourne : { vault_name: str | null, obsidian_dir: str | null }
     """
     obsidian_dir = os.environ.get("OBSIDIAN_DIR", "").strip() or None
     vault_name   = os.environ.get("OBSIDIAN_VAULT_NAME", "").strip() or None
-
-    # Dériver le nom du vault depuis le chemin si non défini explicitement
-    if not vault_name and obsidian_dir:
-        vault_name = Path(obsidian_dir).name or None
 
     return jsonify({"vault_name": vault_name, "obsidian_dir": obsidian_dir})
 

--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -20,6 +20,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import mermaid from 'mermaid'
 import EntityHighlighter from './EntityHighlighter'
+import { obsidianUri } from '../utils/obsidian'
 
 mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' })
 
@@ -872,7 +873,7 @@ ${contentEl.innerHTML}
                   <button
                     onClick={() => {
                       const fname = exportState.obsidian.filename.replace(/\.md$/i, '')
-                      window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(fname)}`, '_blank')
+                      window.open(obsidianUri(fname, obsidianVault), '_blank')
                     }}
                     title="Ouvrir dans Obsidian"
                     className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border bg-violet-100 dark:bg-violet-900/40 border-violet-300 dark:border-violet-600 text-violet-800 dark:text-violet-200 hover:bg-violet-200 dark:hover:bg-violet-800/50 transition-colors"
@@ -952,7 +953,7 @@ ${contentEl.innerHTML}
                 <span className="opacity-50 max-w-[120px] truncate">{rap.fichier}</span>
                 {rap.cible === 'obsidian' && obsidianVault && rap.fichier && (
                   <button
-                    onClick={() => window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(rap.fichier.replace(/\.md$/i, ''))}`, '_blank')}
+                    onClick={() => window.open(obsidianUri(rap.fichier, obsidianVault), '_blank')}
                     className="ml-0.5 underline underline-offset-1 text-violet-600 dark:text-violet-400 hover:text-violet-900 dark:hover:text-violet-100"
                     title="Ouvrir dans Obsidian"
                   >↗</button>

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import EntityHighlighter from './EntityHighlighter'
 import EntityArticlePanel from './EntityArticlePanel'
+import { obsidianUri } from '../utils/obsidian'
 import ArticleFullReportDialog from './ArticleFullReportDialog'
 import TTSButton from './TTSButton'
 
@@ -636,7 +637,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
                   <button
                     onClick={e => {
                       e.stopPropagation()
-                      window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(rap.fichier.replace(/\.md$/i, ''))}`, '_blank')
+                      window.open(obsidianUri(rap.fichier, obsidianVault), '_blank')
                     }}
                     className="ml-0.5 underline underline-offset-1 hover:text-violet-900 dark:hover:text-violet-100 transition-colors"
                     title="Ouvrir dans Obsidian"

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -6,6 +6,7 @@ import EntityGraph from './EntityGraph'
 import EntityCalendar from './EntityCalendar'
 import TTSButton from './TTSButton'
 import EntityFullReportDialog from './EntityFullReportDialog'
+import { obsidianUri } from '../utils/obsidian'
 
 // ── Composants Markdown ────────────────────────────────────────────────────────
 const MD = {
@@ -522,8 +523,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                   <button
                     onClick={() => {
                       const rap = entityRapports[entityRapports.length - 1]
-                      const fname = rap.fichier.replace(/\.md$/i, '')
-                      window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}&file=${encodeURIComponent(fname)}`, '_blank')
+                      window.open(obsidianUri(rap.fichier, obsidianVaultName), '_blank')
                     }}
                     title={`Ouvrir dans Obsidian : ${entityRapports[entityRapports.length - 1].fichier}`}
                     className="inline-flex items-center gap-0.5 text-[10px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
@@ -773,8 +773,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                           <button
                             onClick={e => {
                               e.stopPropagation()
-                              const fname = rap.fichier.replace(/\.md$/i, '')
-                              window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVaultName)}&file=${encodeURIComponent(fname)}`, '_blank')
+                              window.open(obsidianUri(rap.fichier, obsidianVaultName), '_blank')
                             }}
                             className="ml-0.5 underline underline-offset-1 hover:text-violet-900 dark:hover:text-violet-100 transition-colors"
                             title="Ouvrir dans Obsidian"

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -8,6 +8,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, memo } from 'react'
+import { obsidianUri } from '../utils/obsidian'
 import { createPortal } from 'react-dom'
 import {
   X, Maximize2, Minimize2, Copy, Download, RefreshCw,
@@ -674,8 +675,7 @@ export default function EntityFullReportDialog({
                 {exportState.obsidian?.ok && obsidianVault && exportState.obsidian.filename && (
                   <button
                     onClick={() => {
-                      const fname = exportState.obsidian.filename.replace(/\.md$/i, '')
-                      window.open(`obsidian://open?vault=${encodeURIComponent(obsidianVault)}&file=${encodeURIComponent(fname)}`, '_blank')
+                      window.open(obsidianUri(exportState.obsidian.filename, obsidianVault), '_blank')
                     }}
                     title="Ouvrir dans Obsidian"
                     className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border bg-violet-100 dark:bg-violet-900/40 border-violet-300 dark:border-violet-600 text-violet-800 dark:text-violet-200 hover:bg-violet-200 dark:hover:bg-violet-800/50 transition-colors"

--- a/viewer/src/utils/obsidian.js
+++ b/viewer/src/utils/obsidian.js
@@ -1,0 +1,18 @@
+/**
+ * Construit un URI obsidian://open pour ouvrir un fichier dans Obsidian.
+ *
+ * Si vaultName est fourni, l'URI inclut vault=<vaultName>.
+ * Sinon, Obsidian ouvre le fichier dans le dernier vault actif — comportement
+ * recommandé pour éviter l'erreur "vault not found" lorsque le nom du vault
+ * n'est pas explicitement configuré via OBSIDIAN_VAULT_NAME dans .env.
+ *
+ * @param {string} filename  - Nom du fichier (avec ou sans .md)
+ * @param {string|null} vaultName - Nom exact du vault Obsidian (optionnel)
+ * @returns {string} URI obsidian://
+ */
+export function obsidianUri(filename, vaultName) {
+  const fname = (filename ?? '').replace(/\.md$/i, '')
+  const params = new URLSearchParams({ file: fname })
+  if (vaultName) params.set('vault', vaultName)
+  return `obsidian://open?${params.toString()}`
+}


### PR DESCRIPTION
…m de vault

Le nom du vault Obsidian dans l'URI obsidian://open doit correspondre exactement au nom affiché dans l'interface Obsidian, qui peut différer du nom du répertoire (accents, espaces, casse).

- Backend (export.py) : ne plus dériver vault_name depuis Path(OBSIDIAN_DIR).name → vault_name retourné uniquement si OBSIDIAN_VAULT_NAME est explicitement défini dans .env (valeur vide sinon)

- Nouveau helper utils/obsidian.js : obsidianUri(filename, vaultName) → construit obsidian://open?file=... avec vault= optionnel → sans vault= : Obsidian ouvre dans le dernier vault actif (comportement par défaut recommandé, évite l'erreur vault not found)

- Tous les composants migrent vers obsidianUri() — plus de construction manuelle de l'URI (ArticleFullReportDialog, ArticleListViewer, EntityArticlePanel, EntityFullReportDialog)

- .env.example : ajout de OBSIDIAN_VAULT_NAME avec explication

https://claude.ai/code/session_01S9gwHLSe3BgaGupHGnRJb8