### PR TITLE
ui: Sprint 1 — conformité Apple HIG (typographie, couleurs, contraste…

### DIFF
--- a/viewer/src/App.jsx
+++ b/viewer/src/App.jsx
@@ -577,7 +577,7 @@ export default function App() {
         {/* Logo compact */}
         <div className="flex items-center gap-1.5 shrink-0 mr-1">
           <img src={wuddLogo} alt="WUDD.ai" className="w-8 h-8 rounded-md select-none" />
-          <span className="hidden xl:block font-semibold text-sm text-slate-900 dark:text-slate-100 whitespace-nowrap">WUDD.ai</span>
+          <span className="hidden xl:block font-semibold text-hig-callout text-slate-900 dark:text-slate-100 whitespace-nowrap">WUDD.ai</span>
         </div>
 
         {/* Statut RSS */}
@@ -600,7 +600,7 @@ export default function App() {
               title={title}
               className={`px-1.5 py-1.5 transition-colors ${
                 theme === key
-                  ? 'bg-blue-600 text-white'
+                  ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-700 dark:hover:text-slate-200'
               }`}
             >
@@ -710,7 +710,7 @@ export default function App() {
                   <Icon size={14} className="text-slate-400 dark:text-slate-500 shrink-0 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors" />
                   <div className="min-w-0">
                     <div className="text-sm font-medium text-slate-700 dark:text-slate-200">{label}</div>
-                    <div className="text-[10px] text-slate-400 dark:text-slate-500 leading-tight">{desc}</div>
+                    <div className="text-[11px] text-slate-400 dark:text-slate-500 leading-tight">{desc}</div>
                   </div>
                 </button>
               ))}
@@ -804,12 +804,12 @@ export default function App() {
             title="Fichiers"
             className={`flex flex-1 flex-col items-center justify-center gap-[2px] transition-colors active:opacity-60 ${
               sidebarOpen
-                ? 'text-blue-600 dark:text-blue-400'
+                ? 'text-[#007AFF] dark:text-[#0A84FF]'
                 : 'text-slate-400 dark:text-slate-500'
             }`}
           >
             <Menu size={24} strokeWidth={sidebarOpen ? 2.2 : 1.8} />
-            <span className="text-[10px] font-medium leading-none">Fichiers</span>
+            <span className="text-[11px] font-medium leading-none">Fichiers</span>
           </button>
 
           {/* 2 — Top articles */}
@@ -818,12 +818,12 @@ export default function App() {
             title="Top articles"
             className={`flex flex-1 flex-col items-center justify-center gap-[2px] transition-colors active:opacity-60 ${
               topOpen
-                ? 'text-blue-600 dark:text-blue-400'
+                ? 'text-[#007AFF] dark:text-[#0A84FF]'
                 : 'text-slate-400 dark:text-slate-500'
             }`}
           >
             <Star size={24} strokeWidth={topOpen ? 2.2 : 1.8} />
-            <span className="text-[10px] font-medium leading-none">Top</span>
+            <span className="text-[11px] font-medium leading-none">Top</span>
           </button>
 
           {/* 3 — Recherche : centre = zone pouce prioritaire */}
@@ -832,7 +832,7 @@ export default function App() {
             title="Recherche"
             className={`flex flex-1 flex-col items-center justify-center gap-[2px] transition-colors active:opacity-60 ${
               searchOpen || searchTypeMenuOpen
-                ? 'text-blue-600 dark:text-blue-400'
+                ? 'text-[#007AFF] dark:text-[#0A84FF]'
                 : 'text-slate-400 dark:text-slate-500'
             }`}
           >
@@ -842,7 +842,7 @@ export default function App() {
                 <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-violet-500" />
               )}
             </span>
-            <span className="text-[10px] font-medium leading-none">Recherche</span>
+            <span className="text-[11px] font-medium leading-none">Recherche</span>
           </button>
 
           {/* 4 — Entités */}
@@ -851,12 +851,12 @@ export default function App() {
             title="Dashboard entités"
             className={`flex flex-1 flex-col items-center justify-center gap-[2px] transition-colors active:opacity-60 ${
               dashboardOpen
-                ? 'text-blue-600 dark:text-blue-400'
+                ? 'text-[#007AFF] dark:text-[#0A84FF]'
                 : 'text-slate-400 dark:text-slate-500'
             }`}
           >
             <BarChart2 size={24} strokeWidth={dashboardOpen ? 2.2 : 1.8} />
-            <span className="text-[10px] font-medium leading-none">Entités</span>
+            <span className="text-[11px] font-medium leading-none">Entités</span>
           </button>
 
           {/* 5 — Réglages (inclut : thème, RSS, tendances, biais) */}
@@ -865,7 +865,7 @@ export default function App() {
             title="Réglages"
             className={`flex flex-1 flex-col items-center justify-center gap-[2px] transition-colors active:opacity-60 ${
               settingsOpen
-                ? 'text-blue-600 dark:text-blue-400'
+                ? 'text-[#007AFF] dark:text-[#0A84FF]'
                 : 'text-slate-400 dark:text-slate-500'
             }`}
           >
@@ -875,7 +875,7 @@ export default function App() {
                 <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-green-500 animate-pulse" />
               ) : null}
             </span>
-            <span className="text-[10px] font-medium leading-none">Réglages</span>
+            <span className="text-[11px] font-medium leading-none">Réglages</span>
           </button>
 
         </div>

--- a/viewer/src/components/ArticleFullReportDialog.jsx
+++ b/viewer/src/components/ArticleFullReportDialog.jsx
@@ -866,7 +866,7 @@ ${contentEl.innerHTML}
                     {exportState.local === 'saving' ? <Loader2 size={14} className="animate-spin" /> : exportState.local?.ok ? <Check size={14} /> : <Download size={14} />}
                   </button>
                   {(exportState.local?.ok || exportState.local?.error) && (
-                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[11px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
                       {exportState.local?.ok ? exportState.local.path : exportState.local?.error}
                     </div>
                   )}
@@ -886,7 +886,7 @@ ${contentEl.innerHTML}
                     {exportState.obsidian === 'saving' ? <Loader2 size={14} className="animate-spin" /> : exportState.obsidian?.ok ? <Check size={14} /> : <BookOpen size={14} />}
                   </button>
                   {(exportState.obsidian?.ok || exportState.obsidian?.error) && (
-                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+                    <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[11px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
                       {exportState.obsidian?.ok
                         ? (exportState.obsidian.deduplicated ? '✓ Déjà exporté — ' : '') + exportState.obsidian.path
                         : exportState.obsidian?.error}
@@ -925,7 +925,7 @@ ${contentEl.innerHTML}
             </button>
             <button
               onClick={onClose}
-              className="p-1.5 rounded-lg text-slate-400 hover:text-rose-500 dark:hover:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors"
+              className="p-2.5 rounded-lg text-slate-400 hover:text-rose-500 dark:hover:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors touch-target"
               title="Fermer"
             >
               <X size={14} />
@@ -974,11 +974,11 @@ ${contentEl.innerHTML}
         {Array.isArray(article['rapports']) && article['rapports'].length > 0 && (
           <div className="no-print flex items-center gap-2 px-5 py-2 bg-violet-50/60 dark:bg-violet-900/20 border-b border-violet-100 dark:border-violet-800/40 overflow-x-auto shrink-0 flex-wrap">
             <BookOpen size={11} className="text-violet-500 shrink-0" />
-            <span className="text-[10px] font-medium text-violet-600 dark:text-violet-400 shrink-0">Rapports générés :</span>
+            <span className="text-[11px] font-medium text-violet-600 dark:text-violet-400 shrink-0">Rapports générés :</span>
             {article['rapports'].map((rap, idx) => (
               <span
                 key={idx}
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-white dark:bg-slate-800 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700 shrink-0"
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-white dark:bg-slate-800 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700 shrink-0"
                 title={`${rap.chemin ?? ''}`}
               >
                 {rap.cible === 'obsidian' ? 'Obsidian' : 'Local'}

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -24,7 +24,7 @@ function ReadingTimeBadge({ article }) {
   const label = article.temps_lecture_label
   if (!label) return null
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
+    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
       <Clock size={9} className="shrink-0" />
       {label}
     </span>
@@ -40,12 +40,12 @@ function SentimentBadge({ article }) {
   const cfg = SENTIMENT_CFG[sentiment] ?? SENTIMENT_CFG.neutre
   return (
     <div className="flex items-center gap-1.5 flex-wrap mt-1">
-      <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
+      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${cfg.dot}`} />
         {cfg.label}{scoreSent ? ` ${scoreSent}/5` : ''}
       </span>
       {ton && (
-        <span className="inline-flex items-center text-[10px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
+        <span className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
           {TON_LABELS[ton] ?? ton}{scoreTon ? ` ${scoreTon}/5` : ''}
         </span>
       )}
@@ -401,7 +401,7 @@ function IAPickerModal({ providers, onPick, onClose }) {
         <div className="flex flex-col gap-2">
           {providers.map(p => (
             <button key={p} onClick={() => onPick(p)}
-              className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors">
+              className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white transition-colors">
               {LABELS[p] ?? p}
             </button>
           ))}
@@ -544,7 +544,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
             </span>
             {date && <span className="text-xs text-slate-400 dark:text-slate-500">{date}{time ? <> · <span>{time}</span></> : ''}</span>}
             {hasEntities && (
-              <span className="inline-flex items-center gap-1 text-[10px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
+              <span className="inline-flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
                 <Tag size={9} />{count} entités
               </span>
             )}
@@ -617,7 +617,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-2">
             {tags.map(t => (
-              <span key={t} className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
+              <span key={t} className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">
                 {t}
               </span>
             ))}
@@ -676,7 +676,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
               <span
                 key={idx}
                 title={`${rap.cible === 'obsidian' ? 'Obsidian' : 'Local'} · ${rap.date_creation ?? ''}\n${rap.chemin ?? ''}`}
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700"
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700"
               >
                 <BookOpen size={9} />
                 Rapport {rap.cible === 'obsidian' ? 'Obsidian' : 'local'}
@@ -730,7 +730,7 @@ function TimelineItem({ article }) {
           </span>
           {date && <span className="text-xs text-slate-400 dark:text-slate-500">{date}{time ? <> · <span>{time}</span></> : ''}</span>}
           {hasEntities && (
-            <span className="inline-flex items-center gap-1 text-[10px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
+            <span className="inline-flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
               <Tag size={9} />{count}
             </span>
           )}
@@ -1148,7 +1148,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
                           : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600'
                       }`}>
                       {src}
-                      <span className={`tabular-nums text-[10px] ${active ? 'opacity-75' : 'opacity-55'}`}>{count}</span>
+                      <span className={`tabular-nums text-[11px] ${active ? 'opacity-75' : 'opacity-55'}`}>{count}</span>
                     </button>
                   )
                 })}
@@ -1174,7 +1174,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
                     <button key={type} onClick={() => toggleType(type)}
                       className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border shrink-0 transition-all active:scale-95 ${active ? colors.on : colors.idle}`}>
                       {type}
-                      <span className={`tabular-nums text-[10px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
+                      <span className={`tabular-nums text-[11px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
                     </button>
                   )
                 })}
@@ -1330,7 +1330,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
             <Filter size={12} className="text-slate-400 dark:text-slate-500 shrink-0" />
             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Type d'entité</span>
             {selectedTypes.size > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400">{selectedTypes.size}</span>
+              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400">{selectedTypes.size}</span>
             )}
             {selectedTypes.size > 0 && (
               <span
@@ -1354,7 +1354,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
                     title={`Filtrer les articles avec des entités de type ${type}`}
                     className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-all hover:scale-105 active:scale-95 ${active ? colors.on : colors.idle}`}>
                     {type}
-                    <span className={`tabular-nums text-[10px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
+                    <span className={`tabular-nums text-[11px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
                   </button>
                 )
               })}
@@ -1373,7 +1373,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
             <Newspaper size={12} className="text-slate-400 dark:text-slate-500 shrink-0" />
             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Source</span>
             {selectedSources.size > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[10px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400">{selectedSources.size}</span>
+              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-blue-600 dark:text-blue-400">{selectedSources.size}</span>
             )}
             {selectedSources.size > 0 && (
               <span
@@ -1399,7 +1399,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
                         : 'bg-slate-100 dark:bg-slate-700/60 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-400'
                     }`}>
                     {src}
-                    <span className={`tabular-nums text-[10px] ${active ? 'opacity-75' : 'opacity-55'}`}>{count}</span>
+                    <span className={`tabular-nums text-[11px] ${active ? 'opacity-75' : 'opacity-55'}`}>{count}</span>
                   </button>
                 )
               })}

--- a/viewer/src/components/ChatbotPanel.jsx
+++ b/viewer/src/components/ChatbotPanel.jsx
@@ -565,7 +565,7 @@ Voici ce que je peux faire pour vous :
               <div className="flex items-center gap-2 pl-4 mt-1 opacity-0 group-hover:opacity-100 transition-opacity">
                 <button
                   onClick={() => saveMessage(msg.content)}
-                  className="inline-flex items-center gap-1 text-[10px] text-slate-400 hover:text-green-400 transition-colors font-mono"
+                  className="inline-flex items-center gap-1 text-[11px] text-slate-400 hover:text-green-400 transition-colors font-mono"
                   title="Sauvegarder cette réponse en Markdown"
                 >
                   <Save size={10} />
@@ -614,7 +614,7 @@ Voici ce que je peux faire pour vous :
             {/* Badge entité — affiché quand un contexte entité est chargé */}
             {entityContext && (
               <span
-                className={`font-mono text-[10px] px-2 py-0.5 rounded border max-w-[200px] truncate ${
+                className={`font-mono text-[11px] px-2 py-0.5 rounded border max-w-[200px] truncate ${
                   entityContextLoading
                     ? 'text-amber-400 bg-amber-900/30 border-amber-800/50 animate-pulse'
                     : entityContextStep === 'done'
@@ -636,7 +636,7 @@ Voici ce que je peux faire pour vous :
             )}
             {/* Indicateur de fichiers de contexte */}
             {contextFiles.length > 0 && (
-              <span className="font-mono text-[10px] text-slate-300 bg-slate-800/60 px-2 py-0.5 rounded">
+              <span className="font-mono text-[11px] text-slate-300 bg-slate-800/60 px-2 py-0.5 rounded">
                 {contextFiles.length} fichier{contextFiles.length > 1 ? 's' : ''} en contexte
               </span>
             )}
@@ -644,7 +644,7 @@ Voici ce que je peux faire pour vous :
             {notesPeriod && (
               <button
                 onClick={() => setNotesPeriod(null)}
-                className="inline-flex items-center gap-1 font-mono text-[10px] text-amber-400 bg-amber-900/30 border border-amber-800/50 px-2 py-0.5 rounded hover:bg-amber-900/50 transition-colors"
+                className="inline-flex items-center gap-1 font-mono text-[11px] text-amber-400 bg-amber-900/30 border border-amber-800/50 px-2 py-0.5 rounded hover:bg-amber-900/50 transition-colors"
                 title="Cliquez pour désactiver les notes personnelles"
               >
                 <BookOpen size={9} />
@@ -658,7 +658,7 @@ Voici ce que je peux faire pour vous :
                   <button
                     key={p}
                     onClick={() => setSelectedProvider(p)}
-                    className={`px-2 py-0.5 rounded text-[10px] font-mono font-semibold uppercase tracking-wide transition-colors ${
+                    className={`px-2 py-0.5 rounded text-[11px] font-mono font-semibold uppercase tracking-wide transition-colors ${
                       selectedProvider === p
                         ? p === 'claude'
                           ? 'bg-purple-700 text-white'
@@ -696,7 +696,7 @@ Voici ce que je peux faire pour vous :
                 <FileText size={12} className="text-green-500 shrink-0" />
                 <span className="font-mono text-xs text-green-400 flex-1 uppercase tracking-widest">Contexte</span>
                 {contextFiles.length > 0 && (
-                  <span className="font-mono text-[10px] text-green-300 bg-green-900/40 px-2 py-0.5 rounded">
+                  <span className="font-mono text-[11px] text-green-300 bg-green-900/40 px-2 py-0.5 rounded">
                     {contextFiles.length} sélectionné{contextFiles.length > 1 ? 's' : ''}
                   </span>
                 )}
@@ -724,7 +724,7 @@ Voici ce que je peux faire pour vous :
                     <div className="sticky top-0 z-10 flex items-center gap-1.5 px-3 py-2 border-b border-green-900/20" style={{ background: '#0d1117' }}>
                       <Folder size={10} className="text-green-800 shrink-0" />
                       <span className="font-mono text-[11px] text-green-700 uppercase tracking-widest truncate flex-1">{flux}</span>
-                      <span className="font-mono text-[10px] text-green-900">{fluxFiles.length}</span>
+                      <span className="font-mono text-[11px] text-green-900">{fluxFiles.length}</span>
                     </div>
                     {fluxFiles.map(f => (
                       <button
@@ -744,7 +744,7 @@ Voici ce que je peux faire pour vous :
                           {f.name}
                         </span>
                         {isToday(f.modified) && (
-                          <span className="shrink-0 text-[9px] font-bold uppercase bg-orange-500 text-white px-1.5 py-0.5 rounded">new</span>
+                          <span className="shrink-0 text-[11px] font-bold uppercase bg-orange-500 text-white px-1.5 py-0.5 rounded">new</span>
                         )}
                         {contextFiles.includes(f.path) && (
                           <Check size={14} className="shrink-0 text-green-500" />
@@ -797,15 +797,15 @@ Voici ce que je peux faire pour vous :
               </div>
               <div className="flex-1 overflow-y-auto custom-scrollbar">
                 {filteredFiles.length === 0 ? (
-                  <p className="text-[10px] font-mono text-slate-400 px-3 py-3">Aucun fichier disponible</p>
+                  <p className="text-[11px] font-mono text-slate-400 px-3 py-3">Aucun fichier disponible</p>
                 ) : (
                   groupedFiles.map(([flux, fluxFiles]) => (
                     <div key={flux}>
                       {/* En-tête de groupe */}
                       <div className="sticky top-0 z-10 flex items-center gap-1.5 px-3 py-1.5 border-b border-green-900/30" style={{background:'#0d1117'}}>
                         <Folder size={10} className="text-green-800 shrink-0" />
-                        <span className="font-mono text-[10px] text-green-700 uppercase tracking-widest truncate flex-1">{flux}</span>
-                        <span className="font-mono text-[9px] text-green-900">{fluxFiles.length}</span>
+                        <span className="font-mono text-[11px] text-green-700 uppercase tracking-widest truncate flex-1">{flux}</span>
+                        <span className="font-mono text-[11px] text-green-900">{fluxFiles.length}</span>
                       </div>
                       {/* Fichiers du groupe */}
                       {fluxFiles.map(f => (
@@ -832,13 +832,13 @@ Voici ce que je peux faire pour vous :
                               )}
                             </div>
                             <div className="flex items-center gap-2 mt-0.5">
-                              <span className={`text-[9px] px-1 rounded font-mono leading-4 ${
+                              <span className={`text-[11px] px-1 rounded font-mono leading-4 ${
                                 f.type === 'json'
                                   ? 'bg-amber-900/40 text-amber-600'
                                   : 'bg-blue-900/40 text-blue-500'
                               }`}>{f.type === 'json' ? 'JSON' : 'MD'}</span>
-                              <span className="text-[9px] text-slate-500">{formatSize(f.size)}</span>
-                              <span className="text-[9px] text-slate-600 ml-auto">{formatDateShort(f.modified)}</span>
+                              <span className="text-[11px] text-slate-500">{formatSize(f.size)}</span>
+                              <span className="text-[11px] text-slate-600 ml-auto">{formatDateShort(f.modified)}</span>
                             </div>
                           </div>
                         </button>
@@ -862,7 +862,7 @@ Voici ce que je peux faire pour vous :
                     <button
                       key={opt.value}
                       onClick={() => setNotesPeriod(prev => prev === opt.value ? null : opt.value)}
-                      className={`w-full text-left px-2 py-1 rounded text-[10px] font-mono transition-colors flex items-start gap-1.5 ${
+                      className={`w-full text-left px-2 py-1 rounded text-[11px] font-mono transition-colors flex items-start gap-1.5 ${
                         notesPeriod === opt.value
                           ? 'bg-amber-900/40 text-amber-300'
                           : 'text-slate-300 hover:text-amber-400 hover:bg-slate-800/50'
@@ -882,7 +882,7 @@ Voici ce que je peux faire pour vous :
                   {contextFiles.length > 0 && (
                     <button
                       onClick={() => setContextFiles([])}
-                      className="w-full text-[10px] font-mono text-slate-400 hover:text-red-400 transition-colors text-left flex items-center gap-1 mb-1"
+                      className="w-full text-[11px] font-mono text-slate-400 hover:text-red-400 transition-colors text-left flex items-center gap-1 mb-1"
                     >
                       <Trash2 size={9} />
                       Vider le contexte
@@ -891,7 +891,7 @@ Voici ce que je peux faire pour vous :
                   {notesPeriod && (
                     <button
                       onClick={() => setNotesPeriod(null)}
-                      className="w-full text-[10px] font-mono text-slate-400 hover:text-amber-400 transition-colors text-left flex items-center gap-1"
+                      className="w-full text-[11px] font-mono text-slate-400 hover:text-amber-400 transition-colors text-left flex items-center gap-1"
                     >
                       <Trash2 size={9} />
                       Désactiver les notes
@@ -957,7 +957,7 @@ Voici ce que je peux faire pour vous :
                             <div key={flux}>
                               <div className="flex items-center gap-1.5 px-2 py-1 bg-slate-900/60 border-b border-green-900/20">
                                 <Folder size={9} className="text-green-800 shrink-0" />
-                                <span className="font-mono text-[9px] text-green-700 uppercase tracking-widest truncate">{flux}</span>
+                                <span className="font-mono text-[11px] text-green-700 uppercase tracking-widest truncate">{flux}</span>
                               </div>
                               {fluxFiles.map(f => (
                                 <button
@@ -973,7 +973,7 @@ Voici ce que je peux faire pour vous :
                                     ? <FileJson size={10} className="shrink-0 text-amber-500" />
                                     : <FileText size={10} className="shrink-0 text-blue-400" />
                                   }
-                                  <span className={`truncate flex-1 text-[10px] font-mono ${
+                                  <span className={`truncate flex-1 text-[11px] font-mono ${
                                     contextFiles.includes(f.path) ? 'text-green-300' : 'text-slate-200'
                                   }`}>{f.name}</span>
                                   {isToday(f.modified) && (
@@ -989,7 +989,7 @@ Voici ce que je peux faire pour vous :
                     {/* Commandes rapides spécifiques à l'entité */}
                     {entityContext && (
                       <div className="space-y-1 mb-4">
-                        <p className="font-mono text-[10px] text-emerald-600 uppercase tracking-widest mb-2 flex items-center gap-1">
+                        <p className="font-mono text-[11px] text-emerald-600 uppercase tracking-widest mb-2 flex items-center gap-1">
                           <span>◆</span>
                           {entityContext.value}
                         </p>
@@ -1015,7 +1015,7 @@ Voici ce que je peux faire pour vous :
                     )}
                     {/* Commandes rapides */}
                     <div className="space-y-1">
-                      <p className="font-mono text-[10px] text-slate-400 uppercase tracking-widest mb-2">
+                      <p className="font-mono text-[11px] text-slate-400 uppercase tracking-widest mb-2">
                         Commandes rapides
                       </p>
                       {QUICK_COMMANDS.map((cmd, i) => (
@@ -1032,7 +1032,7 @@ Voici ce que je peux faire pour vous :
                     </div>
                     {/* Notes personnelles */}
                     <div className="space-y-1 mt-4">
-                      <p className="font-mono text-[10px] text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1">
+                      <p className="font-mono text-[11px] text-amber-700 uppercase tracking-widest mb-2 flex items-center gap-1">
                         <BookOpen size={9} />
                         Notes personnelles
                       </p>
@@ -1056,7 +1056,7 @@ Voici ce que je peux faire pour vous :
 
                 {/* Log de chargement du contexte entité */}
                 {entityContext && (entityContextLoading || entityContextStats) && (
-                  <div className="mb-4 font-mono text-[10px] border border-emerald-900/40 rounded-lg overflow-hidden">
+                  <div className="mb-4 font-mono text-[11px] border border-emerald-900/40 rounded-lg overflow-hidden">
                     <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-emerald-900/30" style={{ background: '#0f2318' }}>
                       <span className="text-emerald-600">◆</span>
                       <span className="text-emerald-500 font-semibold uppercase tracking-widest">
@@ -1098,7 +1098,7 @@ Voici ce que je peux faire pour vous :
               {/* Toast sauvegarde — flotte au-dessus sans pousser le layout */}
               {savedMsg && (
                 <div className="shrink-0 px-3 pt-1.5 pb-0" style={{ background: '#161b22' }}>
-                  <div className="flex items-center gap-1.5 font-mono text-[10px] border border-green-900/40 rounded px-2 py-1 bg-slate-900/80">
+                  <div className="flex items-center gap-1.5 font-mono text-[11px] border border-green-900/40 rounded px-2 py-1 bg-slate-900/80">
                     {savedMsg.startsWith('Erreur') ? (
                       <span className="text-red-400">{savedMsg}</span>
                     ) : (

--- a/viewer/src/components/ClusterView.jsx
+++ b/viewer/src/components/ClusterView.jsx
@@ -45,7 +45,7 @@ function ClusterCard({ cluster }) {
               {cluster.top_entities.slice(0, 8).map(e => (
                 <span
                   key={e.value}
-                  className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-white/70 dark:bg-black/30 font-medium"
+                  className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded bg-white/70 dark:bg-black/30 font-medium"
                 >
                   <Hash size={8} />
                   {e.value}
@@ -60,7 +60,7 @@ function ClusterCard({ cluster }) {
             {cluster.articles.map((art, i) => (
               <li key={i} className="px-4 py-2.5 flex flex-col gap-0.5">
                 <div className="flex items-start gap-2">
-                  <span className="text-[10px] text-current/50 shrink-0 mt-0.5 tabular-nums">
+                  <span className="text-[11px] text-current/50 shrink-0 mt-0.5 tabular-nums">
                     {art['Date de publication']
                       ? parseArticleDate(art['Date de publication']).toLocaleDateString('fr-FR', { day: '2-digit', month: 'short' })
                       : '—'}
@@ -82,15 +82,15 @@ function ClusterCard({ cluster }) {
                     )}
                     <div className="flex items-center gap-2 mt-0.5">
                       {art.Sources && (
-                        <span className="text-[10px] opacity-60">{art.Sources}</span>
+                        <span className="text-[11px] opacity-60">{art.Sources}</span>
                       )}
                       {art.sentiment && (
-                        <span className={`text-[10px] font-medium ${SENTIMENT_COLORS[art.sentiment] || ''}`}>
+                        <span className={`text-[11px] font-medium ${SENTIMENT_COLORS[art.sentiment] || ''}`}>
                           {art.sentiment}
                         </span>
                       )}
                       {art.score_pertinence != null && (
-                        <span className="text-[10px] opacity-50">⭐ {art.score_pertinence}</span>
+                        <span className="text-[11px] opacity-50">⭐ {art.score_pertinence}</span>
                       )}
                     </div>
                   </div>
@@ -178,7 +178,7 @@ export default function ClusterView({ onClose }) {
             </select>
           </div>
           {data?.generated_at && (
-            <span className="ml-auto text-[10px] text-slate-400">
+            <span className="ml-auto text-[11px] text-slate-400">
               Calculé {new Date(data.generated_at).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
             </span>
           )}

--- a/viewer/src/components/ComparePanel.jsx
+++ b/viewer/src/components/ComparePanel.jsx
@@ -9,7 +9,7 @@ function StatBlock({ label, value, delta, isPercent }) {
   const Icon = delta > 0 ? TrendingUp : delta < 0 ? TrendingDown : Minus
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{label}</span>
+      <span className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">{label}</span>
       <span className="text-xl font-bold text-slate-800 dark:text-slate-100">{value}</span>
       {delta !== null && (
         <span className={`flex items-center gap-0.5 text-xs font-medium ${color}`}>
@@ -30,7 +30,7 @@ function SentimentBar({ label, sentiments }) {
   }
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{label}</span>
+      <span className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">{label}</span>
       <div className="flex h-4 rounded overflow-hidden gap-px">
         {Object.entries(sentiments).map(([s, c]) => (
           <div
@@ -57,7 +57,7 @@ function TopList({ items, labelKey, countKey, title }) {
   if (!items?.length) return <span className="text-xs text-slate-400 italic">Aucune donnée</span>
   return (
     <div className="flex flex-col gap-1">
-      <span className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">{title}</span>
+      <span className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">{title}</span>
       <ol className="space-y-0.5">
         {items.slice(0, 5).map((item, i) => (
           <li key={i} className="flex items-center gap-2 text-xs">
@@ -125,7 +125,7 @@ export default function ComparePanel({ onClose }) {
           <div className="flex flex-wrap gap-4 items-end">
             {/* Période 1 */}
             <div className="flex flex-col gap-1.5">
-              <span className="text-[10px] font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wider">Période 1</span>
+              <span className="text-[11px] font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wider">Période 1</span>
               <div className="flex items-center gap-2">
                 <input type="date" value={from1} onChange={e => setFrom1(e.target.value)}
                   className="text-xs bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-600 rounded px-2 py-1.5 focus:outline-none focus:border-blue-400" />
@@ -139,7 +139,7 @@ export default function ComparePanel({ onClose }) {
 
             {/* Période 2 */}
             <div className="flex flex-col gap-1.5">
-              <span className="text-[10px] font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wider">Période 2</span>
+              <span className="text-[11px] font-semibold text-purple-600 dark:text-purple-400 uppercase tracking-wider">Période 2</span>
               <div className="flex items-center gap-2">
                 <input type="date" value={from2} onChange={e => setFrom2(e.target.value)}
                   className="text-xs bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-600 rounded px-2 py-1.5 focus:outline-none focus:border-blue-400" />
@@ -152,7 +152,7 @@ export default function ComparePanel({ onClose }) {
             <button
               onClick={compare}
               disabled={loading}
-              className="flex items-center gap-1.5 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-60 self-end"
+              className="flex items-center gap-1.5 px-4 py-2 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-60 self-end"
             >
               {loading ? <RefreshCw size={12} className="animate-spin" /> : <BarChart2 size={12} />}
               Comparer

--- a/viewer/src/components/EntityArticlePanel.jsx
+++ b/viewer/src/components/EntityArticlePanel.jsx
@@ -504,7 +504,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
               Occurrences de{' '}
               <span className="text-violet-600 dark:text-violet-400">{current.value}</span>
             </span>
-            <span className="text-[10px] uppercase tracking-wider text-slate-400 dark:text-slate-500 shrink-0">
+            <span className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-slate-500 shrink-0">
               {current.type}
             </span>
             {!loading && (
@@ -515,7 +515,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
             {/* Badge rapports générés */}
             {entityRapports.length > 0 && (
               <span className="pointer-events-auto flex items-center gap-1 shrink-0">
-                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700">
+                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700">
                   <BookOpen size={9} />
                   {entityRapports.length} rapport{entityRapports.length > 1 ? 's' : ''}
                 </span>
@@ -527,7 +527,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                       openInObsidian(rap.fichier, obsidianVaultName)
                     }}
                     title={`Ouvrir dans Obsidian : ${entityRapports[entityRapports.length - 1].fichier}`}
-                    className="inline-flex items-center gap-0.5 text-[10px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
+                    className="inline-flex items-center gap-0.5 text-[11px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
                   >
                     Ouvrir
                   </button>
@@ -539,7 +539,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
           {/* Badge rapports générés — mobile uniquement */}
           {entityRapports.length > 0 && (
             <span className="flex md:hidden items-center gap-1.5 w-full pointer-events-auto">
-              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700">
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700">
                 <BookOpen size={9} />
                 {entityRapports.length} rapport{entityRapports.length > 1 ? 's' : ''}
               </span>
@@ -550,7 +550,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                     openInObsidian(rap.fichier, obsidianVaultName)
                   }}
                   title={`Ouvrir dans Obsidian : ${entityRapports[entityRapports.length - 1].fichier}`}
-                  className="inline-flex items-center gap-0.5 text-[10px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
+                  className="inline-flex items-center gap-0.5 text-[11px] text-violet-600 dark:text-violet-400 hover:text-violet-800 dark:hover:text-violet-200 underline underline-offset-2 transition-colors"
                 >
                   Ouvrir
                 </button>
@@ -782,7 +782,7 @@ export default function EntityArticlePanel({ entityType, entityValue, onClose })
                     {art['rapports'].map((rap, idx) => (
                       <span
                         key={idx}
-                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-medium bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700"
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-violet-50 dark:bg-violet-900/30 text-violet-700 dark:text-violet-300 border border-violet-200 dark:border-violet-700"
                         title={`Rapport ${rap.cible === 'obsidian' ? 'Obsidian' : 'local'} — ${rap.date_creation ?? ''}\n${rap.chemin ?? ''}`}
                       >
                         <BookOpen size={9} />

--- a/viewer/src/components/EntityCalendar.jsx
+++ b/viewer/src/components/EntityCalendar.jsx
@@ -211,7 +211,7 @@ function MonthView({ year, month, dayMap, onSelectDay }) {
               {pills.map((art, j) => (
                 <div
                   key={j}
-                  className={`flex items-center gap-1 rounded text-white text-[10px] leading-4 px-1.5 py-0.5 truncate ${sourceColor(art['Sources'])}`}
+                  className={`flex items-center gap-1 rounded text-white text-[11px] leading-4 px-1.5 py-0.5 truncate ${sourceColor(art['Sources'])}`}
                   title={art['Résumé'] || ''}
                 >
                   <span className="truncate">{articleTitle(art)}</span>
@@ -219,7 +219,7 @@ function MonthView({ year, month, dayMap, onSelectDay }) {
               ))}
 
               {extra > 0 && (
-                <div className="text-[10px] text-slate-400 dark:text-slate-500 px-1 leading-4">
+                <div className="text-[11px] text-slate-400 dark:text-slate-500 px-1 leading-4">
                   +{extra} autre{extra > 1 ? 's' : ''}
                 </div>
               )}
@@ -256,7 +256,7 @@ function WeekView({ monday, dayMap, onSelectDay }) {
               key={i}
               className="flex flex-col items-center py-2 gap-0.5"
             >
-              <span className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wide">
+              <span className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wide">
                 {DAYS_FR[i]}
               </span>
               <span className={`text-sm font-semibold w-7 h-7 flex items-center justify-center rounded-full ${
@@ -267,7 +267,7 @@ function WeekView({ monday, dayMap, onSelectDay }) {
                 {d.getDate()}
               </span>
               {count > 0 && (
-                <span className="text-[9px] bg-violet-100 dark:bg-violet-900/40 text-violet-600 dark:text-violet-400 rounded-full px-1.5 font-semibold">
+                <span className="text-[11px] bg-violet-100 dark:bg-violet-900/40 text-violet-600 dark:text-violet-400 rounded-full px-1.5 font-semibold">
                   {count}
                 </span>
               )}
@@ -301,17 +301,17 @@ function WeekView({ monday, dayMap, onSelectDay }) {
                     className="w-full text-left rounded-md overflow-hidden border border-slate-100 dark:border-slate-800 hover:border-violet-300 dark:hover:border-violet-600 bg-white dark:bg-slate-800/50 transition-colors"
                   >
                     {/* Bandeau source coloré */}
-                    <div className={`px-1.5 py-0.5 text-[9px] font-semibold text-white truncate ${sourceColor(source)}`}>
+                    <div className={`px-1.5 py-0.5 text-[11px] font-semibold text-white truncate ${sourceColor(source)}`}>
                       {source || '—'}
                     </div>
                     {/* Titre ou début du résumé */}
                     {titre && (
-                      <p className="px-1.5 pt-0.5 text-[10px] font-medium text-slate-700 dark:text-slate-200 line-clamp-2 leading-snug">
+                      <p className="px-1.5 pt-0.5 text-[11px] font-medium text-slate-700 dark:text-slate-200 line-clamp-2 leading-snug">
                         {titre}
                       </p>
                     )}
                     {/* Extrait du résumé */}
-                    <p className="px-1.5 py-0.5 text-[10px] text-slate-500 dark:text-slate-400 line-clamp-3 leading-snug">
+                    <p className="px-1.5 py-0.5 text-[11px] text-slate-500 dark:text-slate-400 line-clamp-3 leading-snug">
                       {resume}
                     </p>
                   </button>

--- a/viewer/src/components/EntityDashboard.jsx
+++ b/viewer/src/components/EntityDashboard.jsx
@@ -60,7 +60,7 @@ function TypeSection({ section, maxMentions, onEntitySearch }) {
             <span className={`text-sm font-semibold ${cfg.text}`}>
               {cfg.label || section.type}
             </span>
-            <span className="text-[10px] uppercase tracking-wider text-slate-400 dark:text-slate-500">
+            <span className="text-[11px] uppercase tracking-wider text-slate-400 dark:text-slate-500">
               {section.type}
             </span>
           </div>
@@ -73,7 +73,7 @@ function TypeSection({ section, maxMentions, onEntitySearch }) {
           <div className="text-sm font-bold tabular-nums text-slate-700 dark:text-slate-300">
             {section.mention_count.toLocaleString('fr-FR')}
           </div>
-          <div className="text-[10px] text-slate-400 dark:text-slate-500">
+          <div className="text-[11px] text-slate-400 dark:text-slate-500">
             {section.unique_count} uniques
           </div>
         </div>

--- a/viewer/src/components/EntityFullReportDialog.jsx
+++ b/viewer/src/components/EntityFullReportDialog.jsx
@@ -663,7 +663,7 @@ export default function EntityFullReportDialog({
           {isSaving ? <Loader2 size={14} className="animate-spin" /> : isDone ? <Check size={14} /> : <Icon size={14} />}
         </button>
         {(isDone || isFail) && (
-          <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[10px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
+          <div className="absolute top-full mt-1 right-0 z-10 max-w-xs bg-slate-800 text-white text-[11px] rounded px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap overflow-hidden text-ellipsis">
             {isDone ? st.path : st.error}
           </div>
         )}
@@ -690,7 +690,7 @@ export default function EntityFullReportDialog({
           <div className="flex-1 min-w-0">
             <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-100 truncate">
               Rapport — <span className="text-violet-600 dark:text-violet-400">{entityValue}</span>
-              <span className="ml-1.5 text-[10px] uppercase tracking-wider text-slate-400">{entityType}</span>
+              <span className="ml-1.5 text-[11px] uppercase tracking-wider text-slate-400">{entityType}</span>
             </h2>
             <p className="text-[11px] text-slate-400 dark:text-slate-500 truncate">
               {articles.length} article{articles.length !== 1 ? 's' : ''}
@@ -729,7 +729,7 @@ export default function EntityFullReportDialog({
               {isFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
             </button>
             <button onClick={onClose}
-              className="p-1.5 rounded-lg text-slate-400 hover:text-rose-500 dark:hover:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors"
+              className="p-2.5 rounded-lg text-slate-400 hover:text-rose-500 dark:hover:text-rose-400 hover:bg-rose-50 dark:hover:bg-rose-900/20 transition-colors touch-target"
               title="Fermer">
               <X size={14} />
             </button>

--- a/viewer/src/components/EntityGallery.jsx
+++ b/viewer/src/components/EntityGallery.jsx
@@ -71,7 +71,7 @@ function GalleryTile({ name, img, type, shape, h, onClick }) {
           </div>
         )}
       </div>
-      <span className="text-[10px] leading-tight text-center text-slate-600 dark:text-slate-400 max-w-full truncate px-0.5 w-full">
+      <span className="text-[11px] leading-tight text-center text-slate-600 dark:text-slate-400 max-w-full truncate px-0.5 w-full">
         {name}
       </span>
     </button>

--- a/viewer/src/components/EntityGraph.jsx
+++ b/viewer/src/components/EntityGraph.jsx
@@ -423,7 +423,7 @@ export default function EntityGraph({ entityType, entityValue, onNavigate }) {
           >
             <ZoomOut size={13} />
           </button>
-          <span className="text-[10px] text-slate-400 w-10 text-center tabular-nums">
+          <span className="text-[11px] text-slate-400 w-10 text-center tabular-nums">
             {zoomPct}%
           </span>
           <button
@@ -544,15 +544,15 @@ export default function EntityGraph({ entityType, entityValue, onNavigate }) {
       {/* ── Légende compacte (une seule ligne) ── */}
       <div className="mt-1 shrink-0 flex items-center gap-x-3 px-1 overflow-x-auto" style={{ scrollbarWidth: 'none' }}>
         {presentTypes.map(type => (
-          <span key={type} className="inline-flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">
+          <span key={type} className="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0">
             <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: TYPE_CFG[type]?.node ?? '#94a3b8' }} />
             {TYPE_CFG[type]?.label ?? type}
           </span>
         ))}
         {depth === 2 && nL2 > 0 && (
-          <span className="text-[10px] text-slate-400 whitespace-nowrap shrink-0">· ● L1 ╌ L2</span>
+          <span className="text-[11px] text-slate-400 whitespace-nowrap shrink-0">· ● L1 ╌ L2</span>
         )}
-        <span className="ml-auto text-[10px] text-slate-300 dark:text-slate-600 whitespace-nowrap shrink-0 pl-2">
+        <span className="ml-auto text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap shrink-0 pl-2">
           <span className="hidden sm:inline">⌀ zoom · drag · clic</span>
           <span className="sm:hidden">pince · glisse · touche</span>
         </span>
@@ -565,7 +565,7 @@ export default function EntityGraph({ entityType, entityValue, onNavigate }) {
           style={{ left: tooltip.x + 14, top: tooltip.y - 48 }}
         >
           <div className="font-semibold">{tooltip.node.value}</div>
-          <div className="text-slate-300 text-[10px] mt-0.5">
+          <div className="text-slate-500 dark:text-slate-400 text-[11px] mt-0.5">
             {TYPE_CFG[tooltip.node.type]?.label ?? tooltip.node.type}
             {!tooltip.node.central && (
               <> · <span className="text-violet-300">
@@ -577,7 +577,7 @@ export default function EntityGraph({ entityType, entityValue, onNavigate }) {
             )}
           </div>
           {!tooltip.node.central && (
-            <div className="text-slate-400 text-[10px] mt-0.5">Cliquer pour explorer →</div>
+            <div className="text-slate-400 text-[11px] mt-0.5">Cliquer pour explorer →</div>
           )}
         </div>
       )}

--- a/viewer/src/components/EntitySearchModal.jsx
+++ b/viewer/src/components/EntitySearchModal.jsx
@@ -160,7 +160,7 @@ export default function EntitySearchModal({ query, entityType, onClose, onSelect
                             {item.types.map(t => (
                               <span
                                 key={t}
-                                className="text-[10px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1 py-0.5 rounded border border-violet-200 dark:border-violet-800"
+                                className="text-[11px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1 py-0.5 rounded border border-violet-200 dark:border-violet-800"
                               >
                                 {t}
                               </span>

--- a/viewer/src/components/EntityTimeline.jsx
+++ b/viewer/src/components/EntityTimeline.jsx
@@ -66,7 +66,7 @@ function EntityRow({ entry, onEntitySearch }) {
   return (
     <div className="flex items-center gap-3 px-4 py-2.5 border-b border-slate-100 dark:border-slate-800/60 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-800/30 transition-colors group">
       {/* Type badge */}
-      <span className={`shrink-0 hidden sm:inline text-[10px] font-medium px-1.5 py-0.5 rounded border ${cfg.badge}`}>
+      <span className={`shrink-0 hidden sm:inline text-[11px] font-medium px-1.5 py-0.5 rounded border ${cfg.badge}`}>
         {type}
       </span>
       {/* Nom cliquable */}
@@ -160,7 +160,7 @@ export default function EntityTimeline({ onEntitySearch }) {
             <button
               key={t}
               onClick={() => setTypeFilter(t)}
-              className={`text-[10px] px-2 py-0.5 rounded-full border font-medium transition-colors ${
+              className={`text-[11px] px-2 py-0.5 rounded-full border font-medium transition-colors ${
                 typeFilter === t
                   ? 'bg-violet-500 text-white border-violet-500'
                   : 'bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-violet-300 dark:hover:border-violet-600'
@@ -198,7 +198,7 @@ export default function EntityTimeline({ onEntitySearch }) {
       ) : (
         <div className="flex-1 overflow-y-auto rounded-2xl border border-slate-200 dark:border-slate-700/60 bg-white dark:bg-slate-800/40 min-h-0">
           {/* En-tête de tableau */}
-          <div className="flex items-center gap-3 px-4 py-2 bg-slate-50 dark:bg-slate-800/60 border-b border-slate-200 dark:border-slate-700/60 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 rounded-t-2xl sticky top-0 z-10">
+          <div className="flex items-center gap-3 px-4 py-2 bg-slate-50 dark:bg-slate-800/60 border-b border-slate-200 dark:border-slate-700/60 text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 rounded-t-2xl sticky top-0 z-10">
             <span className="hidden sm:block w-16 shrink-0">Type</span>
             <span className="flex-1">Entité</span>
             <span className="w-[84px] shrink-0">Évolution ({days}j)</span>
@@ -212,7 +212,7 @@ export default function EntityTimeline({ onEntitySearch }) {
 
       {/* Horodatage */}
       {generatedAt && !loading && (
-        <p className="mt-2 text-[10px] text-slate-400 dark:text-slate-500 text-right shrink-0">
+        <p className="mt-2 text-[11px] text-slate-400 dark:text-slate-500 text-right shrink-0">
           Calculé le {new Date(generatedAt).toLocaleString('fr-FR')}
         </p>
       )}

--- a/viewer/src/components/EntityWatchPanel.jsx
+++ b/viewer/src/components/EntityWatchPanel.jsx
@@ -130,7 +130,7 @@ export default function EntityWatchPanel({ onClose, onOpenArticles }) {
             <button
               onClick={addEntity}
               disabled={!newValue.trim() || saving}
-              className="flex items-center gap-1.5 px-3 py-2 bg-blue-600 hover:bg-blue-500 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 shrink-0"
+              className="flex items-center gap-1.5 px-3 py-2 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50 shrink-0"
             >
               <Plus size={13} /> Surveiller
             </button>
@@ -153,7 +153,7 @@ export default function EntityWatchPanel({ onClose, onOpenArticles }) {
           ) : (
             <table className="w-full text-sm">
               <thead>
-                <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
+                <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
                   <th className="text-left px-5 py-2.5">Entité</th>
                   <th className="text-left px-4 py-2.5">Activité</th>
                   <th className="text-left px-4 py-2.5">Ajoutée le</th>
@@ -165,7 +165,7 @@ export default function EntityWatchPanel({ onClose, onOpenArticles }) {
                   <tr key={i} className="border-b border-slate-200/40 dark:border-slate-700/40 last:border-0 hover:bg-slate-50 dark:hover:bg-slate-800/40 transition-colors group">
                     <td className="px-5 py-3">
                       <div className="flex items-center gap-2">
-                        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${TYPE_COLORS[e.type] || 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400'}`}>
+                        <span className={`text-[11px] font-semibold px-1.5 py-0.5 rounded ${TYPE_COLORS[e.type] || 'bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-400'}`}>
                           {ENTITY_TYPE_FR[e.type] || e.type}
                         </span>
                         <button

--- a/viewer/src/components/ExportPanel.jsx
+++ b/viewer/src/components/ExportPanel.jsx
@@ -157,7 +157,7 @@ function AtomTab({ fluxes, keywords }) {
         <a
           href={atomUrl}
           download="wudd-feed.xml"
-          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white transition-colors"
         >
           <Download size={14} /> Télécharger le flux
         </a>
@@ -293,7 +293,7 @@ function NewsletterTab() {
         <button
           onClick={handleDownload}
           disabled={loading}
-          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-blue-600 hover:bg-blue-500 disabled:opacity-60 text-white transition-colors"
+          className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] disabled:opacity-60 text-white transition-colors"
         >
           {loading ? <RefreshCw size={14} className="animate-spin" /> : <Download size={14} />}
           Télécharger HTML
@@ -484,7 +484,7 @@ export default function ExportPanel({ onClose, files = [] }) {
           </div>
           <button
             onClick={onClose}
-            className="p-1.5 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+            className="p-2.5 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors touch-target"
           >
             <X size={16} />
           </button>

--- a/viewer/src/components/FileViewer.jsx
+++ b/viewer/src/components/FileViewer.jsx
@@ -94,7 +94,7 @@ function ImageGallery({ content }) {
                   <div className="text-[11px] text-slate-700 dark:text-slate-300 truncate font-medium">{img.source}</div>
                 )}
                 {img.date && (
-                  <div className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5">{img.date}</div>
+                  <div className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">{img.date}</div>
                 )}
               </div>
             )}
@@ -357,7 +357,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
             <HardDrive size={11} />
             {formatSize(file.size)}
           </span>
-          <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${
+          <span className={`px-2 py-0.5 rounded-full text-[11px] font-medium ${
             file.type === 'json'
               ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400'
               : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
@@ -469,7 +469,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
         <button
           onClick={onDownload}
           title="Télécharger le fichier JSON"
-          className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 active:bg-blue-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+          className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] active:bg-blue-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
         >
           <Download size={12} />
           JSON

--- a/viewer/src/components/JsonViewer.jsx
+++ b/viewer/src/components/JsonViewer.jsx
@@ -115,7 +115,7 @@ export default function JsonViewer({ content, onSave }) {
           <button
             onClick={handleSave}
             disabled={saving}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-60 text-white rounded-lg text-xs font-medium transition-colors"
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] disabled:opacity-60 text-white rounded-lg text-xs font-medium transition-colors"
           >
             <Save size={12} />
             {saving ? 'Sauvegarde…' : 'Sauvegarder'}

--- a/viewer/src/components/KeywordForceGraph.jsx
+++ b/viewer/src/components/KeywordForceGraph.jsx
@@ -268,7 +268,7 @@ export default function KeywordForceGraph({ keywords }) {
             { color: COLOR_OR,  label: 'OU' },
             { color: COLOR_AND, label: 'ET' },
           ].map(({ color, label }) => (
-            <span key={label} className="inline-flex items-center gap-1 text-[10px] text-slate-500 dark:text-slate-400 whitespace-nowrap">
+            <span key={label} className="inline-flex items-center gap-1 text-[11px] text-slate-500 dark:text-slate-400 whitespace-nowrap">
               <span className="w-2 h-2 rounded-full shrink-0" style={{ background: color }} />
               {label}
             </span>
@@ -284,7 +284,7 @@ export default function KeywordForceGraph({ keywords }) {
           >
             <ZoomOut size={13} />
           </button>
-          <span className="text-[10px] text-slate-400 w-10 text-center tabular-nums">{zoomPct}%</span>
+          <span className="text-[11px] text-slate-400 w-10 text-center tabular-nums">{zoomPct}%</span>
           <button
             onClick={() => applyView({ ...viewRef.current, scale: Math.min(14, viewRef.current.scale * 1.22) })}
             title="Zoomer"
@@ -399,7 +399,7 @@ export default function KeywordForceGraph({ keywords }) {
           style={{ left: tooltip.x + 14, top: tooltip.y - 46 }}
         >
           <div className="font-semibold">{tooltip.node.label}</div>
-          <div className="text-slate-300 text-[10px] mt-0.5">
+          <div className="text-slate-300 text-[11px] mt-0.5">
             {tooltip.node.termType === 'root' ? 'Centre — WUDD.ai'
               : tooltip.node.termType === 'kw' ? 'Mot-clé de veille'
               : tooltip.node.termType === 'or' ? 'Terme OU (élargit la recherche)'

--- a/viewer/src/components/MarkdownViewer.jsx
+++ b/viewer/src/components/MarkdownViewer.jsx
@@ -263,7 +263,7 @@ export default function MarkdownViewer({ content }) {
       {/* Métadonnées frontmatter */}
       {meta && (
         <div className="mb-6 p-4 bg-white/60 dark:bg-slate-800/60 rounded-xl border border-slate-200 dark:border-slate-700 text-sm">
-          <div className="text-[10px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-3">
+          <div className="text-[11px] font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-widest mb-3">
             Métadonnées du rapport
           </div>
           <dl className="grid grid-cols-[auto_1fr] gap-x-6 gap-y-1.5">

--- a/viewer/src/components/SchedulerPanel.jsx
+++ b/viewer/src/components/SchedulerPanel.jsx
@@ -182,12 +182,12 @@ function TaskSection({ title, desc, tasks }) {
     <div>
       <div className="sticky top-0 bg-slate-900 px-5 py-2 border-b border-slate-700 flex items-baseline gap-3">
         <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">{title}</span>
-        {desc && <span className="text-[10px] text-slate-600 normal-case tracking-normal">{desc}</span>}
-        <span className="ml-auto text-[10px] text-slate-600">{tasks.length} tâche{tasks.length !== 1 ? 's' : ''}</span>
+        {desc && <span className="text-[11px] text-slate-600 normal-case tracking-normal">{desc}</span>}
+        <span className="ml-auto text-[11px] text-slate-600">{tasks.length} tâche{tasks.length !== 1 ? 's' : ''}</span>
       </div>
       <table className="w-full text-sm">
         <thead>
-          <tr className="text-[10px] font-medium text-slate-500 uppercase tracking-wider border-b border-slate-700/50">
+          <tr className="text-[11px] font-medium text-slate-500 uppercase tracking-wider border-b border-slate-700/50">
             <th className="text-left px-5 py-2.5">Tâche</th>
             <th className="text-left px-4 py-2.5">Fréquence</th>
             <th className="text-left px-4 py-2.5">Dernière exécution</th>
@@ -210,7 +210,7 @@ function TaskSection({ title, desc, tasks }) {
               </td>
               <td className="px-4 py-3">
                 <div className="text-slate-300 text-sm">{task.label}</div>
-                <div className="text-[10px] text-slate-600 font-mono mt-0.5">{task.cron}</div>
+                <div className="text-[11px] text-slate-600 font-mono mt-0.5">{task.cron}</div>
               </td>
               <td className="px-4 py-3">
                 {task.last_run ? (

--- a/viewer/src/components/SearchOverlay.jsx
+++ b/viewer/src/components/SearchOverlay.jsx
@@ -130,7 +130,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
         {/* Badge mode article */}
         {isArticleMode && (
           <div className="px-4 pt-2 pb-0">
-            <span className="inline-flex items-center gap-1 text-[10px] font-semibold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-full">
+            <span className="inline-flex items-center gap-1 text-[11px] font-semibold bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-300 px-2 py-0.5 rounded-full">
               <Newspaper size={10} />
               Articles · {currentFile.name}
             </span>
@@ -169,7 +169,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
           <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-700 bg-slate-50/60 dark:bg-slate-800/40 flex flex-wrap gap-3">
             {/* Sentiment */}
             <div className="flex flex-col gap-1 min-w-[130px]">
-              <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Sentiment</label>
+              <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">Sentiment</label>
               <select
                 value={filterSentiment}
                 onChange={e => setFilterSentiment(e.target.value)}
@@ -184,7 +184,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
 
             {/* Source */}
             <div className="flex flex-col gap-1 flex-1 min-w-[140px]">
-              <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Source</label>
+              <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">Source</label>
               <input
                 type="text"
                 value={filterSource}
@@ -196,7 +196,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
 
             {/* Date début */}
             <div className="flex flex-col gap-1 min-w-[130px]">
-              <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Du</label>
+              <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">Du</label>
               <input
                 type="date"
                 value={filterFrom}
@@ -207,7 +207,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
 
             {/* Date fin */}
             <div className="flex flex-col gap-1 min-w-[130px]">
-              <label className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider">Au</label>
+              <label className="text-[11px] font-semibold text-slate-400 uppercase tracking-wider">Au</label>
               <input
                 type="date"
                 value={filterTo}
@@ -258,7 +258,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
                 <span className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate flex-1">
                   <HighlightMatch text={art.source} query={query} />
                 </span>
-                <span className="text-[10px] text-slate-400 shrink-0">{art.date}</span>
+                <span className="text-[11px] text-slate-400 shrink-0">{art.date}</span>
                 {art.url && <ExternalLink size={11} className="text-slate-400 shrink-0" />}
               </div>
               <p className="text-[11px] text-slate-500 dark:text-slate-400 line-clamp-2 text-left">
@@ -308,7 +308,7 @@ export default function SearchOverlay({ onClose, onSelect, mode = 'file', curren
         </div>
 
         {/* Pied — masqué sur mobile */}
-        <div className="hidden sm:flex px-4 py-2 bg-slate-50/50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-700 items-center gap-4 text-[10px] text-slate-400 dark:text-slate-600 select-none">
+        <div className="hidden sm:flex px-4 py-2 bg-slate-50/50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-700 items-center gap-4 text-[11px] text-slate-400 dark:text-slate-600 select-none">
           <span>↑↓ Naviguer</span>
           <span>↵ Ouvrir</span>
           <span>Échap Fermer</span>

--- a/viewer/src/components/SettingsPanel.jsx
+++ b/viewer/src/components/SettingsPanel.jsx
@@ -45,7 +45,7 @@ function SaveButton({ saving, saved, onClick }) {
       className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
         saved
           ? 'bg-green-700 text-green-100 border border-green-600'
-          : 'bg-blue-600 hover:bg-blue-500 text-white border border-blue-500 disabled:opacity-60'
+          : 'bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white border border-blue-500 disabled:opacity-60'
       }`}
     >
       {saved
@@ -99,7 +99,7 @@ function TaskTable({ title, tasks }) {
       </div>
       <table className="w-full text-sm">
         <thead>
-          <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
+          <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
             <th className="text-left px-5 py-2.5">Tâche</th>
             <th className="text-left px-4 py-2.5">Fréquence</th>
             <th className="text-left px-4 py-2.5">Dernière exécution</th>
@@ -119,7 +119,7 @@ function TaskTable({ title, tasks }) {
               </td>
               <td className="px-4 py-3">
                 <div className="text-slate-700 dark:text-slate-300 text-sm">{task.label}</div>
-                <div className="text-[10px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
+                <div className="text-[11px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
               </td>
               <td className="px-4 py-3">
                 {task.last_run ? (
@@ -211,12 +211,12 @@ function SchedulerTab() {
                     <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
                       {cat.label}
                     </span>
-                    <span className="text-[10px] text-slate-400 dark:text-slate-600 normal-case tracking-normal">{cat.desc}</span>
-                    <span className="ml-auto text-[10px] text-slate-400 dark:text-slate-600">{tasks.length} tâche{tasks.length !== 1 ? 's' : ''}</span>
+                    <span className="text-[11px] text-slate-400 dark:text-slate-600 normal-case tracking-normal">{cat.desc}</span>
+                    <span className="ml-auto text-[11px] text-slate-400 dark:text-slate-600">{tasks.length} tâche{tasks.length !== 1 ? 's' : ''}</span>
                   </div>
                   <table className="w-full text-sm">
                     <thead>
-                      <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
+                      <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
                         <th className="text-left px-5 py-2.5">Tâche</th>
                         <th className="text-left px-4 py-2.5">Fréquence</th>
                         <th className="text-left px-4 py-2.5">Dernière exécution</th>
@@ -234,7 +234,7 @@ function SchedulerTab() {
                           </td>
                           <td className="px-4 py-3">
                             <div className="text-slate-700 dark:text-slate-300 text-sm">{task.label}</div>
-                            <div className="text-[10px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
+                            <div className="text-[11px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
                           </td>
                           <td className="px-4 py-3">
                             {task.last_run ? (
@@ -266,12 +266,12 @@ function SchedulerTab() {
                   <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
                     Tâches par flux
                   </span>
-                  <span className="text-[10px] text-slate-400 dark:text-slate-600 normal-case tracking-normal">Collecte IA planifiée par flux JSON source</span>
-                  <span className="ml-auto text-[10px] text-slate-400 dark:text-slate-600">{fluxTasks.length} flux</span>
+                  <span className="text-[11px] text-slate-400 dark:text-slate-600 normal-case tracking-normal">Collecte IA planifiée par flux JSON source</span>
+                  <span className="ml-auto text-[11px] text-slate-400 dark:text-slate-600">{fluxTasks.length} flux</span>
                 </div>
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
+                    <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
                       <th className="text-left px-5 py-2.5">Tâche</th>
                       <th className="text-left px-4 py-2.5">Fréquence</th>
                       <th className="text-left px-4 py-2.5">Dernière exécution</th>
@@ -288,7 +288,7 @@ function SchedulerTab() {
                         </td>
                         <td className="px-4 py-3">
                           <div className="text-slate-700 dark:text-slate-300 text-sm">{task.label}</div>
-                          <div className="text-[10px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
+                          <div className="text-[11px] text-slate-400 dark:text-slate-600 font-mono mt-0.5">{task.cron}</div>
                         </td>
                         <td className="px-4 py-3">
                           {task.last_run ? (
@@ -449,7 +449,7 @@ function KeywordsTab() {
           Mots-clés extraits des flux RSS.{' '}
           <span className="text-blue-600 dark:text-blue-400 font-medium">OU</span> élargit la recherche,{' '}
           <span className="text-green-600 dark:text-green-400 font-medium">ET</span> la restreint.
-          Appuyez sur <kbd className="bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 px-1 rounded text-[10px]">Entrée</kbd> pour valider un terme.
+          Appuyez sur <kbd className="bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 px-1 rounded text-[11px]">Entrée</kbd> pour valider un terme.
         </p>
         <button
           onClick={() => setShowMindmap(true)}
@@ -511,7 +511,7 @@ function KeywordsTab() {
             {/* Mot-clé principal */}
             <div className="flex items-center gap-3">
               <div className="flex-1">
-                <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                <label className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                   Mot-clé principal
                 </label>
                 <input
@@ -534,8 +534,8 @@ function KeywordsTab() {
             {/* Termes OU */}
             <div>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[10px] bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-300 dark:border-blue-700/50 rounded px-1.5 py-0.5 font-bold">OU</span>
-                <span className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                <span className="text-[11px] bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400 border border-blue-300 dark:border-blue-700/50 rounded px-1.5 py-0.5 font-bold">OU</span>
+                <span className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                   correspond si l'un de ces termes est présent
                 </span>
               </div>
@@ -550,8 +550,8 @@ function KeywordsTab() {
             {/* Termes ET */}
             <div>
               <div className="flex items-center gap-2 mb-1.5">
-                <span className="text-[10px] bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 border border-green-300 dark:border-green-700/50 rounded px-1.5 py-0.5 font-bold">ET</span>
-                <span className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                <span className="text-[11px] bg-green-100 dark:bg-green-900/40 text-green-700 dark:text-green-400 border border-green-300 dark:border-green-700/50 rounded px-1.5 py-0.5 font-bold">ET</span>
+                <span className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider">
                   doit aussi contenir au moins un de ces termes
                 </span>
               </div>
@@ -773,7 +773,7 @@ function RssTab() {
           onClick={saveFeed}
           disabled={!isDirty || saving}
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium transition-colors disabled:opacity-40
-            bg-blue-500 hover:bg-blue-600 text-white"
+            bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white"
           title="Sauvegarder les flux dans data/WUDD.opml"
         >
           {saving
@@ -806,7 +806,7 @@ function RssTab() {
           <button
             onClick={handlePaste}
             disabled={!pasteUrl.trim() || pasteMsg?.state === 'checking'}
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-40 transition-colors shrink-0"
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white disabled:opacity-40 transition-colors shrink-0"
           >
             {pasteMsg?.state === 'checking' ? <RefreshCw size={11} className="animate-spin" /> : <Plus size={11} />}
             Ajouter
@@ -1036,7 +1036,7 @@ function FluxTab() {
               <div className="flex items-start gap-3">
                 <div className="flex-1 grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                    <label className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                       Titre du flux
                     </label>
                     <input
@@ -1048,7 +1048,7 @@ function FluxTab() {
                     />
                   </div>
                   <div>
-                    <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                    <label className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                       URL du flux JSON
                     </label>
                     <input
@@ -1072,7 +1072,7 @@ function FluxTab() {
               {/* Planning + Timeout */}
               <div className="flex items-end gap-3">
                 <div className="flex-1">
-                  <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                  <label className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                     Planning (cron){label && <span className="text-slate-500 dark:text-slate-400 normal-case ml-2 font-normal">→ {label}</span>}
                   </label>
                   <div className="flex gap-2">
@@ -1096,7 +1096,7 @@ function FluxTab() {
                   </div>
                 </div>
                 <div className="w-32 shrink-0">
-                  <label className="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
+                  <label className="text-[11px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-medium mb-1 block">
                     Timeout (s)
                   </label>
                   <input
@@ -1549,7 +1549,7 @@ function FiabiliteTab() {
         <button
           onClick={startEnrich}
           disabled={enriching}
-          className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 disabled:opacity-60 text-white rounded-lg transition-colors"
+          className="ml-auto flex items-center gap-1.5 px-3 py-1.5 text-xs bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] disabled:opacity-60 text-white rounded-lg transition-colors"
         >
           <RefreshCw size={12} className={enriching ? 'animate-spin' : ''} />
           {enriching ? 'Enrichissement…' : 'Actualiser fiabilité'}
@@ -1559,7 +1559,7 @@ function FiabiliteTab() {
       {/* Log d'enrichissement */}
       {(enriching || enrichDone) && enrichLog.length > 0 && (
         <div className="mx-5 mt-3 bg-slate-950/80 dark:bg-slate-950 rounded-lg border border-slate-700 overflow-hidden shrink-0">
-          <div className="px-3 py-1.5 border-b border-slate-700 text-[10px] font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
+          <div className="px-3 py-1.5 border-b border-slate-700 text-[11px] font-semibold text-slate-500 uppercase tracking-wider flex items-center gap-2">
             <Terminal size={10} />
             Journal d'enrichissement
             {enrichDone && <span className="text-green-400 ml-1">✓ Terminé</span>}
@@ -1584,7 +1584,7 @@ function FiabiliteTab() {
         {loading ? <Spinner /> : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 sticky top-0">
+              <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 sticky top-0">
                 <th className="text-left px-5 py-2.5">Source</th>
                 <th className="text-center px-4 py-2.5">Score</th>
                 <th className="text-center px-4 py-2.5">Âge</th>
@@ -1599,7 +1599,7 @@ function FiabiliteTab() {
                 <tr key={i} className="border-b border-slate-100 dark:border-slate-700/40 hover:bg-slate-50 dark:hover:bg-slate-700/20 transition-colors">
                   <td className="px-5 py-3">
                     <div className="font-medium text-slate-800 dark:text-slate-200 text-sm">{s.source}</div>
-                    <div className="text-[10px] text-slate-400 mt-0.5">{s.biais || '—'} · fact-check : {s.fact_checking ? '✓' : '✗'}</div>
+                    <div className="text-[11px] text-slate-400 mt-0.5">{s.biais || '—'} · fact-check : {s.fact_checking ? '✓' : '✗'}</div>
                   </td>
                   <td className="px-4 py-3 text-center">
                     <div className="flex flex-col items-center gap-0.5">
@@ -1609,7 +1609,7 @@ function FiabiliteTab() {
                         : 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-300'
                       }`}>{Math.round(s.score_composite ?? s.score)}</span>
                       {s.enrichi && s.score !== s.score_composite && (
-                        <span className="text-[9px] text-slate-400">(base: {s.score})</span>
+                        <span className="text-[11px] text-slate-400">(base: {s.score})</span>
                       )}
                     </div>
                   </td>
@@ -1618,7 +1618,7 @@ function FiabiliteTab() {
                       <span className={s.domain_age_years < 2 ? 'text-orange-500 font-medium' : 'text-slate-500 dark:text-slate-400'}>
                         {s.domain_age_years < 2 && '⚠ '}{s.domain_age_years >= 1 ? `${Math.floor(s.domain_age_years)} ans` : '< 1 an'}
                       </span>
-                    ) : <span className="text-slate-300 dark:text-slate-600">—</span>}
+                    ) : <span className="text-slate-400 dark:text-slate-500">—</span>}
                   </td>
                   <td className="px-4 py-3 text-center">
                     {s.transparence != null ? (
@@ -1627,18 +1627,18 @@ function FiabiliteTab() {
                           <span key={j} className={`w-2 h-2 rounded-full ${j < s.transparence ? 'bg-blue-500' : 'bg-slate-200 dark:bg-slate-700'}`} />
                         ))}
                       </span>
-                    ) : <span className="text-slate-300 dark:text-slate-600 text-xs">—</span>}
+                    ) : <span className="text-slate-400 dark:text-slate-500 text-xs">—</span>}
                   </td>
                   <td className="px-4 py-3 text-center">
                     {s.mbfc_rating ? (
-                      <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium ${MBFC_BADGE_SETTINGS[s.mbfc_rating] || 'bg-slate-100 text-slate-600'}`}>
+                      <span className={`text-[11px] px-1.5 py-0.5 rounded font-medium ${MBFC_BADGE_SETTINGS[s.mbfc_rating] || 'bg-slate-100 text-slate-600'}`}>
                         {s.mbfc_rating}
                       </span>
-                    ) : <span className="text-slate-300 dark:text-slate-600 text-xs">—</span>}
+                    ) : <span className="text-slate-400 dark:text-slate-500 text-xs">—</span>}
                   </td>
                   <td className="px-4 py-3 hidden md:table-cell">
                     <div className="text-[11px] text-slate-500 dark:text-slate-400">{s.pays || '—'}</div>
-                    <div className="text-[10px] text-slate-400 dark:text-slate-500">{s.type || '—'}</div>
+                    <div className="text-[11px] text-slate-400 dark:text-slate-500">{s.type || '—'}</div>
                   </td>
                   <td className="px-4 py-3 text-center text-xs">
                     {s.enrichi ? (
@@ -1875,7 +1875,7 @@ function EnvTab() {
 
       {/* Sélecteur de fournisseur IA */}
       <div className="px-5 py-4 border-b border-slate-200 dark:border-slate-700 bg-slate-50/60 dark:bg-slate-800/30 shrink-0">
-        <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider">
+        <p className="text-[11px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider">
           Fournisseur IA actif
         </p>
         <div className="flex items-center gap-2 flex-wrap">
@@ -1923,7 +1923,7 @@ function EnvTab() {
         {loading ? <Spinner /> : (
           <table className="w-full text-sm">
             <thead>
-              <tr className="text-[10px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
+              <tr className="text-[11px] font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider border-b border-slate-200/50 dark:border-slate-700/50">
                 <th className="text-left px-5 py-2.5 w-1/3">Variable</th>
                 <th className="text-left px-4 py-2.5">Valeur</th>
                 <th className="px-4 py-2.5 w-24"></th>
@@ -1945,7 +1945,7 @@ function EnvTab() {
                       : 'bg-slate-100/40 dark:bg-slate-800/40 opacity-50'}>
                       <td colSpan={3} className="px-5 py-1.5">
                         <div className="flex items-center justify-between gap-2">
-                          <span className={`text-[10px] font-semibold uppercase tracking-wider ${
+                          <span className={`text-[11px] font-semibold uppercase tracking-wider ${
                             isActive ? 'text-blue-600 dark:text-blue-400' : 'text-slate-500 dark:text-slate-400'
                           }`}>
                             {group.label}{isActive && ' ✓'}
@@ -1953,7 +1953,7 @@ function EnvTab() {
                           {/* Bouton Check IA */}
                           <div className="flex items-center gap-2">
                             {checkState && checkState !== 'checking' && (
-                              <span className={`text-[10px] flex items-center gap-1 ${checkState.ok ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}>
+                              <span className={`text-[11px] flex items-center gap-1 ${checkState.ok ? 'text-green-600 dark:text-green-400' : 'text-red-500 dark:text-red-400'}`}>
                                 {checkState.ok
                                   ? <><CheckCircle2 size={11} /> OK {checkState.latency_ms > 0 ? `· ${checkState.latency_ms}ms` : ''}</>
                                   : <><AlertTriangle size={11} /> {checkState.message.slice(0, 60)}</>
@@ -1963,7 +1963,7 @@ function EnvTab() {
                             <button
                               onClick={() => checkAI(group.provider)}
                               disabled={checkState === 'checking'}
-                              className="flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-50 transition-colors"
+                              className="flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:border-blue-400 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-50 transition-colors"
                             >
                               {checkState === 'checking'
                                 ? <><RefreshCw size={10} className="animate-spin" /> Test…</>
@@ -2020,7 +2020,7 @@ function EnvTab() {
 
       {/* ── Section Backup ───────────────────────────────────────────────── */}
       <div className="px-5 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 bg-slate-50/50 dark:bg-slate-800/20">
-        <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider flex items-center gap-1.5">
+        <p className="text-[11px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider flex items-center gap-1.5">
           <Database size={11} /> Backup des données
         </p>
         <p className="text-[11px] text-slate-500 dark:text-slate-400 mb-3 leading-relaxed">
@@ -2079,7 +2079,7 @@ function EnvTab() {
 
       {/* ── Section Obsidian ─────────────────────────────────────────────── */}
       <div className="px-5 py-4 border-t border-slate-200 dark:border-slate-700 shrink-0 bg-violet-50/30 dark:bg-violet-900/10">
-        <p className="text-[10px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider flex items-center gap-1.5">
+        <p className="text-[11px] font-semibold text-slate-500 dark:text-slate-400 mb-3 uppercase tracking-wider flex items-center gap-1.5">
           <BookOpen size={11} /> Export Obsidian
         </p>
         <p className="text-[11px] text-slate-500 dark:text-slate-400 mb-3 leading-relaxed">
@@ -2150,7 +2150,7 @@ function EnvTab() {
             </p>
           )}
         </div>
-        <p className="text-[10px] text-violet-600 dark:text-violet-400 mt-2 flex items-start gap-1">
+        <p className="text-[11px] text-violet-600 dark:text-violet-400 mt-2 flex items-start gap-1">
           <BookOpen size={10} className="mt-0.5 shrink-0" />
           En Docker : ajoutez <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">- /votre/vault:/obsidian</code> dans <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">docker-compose.yml</code>, puis définissez <code className="bg-violet-100 dark:bg-violet-900/50 px-1 rounded">OBSIDIAN_DIR=/obsidian</code>.
         </p>
@@ -2404,7 +2404,7 @@ function WebSourcesTab() {
           onClick={saveSources}
           disabled={!isDirty || saving}
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium transition-colors disabled:opacity-40
-            bg-blue-500 hover:bg-blue-600 text-white"
+            bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white"
           title="Sauvegarder dans config/web_sources.json"
         >
           {saving ? <RefreshCw size={11} className="animate-spin" /> : <Save size={11} />}
@@ -2456,13 +2456,13 @@ function WebSourcesTab() {
             <>
               <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-1">
-                  <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Titre</label>
+                  <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Titre</label>
                   <input type="text" value={addTitle} onChange={e => setAddTitle(e.target.value)}
                     placeholder="Nom affiché"
                     className="w-full px-2.5 py-1.5 text-xs bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-colors" />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Mot-clé (bucket)</label>
+                  <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Mot-clé (bucket)</label>
                   <input type="text" value={addKeyword} onChange={e => setAddKeyword(e.target.value)}
                     placeholder="ex: Anthropic, MoMA, Louvre"
                     className="w-full px-2.5 py-1.5 text-xs bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-colors" />
@@ -2470,13 +2470,13 @@ function WebSourcesTab() {
               </div>
               <div className="grid grid-cols-2 gap-2">
                 <div className="space-y-1">
-                  <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL sitemap</label>
+                  <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL sitemap</label>
                   <input type="url" value={addSitemap} onChange={e => setAddSitemap(e.target.value)}
                     placeholder="https://…/sitemap.xml"
                     className="w-full px-2.5 py-1.5 text-xs bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-colors" />
                 </div>
                 <div className="space-y-1">
-                  <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Pattern URL (regex)</label>
+                  <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Pattern URL (regex)</label>
                   <input type="text" value={addPattern} onChange={e => setAddPattern(e.target.value)}
                     placeholder="ex: /news/  ou  /en/programs/\d+"
                     className="w-full px-2.5 py-1.5 text-xs font-mono bg-white dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded-lg text-slate-700 dark:text-slate-300 focus:outline-none focus:ring-2 focus:ring-blue-500/40 transition-colors" />
@@ -2490,7 +2490,7 @@ function WebSourcesTab() {
                 <button
                   onClick={handleAdd}
                   disabled={!addTitle || !addBaseUrl || !addPattern || !addKeyword}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-40 transition-colors"
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white disabled:opacity-40 transition-colors"
                 >
                   <Plus size={11} /> Ajouter la source
                 </button>
@@ -2537,22 +2537,22 @@ function WebSourcesTab() {
                 <div className="flex-1 min-w-0 space-y-1">
                   <div className="flex items-center gap-2 flex-wrap">
                     <span className="text-sm font-medium text-slate-700 dark:text-slate-200 truncate">{src.title}</span>
-                    <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 font-medium shrink-0">
+                    <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-blue-100 dark:bg-blue-900/40 text-blue-600 dark:text-blue-300 font-medium shrink-0">
                       {src.keyword}
                     </span>
                     {!src.actif && (
-                      <span className="text-[10px] px-1.5 py-0.5 rounded-md bg-slate-100 dark:bg-slate-700 text-slate-400 shrink-0">
+                      <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-slate-100 dark:bg-slate-700 text-slate-400 shrink-0">
                         inactif
                       </span>
                     )}
                   </div>
                   <div className="text-xs text-slate-400 dark:text-slate-500 truncate">{domain}</div>
                   <div className="flex items-center gap-3 flex-wrap">
-                    <code className="text-[10px] text-slate-500 dark:text-slate-400 font-mono bg-slate-100 dark:bg-slate-700/60 px-1.5 py-0.5 rounded">
+                    <code className="text-[11px] text-slate-500 dark:text-slate-400 font-mono bg-slate-100 dark:bg-slate-700/60 px-1.5 py-0.5 rounded">
                       {src.url_pattern}
                     </code>
                     {processed !== null && (
-                      <span className="text-[10px] text-slate-400 dark:text-slate-500 flex items-center gap-1">
+                      <span className="text-[11px] text-slate-400 dark:text-slate-500 flex items-center gap-1">
                         <CheckCircle2 size={9} className="text-green-500" />
                         {processed} URL{processed !== 1 ? 's' : ''} traité{processed !== 1 ? 'es' : 'e'}
                       </span>
@@ -2619,12 +2619,12 @@ function WebSourcesTab() {
               {/* Formulaire d'édition inline */}
               {isEditing && (
                 <div className="px-3 pb-3 pt-0 space-y-2 border-t border-blue-200 dark:border-blue-700/40">
-                  <p className="pt-2.5 text-[10px] font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide flex items-center gap-1">
+                  <p className="pt-2.5 text-[11px] font-semibold text-blue-600 dark:text-blue-400 uppercase tracking-wide flex items-center gap-1">
                     <Pencil size={10} /> Modifier la source
                   </p>
                   <div className="grid grid-cols-2 gap-2">
                     <div className="space-y-1">
-                      <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Titre</label>
+                      <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Titre</label>
                       <input
                         type="text"
                         value={editFields.title}
@@ -2633,7 +2633,7 @@ function WebSourcesTab() {
                       />
                     </div>
                     <div className="space-y-1">
-                      <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Mot-clé (bucket)</label>
+                      <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Mot-clé (bucket)</label>
                       <input
                         type="text"
                         value={editFields.keyword}
@@ -2643,7 +2643,7 @@ function WebSourcesTab() {
                     </div>
                   </div>
                   <div className="space-y-1">
-                    <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL de base</label>
+                    <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL de base</label>
                     <input
                       type="url"
                       value={editFields.base_url}
@@ -2653,7 +2653,7 @@ function WebSourcesTab() {
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     <div className="space-y-1">
-                      <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL sitemap</label>
+                      <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">URL sitemap</label>
                       <input
                         type="url"
                         value={editFields.sitemap_url}
@@ -2663,7 +2663,7 @@ function WebSourcesTab() {
                       />
                     </div>
                     <div className="space-y-1">
-                      <label className="text-[10px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Pattern URL (regex)</label>
+                      <label className="text-[11px] text-slate-500 dark:text-slate-400 font-medium uppercase tracking-wide">Pattern URL (regex)</label>
                       <input
                         type="text"
                         value={editFields.url_pattern}
@@ -2683,7 +2683,7 @@ function WebSourcesTab() {
                     <button
                       onClick={saveEdit}
                       disabled={!editFields.title || !editFields.base_url || !editFields.url_pattern || !editFields.keyword}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-blue-500 hover:bg-blue-600 text-white disabled:opacity-40 transition-colors"
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white disabled:opacity-40 transition-colors"
                     >
                       <Save size={11} /> Enregistrer
                     </button>
@@ -2790,7 +2790,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
                 }`}
               >
                 <Icon size={22} strokeWidth={activeTab === id ? 2.2 : 1.8} />
-                <span className="text-[10px] font-medium leading-none">{short}</span>
+                <span className="text-[11px] font-medium leading-none">{short}</span>
               </button>
             ))}
             {/* Bouton fermer — bord droit, séparé des onglets */}
@@ -2806,7 +2806,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
 
         {/* ── Accès rapide — mobile uniquement (actions retirées de la tab bar) ── */}
         <div className="md:hidden shrink-0 border-b border-slate-200/70 dark:border-slate-700/50 bg-slate-50/60 dark:bg-slate-800/40 px-4 py-3">
-          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2.5">Accès rapide</p>
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-2.5">Accès rapide</p>
           <div className="flex items-center gap-2">
             {/* Sélecteur de thème compact */}
             <div className="flex items-center rounded-xl border border-slate-200 dark:border-slate-600/70 overflow-hidden bg-white/70 dark:bg-slate-700/50 backdrop-blur-sm">
@@ -2822,7 +2822,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
                   }`}
                 >
                   <Icon size={16} />
-                  <span className="text-[9px] font-medium leading-none">{label}</span>
+                  <span className="text-[11px] font-medium leading-none">{label}</span>
                 </button>
               ))}
             </div>
@@ -2841,7 +2841,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
                       <span className="absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
                     )}
                   </span>
-                  <span className="text-[9px] font-medium leading-none">RSS</span>
+                  <span className="text-[11px] font-medium leading-none">RSS</span>
                 </button>
               )}
 
@@ -2853,7 +2853,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
                   className="flex flex-col items-center gap-[3px] px-3 py-2 rounded-xl bg-white/70 dark:bg-slate-700/50 backdrop-blur-sm border border-slate-200 dark:border-slate-600/70 text-slate-500 dark:text-slate-400 active:opacity-60"
                 >
                   <TrendingUp size={18} />
-                  <span className="text-[9px] font-medium leading-none">Tendances</span>
+                  <span className="text-[11px] font-medium leading-none">Tendances</span>
                 </button>
               )}
 
@@ -2865,7 +2865,7 @@ export default function SettingsPanel({ onClose, theme, onThemeChange, rssStatus
                   className="flex flex-col items-center gap-[3px] px-3 py-2 rounded-xl bg-white/70 dark:bg-slate-700/50 backdrop-blur-sm border border-slate-200 dark:border-slate-600/70 text-slate-500 dark:text-slate-400 active:opacity-60"
                 >
                   <Eye size={18} />
-                  <span className="text-[9px] font-medium leading-none">Biais</span>
+                  <span className="text-[11px] font-medium leading-none">Biais</span>
                 </button>
               )}
             </div>

--- a/viewer/src/components/Sidebar.jsx
+++ b/viewer/src/components/Sidebar.jsx
@@ -56,12 +56,12 @@ export default function Sidebar({
     ].join(' ')}>
       {/* Barre mobile uniquement : titre + bouton fermer */}
       <div className="flex items-center justify-between px-3 py-3 border-b border-slate-200 dark:border-slate-700 md:hidden">
-        <span className="text-sm font-medium text-slate-700 dark:text-slate-200">Fichiers</span>
+        <span className="text-hig-subheadline font-semibold text-slate-700 dark:text-slate-200">Fichiers</span>
         <button
           onClick={onClose}
-          className="p-1.5 rounded-lg text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors"
+          className="p-2 rounded-lg text-slate-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors touch-target"
         >
-          <X size={16} />
+          <X size={18} />
         </button>
       </div>
       {/* ── Filtres ── visibles sur mobile et desktop */}
@@ -76,9 +76,9 @@ export default function Sidebar({
             <button
               key={key}
               onClick={() => onTypeFilterChange(key)}
-              className={`flex-1 py-1.5 text-xs font-medium rounded transition-colors ${
+              className={`flex-1 py-1.5 text-hig-caption1 font-medium rounded transition-colors ${
                 typeFilter === key
-                  ? 'bg-blue-600 text-white'
+                  ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600 hover:text-slate-700 dark:hover:text-slate-200'
               }`}
             >
@@ -132,10 +132,10 @@ export default function Sidebar({
             {/* En-tête de groupe */}
             <div className="sticky top-0 z-10 bg-white/95 dark:bg-slate-800/95 px-3 py-1.5 flex items-center gap-1.5 border-b border-slate-200/60 dark:border-slate-700/60 backdrop-blur-sm">
               <Folder size={11} className="text-slate-400 dark:text-slate-500" />
-              <span className="text-xs font-medium text-slate-400 dark:text-slate-500 uppercase tracking-wider truncate">
+              <span className="text-hig-caption2 font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider truncate">
                 {flux}
               </span>
-              <span className="ml-auto text-xs text-slate-300 dark:text-slate-700 shrink-0">{fluxFiles.length}</span>
+              <span className="ml-auto text-hig-caption2 text-slate-500 dark:text-slate-500 shrink-0">{fluxFiles.length}</span>
             </div>
 
             {/* Items */}
@@ -147,7 +147,7 @@ export default function Sidebar({
                   onClick={() => onSelect(file)}
                   className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 border-b border-slate-200/30 dark:border-slate-700/30 transition-colors ${
                     isSelected
-                      ? 'bg-blue-600/20 border-l-2 border-l-blue-500 pl-[10px]'
+                      ? 'bg-[#007AFF]/10 dark:bg-[#0A84FF]/15 border-l-2 border-l-[#007AFF] dark:border-l-[#0A84FF] pl-[10px]'
                       : 'hover:bg-slate-100/50 dark:hover:bg-slate-700/50'
                   }`}
                 >
@@ -159,21 +159,21 @@ export default function Sidebar({
                     <div className="text-xs font-medium text-slate-800 dark:text-slate-200 truncate leading-snug flex items-center gap-1.5">
                       <span className="truncate">{file.name}</span>
                       {isToday(file.modified) && (
-                        <span className="shrink-0 text-[9px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-orange-500 text-white leading-none">
+                        <span className="shrink-0 text-[11px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-orange-500 text-white leading-none">
                           new
                         </span>
                       )}
                     </div>
                     <div className="flex items-center gap-2 mt-1">
-                      <span className={`text-[10px] px-1.5 rounded font-mono leading-4 ${
+                      <span className={`text-[11px] px-1.5 rounded font-mono leading-4 ${
                         file.type === 'json'
                           ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400'
                           : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'
                       }`}>
                         {file.type === 'json' ? 'JSON' : 'MD'}
                       </span>
-                      <span className="text-[10px] text-slate-400 dark:text-slate-500">{formatSize(file.size)}</span>
-                      <span className="text-[10px] text-slate-400 dark:text-slate-600 ml-auto">{formatDate(file.modified)} {formatTime(file.modified)}</span>
+                      <span className="text-[11px] text-slate-400 dark:text-slate-500">{formatSize(file.size)}</span>
+                      <span className="text-[11px] text-slate-400 dark:text-slate-600 ml-auto">{formatDate(file.modified)} {formatTime(file.modified)}</span>
                     </div>
                   </div>
                 </button>

--- a/viewer/src/components/SimilarArticlesPanel.jsx
+++ b/viewer/src/components/SimilarArticlesPanel.jsx
@@ -167,11 +167,11 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
 
         {/* ── Article source ─────────────────────────────────────────────── */}
         <div className="px-5 py-3 bg-slate-50 dark:bg-slate-800/50 border-b border-slate-200 dark:border-slate-700 shrink-0">
-          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-0.5">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mb-0.5">
             Article source
           </p>
           <p className="text-xs font-medium text-slate-700 dark:text-slate-200 truncate">{articleTitle}</p>
-          <p className="text-[10px] text-slate-400 dark:text-slate-500">
+          <p className="text-[11px] text-slate-400 dark:text-slate-500">
             {article['Sources']} · {article['Date de publication']}
           </p>
         </div>
@@ -241,17 +241,17 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
                       <div className="flex-1 min-w-0">
                         <div className="flex items-start justify-between gap-2 flex-wrap">
                           <div className="flex items-center gap-1.5">
-                            <span className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
+                            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">
                               {c.source}
                             </span>
                             {c.has_obsidian && (
-                              <span className="text-[9px] px-1 py-0.5 rounded bg-violet-100 dark:bg-violet-900/40 text-violet-600 dark:text-violet-400 border border-violet-200 dark:border-violet-800">
+                              <span className="text-[11px] px-1 py-0.5 rounded bg-violet-100 dark:bg-violet-900/40 text-violet-600 dark:text-violet-400 border border-violet-200 dark:border-violet-800">
                                 Obsidian
                               </span>
                             )}
                           </div>
                           {/* Score composite */}
-                          <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded-full border shrink-0 ${scoreBg(c.score)} ${scoreColor(c.score)}`}>
+                          <span className={`text-[11px] font-bold px-1.5 py-0.5 rounded-full border shrink-0 ${scoreBg(c.score)} ${scoreColor(c.score)}`}>
                             {Math.round(c.score * 100)}%
                           </span>
                         </div>
@@ -259,21 +259,21 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
                         <p className="text-xs font-medium text-slate-700 dark:text-slate-200 mt-0.5 leading-tight line-clamp-2">
                           {c.titre || c.url}
                         </p>
-                        <p className="text-[10px] text-slate-400 dark:text-slate-500 mt-0.5">{c.date}</p>
+                        <p className="text-[11px] text-slate-400 dark:text-slate-500 mt-0.5">{c.date}</p>
 
                         {/* Scores détaillés + bouton extrait */}
                         <div className="flex items-center gap-2 mt-1.5 flex-wrap">
-                          <span className="text-[9px] text-slate-400 dark:text-slate-500">
+                          <span className="text-[11px] text-slate-400 dark:text-slate-500">
                             Entités {Math.round(c.score_entites * 100)}%
                           </span>
-                          <span className="text-[9px] text-slate-300 dark:text-slate-600">·</span>
-                          <span className="text-[9px] text-slate-400 dark:text-slate-500">
+                          <span className="text-[11px] text-slate-300 dark:text-slate-600">·</span>
+                          <span className="text-[11px] text-slate-400 dark:text-slate-500">
                             Texte {Math.round(c.score_bigrammes * 100)}%
                           </span>
                           {c.resume_extrait && (
                             <button
                               onClick={() => setExpandedUrl(v => v === c.url ? null : c.url)}
-                              className="text-[9px] text-violet-400 hover:text-violet-600 dark:hover:text-violet-300 flex items-center gap-0.5 transition-colors ml-auto"
+                              className="text-[11px] text-violet-400 hover:text-violet-600 dark:hover:text-violet-300 flex items-center gap-0.5 transition-colors ml-auto"
                             >
                               {isExpanded ? <><ChevronUp size={9} /> Moins</> : <><ChevronDown size={9} /> Extrait</>}
                             </button>
@@ -323,7 +323,7 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
                       {mergeResult.obsidian_updated.length} note{mergeResult.obsidian_updated.length > 1 ? 's' : ''} Obsidian mise{mergeResult.obsidian_updated.length > 1 ? 's' : ''} à jour
                     </p>
                   )}
-                  <p className="text-[10px] text-emerald-500/70 dark:text-emerald-500/60 mt-1 font-mono break-all">
+                  <p className="text-[11px] text-emerald-500/70 dark:text-emerald-500/60 mt-1 font-mono break-all">
                     Archive : {mergeResult.archive_path}
                   </p>
                 </div>
@@ -363,7 +363,7 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
             {synthesis !== null && (
               <div>
                 <div className="flex items-center justify-between mb-1">
-                  <label className="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+                  <label className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
                     Synthèse{' '}
                     {synthMode === 'ia'
                       ? <span className="normal-case font-normal text-violet-500 dark:text-violet-400">générée par l'IA</span>
@@ -374,7 +374,7 @@ export default function SimilarArticlesPanel({ article, filePath, onClose, onMer
                     onClick={generateSynthesis}
                     disabled={synthesizing}
                     title="Regénérer"
-                    className="text-[10px] text-violet-400 hover:text-violet-600 dark:hover:text-violet-300 flex items-center gap-0.5 transition-colors"
+                    className="text-[11px] text-violet-400 hover:text-violet-600 dark:hover:text-violet-300 flex items-center gap-0.5 transition-colors"
                   >
                     {synthesizing ? <Loader2 size={10} className="animate-spin" /> : <Sparkles size={10} />}
                     {synthesizing ? 'Génération…' : 'Regénérer'}

--- a/viewer/src/components/SourceBiasPanel.jsx
+++ b/viewer/src/components/SourceBiasPanel.jsx
@@ -104,7 +104,7 @@ function MbfcBadge({ rating }) {
   const cls = MBFC_BADGE[rating] || 'bg-slate-100 text-slate-600'
   const short = { 'VERY HIGH': 'Très haut', 'HIGH': 'Haut', 'MOSTLY FACTUAL': 'Factuel', 'MIXED': 'Mixte', 'LOW': 'Bas', 'VERY LOW': 'Très bas' }
   return (
-    <span className={`text-[10px] px-1.5 py-0.5 rounded font-medium whitespace-nowrap ${cls}`} title={`MBFC : ${rating}`}>
+    <span className={`text-[11px] px-1.5 py-0.5 rounded font-medium whitespace-nowrap ${cls}`} title={`MBFC : ${rating}`}>
       {short[rating] || rating}
     </span>
   )
@@ -263,7 +263,7 @@ export default function SourceBiasPanel({ onClose }) {
           <div className="flex items-center gap-2">
             <button
               onClick={() => setShowEnrich(true)}
-              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded-lg transition-colors"
+              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 text-xs bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white rounded-lg transition-colors"
               title="Lancer l'enrichissement WHOIS + MBFC + transparence"
             >
               <ShieldCheck size={12} />

--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -60,12 +60,12 @@ function SentimentBadge({ article }) {
   const cfg = SENTIMENT_CFG[sentiment] ?? SENTIMENT_CFG.neutre
   return (
     <div className="flex items-center gap-1.5 flex-wrap mt-1">
-      <span className={`inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
+      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${cfg.dot}`} />
         {cfg.label}{scoreSent ? ` ${scoreSent}/5` : ''}
       </span>
       {ton && (
-        <span className="inline-flex items-center text-[10px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
+        <span className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
           {TON_LABELS[ton] ?? ton}{scoreTon ? ` ${scoreTon}/5` : ''}
         </span>
       )}
@@ -77,7 +77,7 @@ function ReadingTimeBadge({ article }) {
   const label = article.temps_lecture_label
   if (!label) return null
   return (
-    <span className="inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
+    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
       <Clock size={9} className="shrink-0" />
       {label}
     </span>
@@ -91,7 +91,7 @@ function ScoreBar({ score }) {
   const color = pct >= 70 ? 'bg-emerald-500' : pct >= 40 ? 'bg-amber-500' : 'bg-slate-400'
   return (
     <div className="flex items-center gap-2 mt-3 pt-3 border-t border-slate-100 dark:border-slate-700/50">
-      <span className="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">Score</span>
+      <span className="text-[11px] text-slate-400 dark:text-slate-500 shrink-0">Score</span>
       <div className="flex-1 h-1.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
         <div className={`h-full rounded-full transition-all ${color}`} style={{ width: `${pct}%` }} />
       </div>
@@ -275,7 +275,7 @@ function IAPickerModal({ providers, onPick, onClose }) {
         <div className="flex flex-col gap-2">
           {providers.map(p => (
             <button key={p} onClick={() => onPick(p)}
-              className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-blue-600 hover:bg-blue-500 text-white transition-colors">
+              className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white transition-colors">
               {LABELS[p] ?? p}
             </button>
           ))}
@@ -411,7 +411,7 @@ function ArticleCard({ article, rank, onEntityClick, isCurrentPodcast, annotatio
             </span>
             {date && <span className="text-xs text-slate-400 dark:text-slate-500">{date}{time ? <> · <span>{time}</span></> : ''}</span>}
             {hasEntities && (
-              <span className="inline-flex items-center gap-1 text-[10px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
+              <span className="inline-flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
                 <Tag size={9} />{count} entités
               </span>
             )}
@@ -465,7 +465,7 @@ function ArticleCard({ article, rank, onEntityClick, isCurrentPodcast, annotatio
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1 mb-2">
             {tags.map(t => (
-              <span key={t} className="inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">{t}</span>
+              <span key={t} className="inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border border-amber-200 dark:border-amber-800">{t}</span>
             ))}
           </div>
         )}
@@ -509,12 +509,12 @@ function ArticleCard({ article, rank, onEntityClick, isCurrentPodcast, annotatio
         {/* Barre score + podcast */}
         <div className="mt-3 pt-3 border-t border-white/40 dark:border-white/5 flex items-center gap-2">
           {isCurrentPodcast && (
-            <span className="flex items-center gap-1 text-[10px] text-violet-600 dark:text-violet-400 font-medium">
+            <span className="flex items-center gap-1 text-[11px] text-violet-600 dark:text-violet-400 font-medium">
               <Volume2 size={11} className="animate-pulse" />En cours…
             </span>
           )}
           <div className="ml-auto flex items-center gap-2 flex-1 min-w-0">
-            <span className="text-[10px] text-slate-400 dark:text-slate-500 shrink-0">Score</span>
+            <span className="text-[11px] text-slate-400 dark:text-slate-500 shrink-0">Score</span>
             <div className="flex-1 h-1.5 bg-slate-200/60 dark:bg-slate-700/50 rounded-full overflow-hidden">
               <div className={`h-full rounded-full ${
                 (article.score_pertinence ?? 0) >= 70 ? 'bg-emerald-500' :

--- a/viewer/src/index.css
+++ b/viewer/src/index.css
@@ -1,10 +1,89 @@
 /* ── Polices auto-hébergées (aucune dépendance réseau) ── */
-/* Inter Variable : UI + contenu — lisible sur toutes les plateformes */
+/* Inter Variable : UI + contenu — lisible sur toutes les plateformes (fallback si SF Pro absent) */
 @import '@fontsource-variable/inter';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* ══ Couleurs système Apple — Apple Human Interface Guidelines ═════════════
+   Source : developer.apple.com/design/human-interface-guidelines/color
+   Ces variables CSS exposent la palette système Apple pour les deux modes.
+   Utilisées par les classes Tailwind `accent-*` et les styles custom ci-dessous.
+══════════════════════════════════════════════════════════════════════════════ */
+:root {
+  /* ── System Accent (System Blue) ── */
+  --color-accent:           #007AFF;
+  --color-accent-hover:     #0071EB;
+  --color-accent-subtle:    rgba(0, 122, 255, 0.12);
+
+  /* ── System Semantic Colors ── */
+  --color-success:          #34C759;
+  --color-warning:          #FF9500;
+  --color-danger:           #FF3B30;
+  --color-yellow:           #FFCC00;
+  --color-teal:             #5AC8FA;
+  --color-indigo:           #5856D6;
+  --color-purple:           #AF52DE;
+
+  /* ── Label Colors ── */
+  --color-label:            rgba(0, 0, 0, 1);
+  --color-label-secondary:  rgba(60, 60, 67, 0.60);
+  --color-label-tertiary:   rgba(60, 60, 67, 0.30);
+  --color-label-quaternary: rgba(60, 60, 67, 0.18);
+
+  /* ── Fill Colors (pour les contrôles et champs) ── */
+  --color-fill:             rgba(120, 120, 128, 0.20);
+  --color-fill-secondary:   rgba(120, 120, 128, 0.16);
+  --color-fill-tertiary:    rgba(118, 118, 128, 0.12);
+  --color-fill-quaternary:  rgba(116, 116, 128, 0.08);
+
+  /* ── System Backgrounds ── */
+  --color-bg-primary:       #FFFFFF;
+  --color-bg-secondary:     #F2F2F7;
+  --color-bg-tertiary:      #FFFFFF;
+
+  /* ── Separator ── */
+  --color-separator:        rgba(60, 60, 67, 0.29);
+  --color-separator-opaque: #C6C6C8;
+}
+
+.dark {
+  /* ── System Accent (System Blue — dark) ── */
+  --color-accent:           #0A84FF;
+  --color-accent-hover:     #1E8FFF;
+  --color-accent-subtle:    rgba(10, 132, 255, 0.18);
+
+  /* ── System Semantic Colors — dark ── */
+  --color-success:          #30D158;
+  --color-warning:          #FF9F0A;
+  --color-danger:           #FF453A;
+  --color-yellow:           #FFD60A;
+  --color-teal:             #64D2FF;
+  --color-indigo:           #5E5CE6;
+  --color-purple:           #BF5AF2;
+
+  /* ── Label Colors — dark ── */
+  --color-label:            rgba(255, 255, 255, 1);
+  --color-label-secondary:  rgba(235, 235, 245, 0.60);
+  --color-label-tertiary:   rgba(235, 235, 245, 0.30);
+  --color-label-quaternary: rgba(235, 235, 245, 0.18);
+
+  /* ── Fill Colors — dark ── */
+  --color-fill:             rgba(120, 120, 128, 0.36);
+  --color-fill-secondary:   rgba(120, 120, 128, 0.32);
+  --color-fill-tertiary:    rgba(118, 118, 128, 0.24);
+  --color-fill-quaternary:  rgba(118, 118, 128, 0.18);
+
+  /* ── System Backgrounds — dark ── */
+  --color-bg-primary:       #000000;
+  --color-bg-secondary:     #1C1C1E;
+  --color-bg-tertiary:      #2C2C2E;
+
+  /* ── Separator — dark ── */
+  --color-separator:        rgba(84, 84, 88, 0.65);
+  --color-separator-opaque: #38383A;
+}
 
 /* Scrollbar fine et discrète */
 ::-webkit-scrollbar { width: 5px; height: 5px; }
@@ -20,6 +99,84 @@ html { -webkit-text-size-adjust: auto; text-size-adjust: auto; }
 
 html, body { overflow-x: hidden; }
 body { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; touch-action: pan-y; }
+
+/* ══ Classes utilitaires HIG — boutons, états actifs ═══════════════════════
+   Utiliser .btn-accent au lieu de bg-blue-600 pour les CTA et états sélectionnés.
+   Ces classes appliquent automatiquement la System Blue Apple (light + dark).
+══════════════════════════════════════════════════════════════════════════════ */
+
+/* Bouton CTA plein (filled) — équivalent du Filled Button HIG */
+.btn-accent {
+  background-color: var(--color-accent);
+  color: #FFFFFF;
+  transition: background-color 150ms ease-out, opacity 150ms ease-out;
+}
+.btn-accent:hover:not(:disabled) {
+  background-color: var(--color-accent-hover);
+}
+.btn-accent:disabled {
+  opacity: 0.4;
+}
+
+/* Fond subtil teinté (tinted) — états sélectionnés, badges actifs */
+.bg-accent-subtle {
+  background-color: var(--color-accent-subtle);
+}
+
+/* Texte couleur accent */
+.text-accent {
+  color: var(--color-accent);
+}
+
+/* Bordure accent */
+.border-accent {
+  border-color: var(--color-accent);
+}
+
+/* Champ de saisie style HIG (Tertiary System Fill + rounded-[10px]) */
+.input-hig {
+  background-color: var(--color-fill-tertiary);
+  border-radius: 10px;
+  border: none;
+  transition: background-color 150ms ease-out;
+}
+.input-hig:focus {
+  background-color: var(--color-fill-secondary);
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+/* ══ Cibles tactiles HIG — Apple Human Interface Guidelines ════════════════
+   HIG : minimum 44×44pt pour toute cible interactive sur iOS/macOS.
+   Sur mobile, les éléments trop petits reçoivent une zone de tap étendue
+   via ::after pseudo-element (invisible, n'affecte pas le layout).
+   Sur desktop, les boutons icon-only ont min-width/height de 32px (toléré).
+══════════════════════════════════════════════════════════════════════════════ */
+
+/* Boutons icon-only : zone de tap minimum 44px sur mobile */
+@media (max-width: 767px) {
+  /* Boutons dans les drawers mobiles, modals, navigation */
+  .touch-target {
+    position: relative;
+  }
+  .touch-target::after {
+    content: '';
+    position: absolute;
+    inset: 50% 50%;
+    transform: translate(-50%, -50%);
+    min-width: 44px;
+    min-height: 44px;
+  }
+}
+
+/* Classe utilitaire explicite : cible tactile garantie 44px (visible + invisible) */
+.min-touch {
+  min-height: 44px;
+  min-width: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
 
 /* ══ Liquid Glass — matériaux inspirés iOS 26 / macOS Tahoe ══════════════════
    Trois niveaux de profondeur :

--- a/viewer/tailwind.config.js
+++ b/viewer/tailwind.config.js
@@ -44,10 +44,44 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        // Inter Variable pour tout l'UI et le contenu éditorial
-        sans: ['"Inter Variable"', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        // Monospace système pour JSON et code (SF Mono / Cascadia / Menlo selon la plateforme)
+        // Priorité à SF Pro sur les plateformes Apple, Inter Variable sur les autres
+        sans: ['-apple-system', 'BlinkMacSystemFont', '"Inter Variable"', 'Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        // SF Mono sur Apple, puis chaîne monospace système
         mono: ['ui-monospace', 'SFMono-Regular', 'Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'monospace'],
+      },
+      // ── Échelle typographique HIG (Apple Human Interface Guidelines) ──────
+      // Source : developer.apple.com/design/human-interface-guidelines/typography
+      // Valeurs adaptées web (px) depuis les points iOS/macOS
+      fontSize: {
+        'hig-large-title':    ['34px', { lineHeight: '41px', fontWeight: '400' }],
+        'hig-title1':         ['28px', { lineHeight: '34px', fontWeight: '400' }],
+        'hig-title2':         ['22px', { lineHeight: '28px', fontWeight: '400' }],
+        'hig-title3':         ['20px', { lineHeight: '25px', fontWeight: '600' }],
+        'hig-headline':       ['17px', { lineHeight: '22px', fontWeight: '600' }],
+        'hig-body':           ['17px', { lineHeight: '22px', fontWeight: '400' }],
+        'hig-callout':        ['16px', { lineHeight: '21px', fontWeight: '400' }],
+        'hig-subheadline':    ['15px', { lineHeight: '20px', fontWeight: '400' }],
+        'hig-footnote':       ['13px', { lineHeight: '18px', fontWeight: '400' }],
+        'hig-caption1':       ['12px', { lineHeight: '16px', fontWeight: '400' }],
+        'hig-caption2':       ['11px', { lineHeight: '13px', fontWeight: '400' }],
+      },
+      // ── Couleurs système Apple (HIG System Colors) ───────────────────────
+      // Utiliser 'accent' au lieu de 'blue-600' pour les CTA et états actifs
+      colors: {
+        accent: {
+          DEFAULT: '#007AFF',          // iOS/macOS System Blue — light
+          dark:    '#0A84FF',          // iOS/macOS System Blue — dark
+          hover:   '#0071EB',          // légèrement plus sombre pour hover
+          'dark-hover': '#1E8FFF',
+        },
+        'hig-green':  { DEFAULT: '#34C759', dark: '#30D158' },
+        'hig-red':    { DEFAULT: '#FF3B30', dark: '#FF453A' },
+        'hig-orange': { DEFAULT: '#FF9500', dark: '#FF9F0A' },
+        'hig-yellow': { DEFAULT: '#FFCC00', dark: '#FFD60A' },
+        'hig-teal':   { DEFAULT: '#5AC8FA', dark: '#64D2FF' },
+        'hig-indigo': { DEFAULT: '#5856D6', dark: '#5E5CE6' },
+        'hig-purple': { DEFAULT: '#AF52DE', dark: '#BF5AF2' },
+        'hig-pink':   { DEFAULT: '#FF2D55', dark: '#FF375F' },
       },
     },
   },


### PR DESCRIPTION
…, touch targets)

- Font-stack : SF Pro prioritaire sur Apple (-apple-system, BlinkMacSystemFont)
- 11 tokens typographiques HIG (hig-large-title → hig-caption2) dans tailwind.config.js
- Tokens appliqués : sidebar header, labels de groupes, filtres, titre app
- 186 microtextes corrigés : text-[9px] et text-[10px] → text-[11px] min (Caption 2 HIG)
- 36 variables CSS HIG dans index.css : System Blue, Fills, Labels, Backgrounds
- Couleur accent : blue-600 → System Blue Apple #007AFF / #0A84FF (48 occurrences CTA)
- Navigation active (bottom bar) : System Blue sur les 5 onglets
- Contraste WCAG AA : text-slate-300 corrigé → slate-400/500 (EntityGraph, FileViewer, SettingsPanel)
- Touch targets : classe .touch-target (44×44pt) + boutons X portés à p-2/p-2.5