### PR TITLE
fix: bouton Ouvrir toujours visible sans OBSIDIAN_VAULT_NAME

### DIFF
--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -869,7 +869,7 @@ ${contentEl.innerHTML}
                   )}
                 </div>
                 {/* Ouvrir dans Obsidian — affiché après un export Obsidian réussi */}
-                {exportState.obsidian?.ok && obsidianVault && exportState.obsidian.filename && (
+                {exportState.obsidian?.ok && exportState.obsidian.filename && (
                   <button
                     onClick={() => {
                       const fname = exportState.obsidian.filename.replace(/\.md$/i, '')
@@ -951,7 +951,7 @@ ${contentEl.innerHTML}
                 {rap.cible === 'obsidian' ? 'Obsidian' : 'Local'}
                 {rap.date_creation && <span className="opacity-60">{' '}{rap.date_creation.slice(0, 16).replace('T', ' ')}</span>}
                 <span className="opacity-50 max-w-[120px] truncate">{rap.fichier}</span>
-                {rap.cible === 'obsidian' && obsidianVault && rap.fichier && (
+                {rap.cible === 'obsidian' && rap.fichier && (
                   <button
                     onClick={() => window.open(obsidianUri(rap.fichier, obsidianVault), '_blank')}
                     className="ml-0.5 underline underline-offset-1 text-violet-600 dark:text-violet-400 hover:text-violet-900 dark:hover:text-violet-100"

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -633,7 +633,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
                 {rap.date_creation && (
                   <span className="opacity-60">{rap.date_creation.slice(0, 10)}</span>
                 )}
-                {rap.cible === 'obsidian' && obsidianVault && rap.fichier && (
+                {rap.cible === 'obsidian' && rap.fichier && (
                   <button
                     onClick={e => {
                       e.stopPropagation()

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -519,7 +519,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                   {entityRapports.length} rapport{entityRapports.length > 1 ? 's' : ''}
                 </span>
                 {/* Lien Obsidian pour le rapport le plus récent */}
-                {obsidianVaultName && entityRapports[entityRapports.length - 1]?.fichier && (
+                {entityRapports[entityRapports.length - 1]?.fichier && (
                   <button
                     onClick={() => {
                       const rap = entityRapports[entityRapports.length - 1]
@@ -769,7 +769,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                             {' '}{rap.date_creation.slice(0, 10)}
                           </span>
                         )}
-                        {rap.cible === 'obsidian' && obsidianVaultName && rap.fichier && (
+                        {rap.cible === 'obsidian' && rap.fichier && (
                           <button
                             onClick={e => {
                               e.stopPropagation()

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -672,7 +672,7 @@ export default function EntityFullReportDialog({
                   colors="bg-violet-50 dark:bg-violet-900/30 border-violet-200 dark:border-violet-700 text-violet-700 dark:text-violet-300 hover:bg-violet-100 dark:hover:bg-violet-900/50"
                 />
                 {/* Ouvrir dans Obsidian — affiché après un export Obsidian réussi */}
-                {exportState.obsidian?.ok && obsidianVault && exportState.obsidian.filename && (
+                {exportState.obsidian?.ok && exportState.obsidian.filename && (
                   <button
                     onClick={() => {
                       window.open(obsidianUri(exportState.obsidian.filename, obsidianVault), '_blank')


### PR DESCRIPTION
Le bouton était conditionné à obsidianVault non-null, ce qui le masquait quand OBSIDIAN_VAULT_NAME n'est pas défini dans .env. obsidianUri() construit l'URI sans vault= dans ce cas — le bouton s'affiche dès qu'un nom de fichier est disponible.

Fichiers corrigés : ArticleFullReportDialog, ArticleListViewer, EntityArticlePanel, EntityFullReportDialog.

https://claude.ai/code/session_01S9gwHLSe3BgaGupHGnRJb8