### PR TITLE
fix: restaurer _get_obsidian_note_name écrasé par l'édition précédente

### DIFF
--- a/utils/article_merger.py
+++ b/utils/article_merger.py
@@ -309,6 +309,9 @@ def _build_combined_resume(articles: list[dict]) -> str:
         header = f"[{source}{' — ' + date if date else ''}]"
         parts.append(f"{header}\n{resume}")
     return "\n\n".join(parts)
+
+
+def _get_obsidian_note_name(article: dict) -> str:
     """Extrait le nom (sans extension) de la note Obsidian de l'article."""
     for rapport in (article.get("rapports") or []):
         if rapport.get("cible") == "obsidian":


### PR DESCRIPTION
La ligne `def _get_obsidian_note_name(...)` avait été supprimée lors de l'insertion de _build_combined_resume, rendant le corps de la fonction inaccessible (code mort après le return) et causant un NameError à l'exécution — à l'origine de l'erreur "The string did not match the expected pattern" côté navigateur (Flask renvoyait du HTML au lieu de JSON).

https://claude.ai/code/session_01Xwc9cspKSyeZYQsGk55yTP