### PR TITLE
fix: plus de fenêtre vide à l'ouverture dans Obsidian

### DIFF
--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -20,7 +20,7 @@ import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
 import mermaid from 'mermaid'
 import EntityHighlighter from './EntityHighlighter'
-import { obsidianUri } from '../utils/obsidian'
+import { obsidianUri, openInObsidian } from '../utils/obsidian'
 
 mermaid.initialize({ startOnLoad: false, theme: 'neutral', securityLevel: 'loose' })
 
@@ -873,7 +873,7 @@ ${contentEl.innerHTML}
                   <button
                     onClick={() => {
                       const fname = exportState.obsidian.filename.replace(/\.md$/i, '')
-                      window.open(obsidianUri(fname, obsidianVault), '_blank')
+                      openInObsidian(fname, obsidianVault)
                     }}
                     title="Ouvrir dans Obsidian"
                     className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border bg-violet-100 dark:bg-violet-900/40 border-violet-300 dark:border-violet-600 text-violet-800 dark:text-violet-200 hover:bg-violet-200 dark:hover:bg-violet-800/50 transition-colors"
@@ -953,7 +953,7 @@ ${contentEl.innerHTML}
                 <span className="opacity-50 max-w-[120px] truncate">{rap.fichier}</span>
                 {rap.cible === 'obsidian' && rap.fichier && (
                   <button
-                    onClick={() => window.open(obsidianUri(rap.fichier, obsidianVault), '_blank')}
+                    onClick={() => openInObsidian(rap.fichier, obsidianVault)}
                     className="ml-0.5 underline underline-offset-1 text-violet-600 dark:text-violet-400 hover:text-violet-900 dark:hover:text-violet-100"
                     title="Ouvrir dans Obsidian"
                   >↗</button>

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import EntityHighlighter from './EntityHighlighter'
 import EntityArticlePanel from './EntityArticlePanel'
-import { obsidianUri } from '../utils/obsidian'
+import { openInObsidian } from '../utils/obsidian'
 import ArticleFullReportDialog from './ArticleFullReportDialog'
 import TTSButton from './TTSButton'
 
@@ -637,7 +637,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
                   <button
                     onClick={e => {
                       e.stopPropagation()
-                      window.open(obsidianUri(rap.fichier, obsidianVault), '_blank')
+                      openInObsidian(rap.fichier, obsidianVault)
                     }}
                     className="ml-0.5 underline underline-offset-1 hover:text-violet-900 dark:hover:text-violet-100 transition-colors"
                     title="Ouvrir dans Obsidian"

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -6,7 +6,7 @@ import EntityGraph from './EntityGraph'
 import EntityCalendar from './EntityCalendar'
 import TTSButton from './TTSButton'
 import EntityFullReportDialog from './EntityFullReportDialog'
-import { obsidianUri } from '../utils/obsidian'
+import { openInObsidian } from '../utils/obsidian'
 
 // ── Composants Markdown ────────────────────────────────────────────────────────
 const MD = {
@@ -523,7 +523,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                   <button
                     onClick={() => {
                       const rap = entityRapports[entityRapports.length - 1]
-                      window.open(obsidianUri(rap.fichier, obsidianVaultName), '_blank')
+                      openInObsidian(rap.fichier, obsidianVaultName)
                     }}
                     title={`Ouvrir dans Obsidian : ${entityRapports[entityRapports.length - 1].fichier}`}
                     className="inline-flex items-center gap-0.5 text-[10px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
@@ -773,7 +773,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                           <button
                             onClick={e => {
                               e.stopPropagation()
-                              window.open(obsidianUri(rap.fichier, obsidianVaultName), '_blank')
+                              openInObsidian(rap.fichier, obsidianVaultName)
                             }}
                             className="ml-0.5 underline underline-offset-1 hover:text-violet-900 dark:hover:text-violet-100 transition-colors"
                             title="Ouvrir dans Obsidian"

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -8,7 +8,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, memo } from 'react'
-import { obsidianUri } from '../utils/obsidian'
+import { openInObsidian } from '../utils/obsidian'
 import { createPortal } from 'react-dom'
 import {
   X, Maximize2, Minimize2, Copy, Download, RefreshCw,
@@ -675,7 +675,7 @@ export default function EntityFullReportDialog({
                 {exportState.obsidian?.ok && exportState.obsidian.filename && (
                   <button
                     onClick={() => {
-                      window.open(obsidianUri(exportState.obsidian.filename, obsidianVault), '_blank')
+                      openInObsidian(exportState.obsidian.filename, obsidianVault)
                     }}
                     title="Ouvrir dans Obsidian"
                     className="flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-medium border bg-violet-100 dark:bg-violet-900/40 border-violet-300 dark:border-violet-600 text-violet-800 dark:text-violet-200 hover:bg-violet-200 dark:hover:bg-violet-800/50 transition-colors"

--- a/viewer/src/utils/obsidian.js
+++ b/viewer/src/utils/obsidian.js
@@ -16,3 +16,19 @@ export function obsidianUri(filename, vaultName) {
   if (vaultName) params.set('vault', vaultName)
   return `obsidian://open?${params.toString()}`
 }
+
+/**
+ * Ouvre un fichier dans Obsidian sans laisser d'onglet vide.
+ *
+ * window.open() avec un URI custom crée systématiquement un onglet blanc.
+ * Un <a> cliqué programmatiquement transmet l'URI au système sans ouvrir
+ * de nouvelle fenêtre.
+ *
+ * @param {string} filename  - Nom du fichier (avec ou sans .md)
+ * @param {string|null} vaultName - Nom exact du vault Obsidian (optionnel)
+ */
+export function openInObsidian(filename, vaultName) {
+  const a = document.createElement('a')
+  a.href = obsidianUri(filename, vaultName)
+  a.click()
+}


### PR DESCRIPTION
window.open() avec un URI custom ouvre systématiquement un onglet blanc avant de passer la main au système d'exploitation.

Remplacement par openInObsidian() qui crée un <a> temporaire et l'active programmatiquement — l'URI est transmise au système sans ouvrir de nouvel onglet.

- utils/obsidian.js : ajout de openInObsidian(filename, vaultName)
- ArticleFullReportDialog, ArticleListViewer, EntityArticlePanel, EntityFullReportDialog : migration vers openInObsidian()

https://claude.ai/code/session_01S9gwHLSe3BgaGupHGnRJb8