### PR TITLE
fix: scroll liste articles similaires + footer toujours visible

### DIFF
--- a/viewer/src/components/SimilarArticlesPanel.jsx
+++ b/viewer/src/components/SimilarArticlesPanel.jsx
@@ -173,7 +173,7 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
         </div>
 
         {/* ── Corps scrollable ───────────────────────────────────────────── */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto min-h-0">
 
           {/* Chargement */}
           {loading && (


### PR DESCRIPTION
Ajout de min-h-0 sur le div flex-1 du corps scrollable. Sans min-h-0, un flex item ne peut pas rétrécir en dessous de sa taille de contenu naturelle, ce qui empêche overflow-y-auto de s'activer et pousse le footer hors de l'écran.

https://claude.ai/code/session_01Xwc9cspKSyeZYQsGk55yTP