### PR TITLE
fix: scroll premier article non lu + Axe 3 HIG — espacement grille 8pt

### DIFF
--- a/viewer/src/App.jsx
+++ b/viewer/src/App.jsx
@@ -128,7 +128,7 @@ function RssStatusBar({ status, nextRssLabel }) {
           </span>
           {/* Progression flux X/Y */}
           {prog && prog.total_feeds > 0 && (
-            <span className="inline-flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400">
+            <span className="inline-flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
               <span className="tabular-nums">{prog.current_feed_idx}/{prog.total_feeds}</span>
               {/* barre de progression */}
               <span className="w-20 h-1.5 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden inline-block align-middle">
@@ -247,8 +247,8 @@ export default function App() {
   const [sidebarOpen, setSidebarOpen]     = useState(() => window.innerWidth >= 768)
   const [loadingProgress, setLoadingProgress] = useState(0)
   const [isRefreshing, setIsRefreshing]   = useState(false)
-  // Annotations manuelles (dict keyed par URL article)
-  const [annotations, setAnnotations]     = useState({})
+  // Annotations manuelles (dict keyed par URL article) — null tant que le fetch initial n'est pas terminé
+  const [annotations, setAnnotations]     = useState(null)
   // Compteur de requêtes pour ignorer les réponses périmées (race condition)
   const fetchIdRef = useRef(0)
   // Ref sur le fichier en cours de consultation (accessible dans les callbacks
@@ -393,8 +393,9 @@ export default function App() {
     if (!url) return
     // Mise à jour optimiste immédiate
     setAnnotations(prev => {
-      const existing = prev[url] || {}
-      return { ...prev, [url]: { ...existing, ...changes } }
+      const base = prev ?? {}
+      const existing = base[url] || {}
+      return { ...base, [url]: { ...existing, ...changes } }
     })
     try {
       const r = await fetch('/api/annotations', {
@@ -571,11 +572,11 @@ export default function App() {
     <div className="h-screen flex flex-col bg-slate-50 dark:bg-slate-900 text-slate-900 dark:text-slate-100 overflow-hidden">
       {/* ── Barre de navigation desktop ── */}
       <header
-        className="hidden md:flex items-center gap-1.5 px-3 py-2 glass-nav border-b border-white/35 dark:border-white/[0.08] shrink-0 relative z-50"
+        className="hidden md:flex items-center gap-2 px-3 py-2 glass-nav border-b border-white/35 dark:border-white/[0.08] shrink-0 relative z-50"
         style={{ paddingTop: 'max(8px, env(safe-area-inset-top))' }}
       >
         {/* Logo compact */}
-        <div className="flex items-center gap-1.5 shrink-0 mr-1">
+        <div className="flex items-center gap-2 shrink-0 mr-1">
           <img src={wuddLogo} alt="WUDD.ai" className="w-8 h-8 rounded-md select-none" />
           <span className="hidden xl:block font-semibold text-hig-callout text-slate-900 dark:text-slate-100 whitespace-nowrap">WUDD.ai</span>
         </div>
@@ -598,7 +599,7 @@ export default function App() {
               key={key}
               onClick={() => setTheme(key)}
               title={title}
-              className={`px-1.5 py-1.5 transition-colors ${
+              className={`p-2 transition-colors ${
                 theme === key
                   ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-700 dark:hover:text-slate-200'
@@ -615,7 +616,7 @@ export default function App() {
         {/* Console RSS keywords */}
         <button
           onClick={() => setConsoleOpen(true)}
-          className={`flex items-center gap-1.5 px-2.5 py-1.5 border rounded-lg text-sm transition-colors ${
+          className={`flex items-center gap-2 px-3 py-2 border rounded-lg text-sm transition-colors ${
             rssStatus?.running
               ? 'bg-green-50 dark:bg-green-900/20 border-green-300 dark:border-green-700 text-green-700 dark:text-green-400'
               : 'bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
@@ -638,7 +639,7 @@ export default function App() {
         {/* Top articles */}
         <button
           onClick={() => setTopOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Top articles par score de pertinence"
         >
           <Star size={13} />
@@ -648,7 +649,7 @@ export default function App() {
         {/* Tendances & alertes */}
         <button
           onClick={() => setAlertsOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Alertes de tendances"
         >
           <TrendingUp size={13} />
@@ -658,7 +659,7 @@ export default function App() {
         {/* Dashboard entités */}
         <button
           onClick={() => setDashboardOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Dashboard des entités nommées"
         >
           <BarChart2 size={13} />
@@ -671,7 +672,7 @@ export default function App() {
         {/* Chatbot IA */}
         <button
           onClick={() => setChatOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-green-50 dark:hover:bg-green-900/20 border border-slate-200 dark:border-slate-600 hover:border-green-300 dark:hover:border-green-700 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-green-700 dark:hover:text-green-400 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-green-50 dark:hover:bg-green-900/20 border border-slate-200 dark:border-slate-600 hover:border-green-300 dark:hover:border-green-700 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-green-700 dark:hover:text-green-400 transition-colors"
           title="Chatbot IA — interrogez vos données et rapports"
         >
           <span className="font-mono text-sm">&gt;_ IA</span>
@@ -681,7 +682,7 @@ export default function App() {
         <div ref={outilsMenuRef} className="relative shrink-0">
           <button
             onClick={() => setOutilsOpen(v => !v)}
-            className={`flex items-center gap-1 px-2.5 py-1.5 border rounded-lg text-sm transition-colors ${
+            className={`flex items-center gap-1 px-3 py-2 border rounded-lg text-sm transition-colors ${
               outilsOpen
                 ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-300 dark:border-blue-600 text-blue-700 dark:text-blue-300'
                 : 'bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'
@@ -705,7 +706,7 @@ export default function App() {
                 <button
                   key={label}
                   onClick={action}
-                  className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-slate-100/80 dark:hover:bg-slate-700/60 transition-colors group"
+                  className="w-full flex items-center gap-3 px-4 py-3 text-left hover:bg-slate-100/80 dark:hover:bg-slate-700/60 transition-colors group"
                 >
                   <Icon size={14} className="text-slate-400 dark:text-slate-500 shrink-0 group-hover:text-slate-600 dark:group-hover:text-slate-300 transition-colors" />
                   <div className="min-w-0">
@@ -724,7 +725,7 @@ export default function App() {
         {/* Réglages */}
         <button
           onClick={() => setSettingsOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Réglages — planification, mots-clés, flux"
         >
           <span className="relative">
@@ -739,7 +740,7 @@ export default function App() {
         {/* Recherche plein texte */}
         <button
           onClick={() => setSearchOpen(true)}
-          className="flex items-center gap-1.5 px-2.5 py-1.5 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-slate-100 dark:bg-slate-700 hover:bg-slate-200 dark:hover:bg-slate-600 border border-slate-200 dark:border-slate-600 rounded-lg text-sm text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 transition-colors"
           title="Recherche plein texte (Ctrl+K)"
         >
           <Search size={13} />
@@ -914,7 +915,7 @@ export default function App() {
             <div className="flex flex-col gap-2 px-4 pb-5">
               <button
                 onClick={() => { setSearchMode('file'); setSearchTypeMenuOpen(false); setSearchOpen(true) }}
-                className="flex items-center gap-3 px-4 py-3.5 rounded-xl bg-slate-100 dark:bg-slate-700 text-left active:opacity-70 transition-opacity"
+                className="flex items-center gap-3 px-4 py-4 rounded-xl bg-slate-100 dark:bg-slate-700 text-left active:opacity-70 transition-opacity"
               >
                 <Search size={20} className="text-blue-500 shrink-0" />
                 <div>
@@ -932,7 +933,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'
@@ -964,7 +965,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'
@@ -987,7 +988,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'
@@ -1010,7 +1011,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'
@@ -1033,7 +1034,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'
@@ -1056,7 +1057,7 @@ export default function App() {
                   }
                 }}
                 disabled={!selectedFile || selectedFile?.type !== 'json'}
-                className={`flex items-center gap-3 px-4 py-3.5 rounded-xl text-left transition-opacity ${
+                className={`flex items-center gap-3 px-4 py-4 rounded-xl text-left transition-opacity ${
                   selectedFile && selectedFile.type === 'json'
                     ? 'bg-slate-100 dark:bg-slate-700 active:opacity-70'
                     : 'bg-slate-50 dark:bg-slate-800/50 opacity-40 cursor-not-allowed'

--- a/viewer/src/components/AlertsPanel.jsx
+++ b/viewer/src/components/AlertsPanel.jsx
@@ -67,7 +67,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
             <TrendingUp size={18} className="text-orange-500" />
             <h2 className="font-semibold text-slate-900 dark:text-slate-100">Tendances &amp; Alertes</h2>
             {alerts.length > 0 && (
-              <span className="px-2 py-0.5 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 text-xs rounded-full font-medium">
+              <span className="px-2 py-1 bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400 text-xs rounded-full font-medium">
                 {alerts.length}
               </span>
             )}
@@ -109,7 +109,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
           <button
             onClick={runDetector}
             disabled={running}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-sm rounded-lg transition-colors"
+            className="flex items-center gap-2 px-3 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-sm rounded-lg transition-colors"
           >
             <RefreshCw size={13} className={running ? 'animate-spin' : ''} />
             {running ? 'Analyse…' : 'Lancer l\'analyse'}
@@ -153,7 +153,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
                       <div className="flex items-center gap-2 flex-wrap">
                         <span className="font-semibold">{alert.entity_value}</span>
                         <span className="text-xs opacity-70">{typeLabel}</span>
-                        <span className={`text-xs px-1.5 py-0.5 rounded font-medium border ${cfg.color}`}>
+                        <span className={`text-xs px-2 py-0.5 rounded font-medium border ${cfg.color}`}>
                           {cfg.label}
                         </span>
                       </div>
@@ -183,7 +183,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
       style={{ paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}
     >
       <div className="flex flex-wrap items-center gap-2 flex-1">
-        <div className="flex items-center gap-1.5 text-sm">
+        <div className="flex items-center gap-2 text-sm">
           <label className="text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">Seuil :</label>
           <select
             value={threshold}
@@ -196,7 +196,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
             <option value="5.0">×5.0 (critique)</option>
           </select>
         </div>
-        <div className="flex items-center gap-1.5 text-sm">
+        <div className="flex items-center gap-2 text-sm">
           <label className="text-slate-500 dark:text-slate-400 text-xs whitespace-nowrap">Filtre :</label>
           <select
             value={filterNiveau}
@@ -212,7 +212,7 @@ export default function AlertsPanel({ onClose, onEntitySearch }) {
         <button
           onClick={runDetector}
           disabled={running}
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-xs rounded-lg transition-colors"
+          className="flex items-center gap-2 px-3 py-2 bg-orange-500 hover:bg-orange-600 disabled:opacity-50 text-white text-xs rounded-lg transition-colors"
         >
           <RefreshCw size={12} className={running ? 'animate-spin' : ''} />
           {running ? 'Analyse…' : 'Lancer'}

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -25,7 +25,7 @@ function ReadingTimeBadge({ article }) {
   const label = article.temps_lecture_label
   if (!label) return null
   return (
-    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
+    <span className="inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-500 dark:text-slate-400">
       <Clock size={9} className="shrink-0" />
       {label}
     </span>
@@ -40,13 +40,13 @@ function SentimentBadge({ article }) {
   if (!sentiment) return null
   const cfg = SENTIMENT_CFG[sentiment] ?? SENTIMENT_CFG.neutre
   return (
-    <div className="flex items-center gap-1.5 flex-wrap mt-1">
-      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-1.5 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
+    <div className="flex items-center gap-2 flex-wrap mt-1">
+      <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full border ${cfg.bg} ${cfg.text}`}>
         <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${cfg.dot}`} />
         {cfg.label}{scoreSent ? ` ${scoreSent}/5` : ''}
       </span>
       {ton && (
-        <span className="inline-flex items-center text-[11px] font-medium px-1.5 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
+        <span className="inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full border bg-slate-100 dark:bg-slate-700/50 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-400">
           {TON_LABELS[ton] ?? ton}{scoreTon ? ` ${scoreTon}/5` : ''}
         </span>
       )}
@@ -214,7 +214,7 @@ function AnnotationPanel({ annotation, onSave, onClose }) {
   return (
     <div className="mt-3 p-3 rounded-xl bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/60">
       {/* Tags */}
-      <div className="flex flex-wrap gap-1.5 mb-2">
+      <div className="flex flex-wrap gap-2 mb-2">
         {tags.map(t => (
           <span key={t} className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium bg-amber-100 dark:bg-amber-800/50 text-amber-800 dark:text-amber-200 border border-amber-300 dark:border-amber-700">
             {t}
@@ -238,7 +238,7 @@ function AnnotationPanel({ annotation, onSave, onClose }) {
         placeholder="Notes personnelles…"
         maxLength={5000}
         rows={2}
-        className="w-full text-xs px-2.5 py-1.5 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-amber-400 resize-none"
+        className="w-full text-xs px-3 py-2 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-slate-800 text-slate-700 dark:text-slate-300 placeholder-slate-400 focus:outline-none focus:ring-1 focus:ring-amber-400 resize-none"
       />
       <div className="flex items-center justify-end gap-2 mt-1.5">
         <button onClick={onClose} className="text-[11px] text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors">
@@ -251,7 +251,7 @@ function AnnotationPanel({ annotation, onSave, onClose }) {
             onSave({ notes, tags: finalTags })
             onClose()
           }}
-          className="inline-flex items-center gap-1 text-[11px] px-2.5 py-1 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-medium transition-colors"
+          className="inline-flex items-center gap-1 text-[11px] px-3 py-1 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-medium transition-colors"
         >
           <Check size={10} /> Enregistrer
         </button>
@@ -364,7 +364,7 @@ function ContradictionDialog({ article, onClose }) {
             <div className="text-slate-500 animate-pulse">Connexion en cours…</div>
           )}
           {!done && !error && logs.length > 0 && (
-            <div className="flex items-center gap-1.5 mt-1 text-slate-500">
+            <div className="flex items-center gap-2 mt-1 text-slate-500">
               <span className="w-1.5 h-1.5 rounded-full bg-blue-400 animate-pulse" />
               En cours…
             </div>
@@ -381,7 +381,7 @@ function ContradictionDialog({ article, onClose }) {
             {done ? 'Analyse terminée' : error ? 'Erreur' : 'Analyse en cours…'}
           </span>
           <button onClick={onClose}
-            className="text-xs px-3 py-1.5 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300 transition-colors">
+            className="text-xs px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-600 dark:text-slate-300 transition-colors">
             Fermer
           </button>
         </div>
@@ -402,7 +402,7 @@ function IAPickerModal({ providers, onPick, onClose }) {
         <div className="flex flex-col gap-2">
           {providers.map(p => (
             <button key={p} onClick={() => onPick(p)}
-              className="w-full px-4 py-2.5 rounded-xl text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white transition-colors">
+              className="w-full px-4 py-3 rounded-xl text-sm font-medium bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] text-white transition-colors">
               {LABELS[p] ?? p}
             </button>
           ))}
@@ -540,12 +540,12 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
         <div className="mb-2">
           {/* Source + date en pill frosted */}
           <div className="flex items-center gap-2 flex-wrap mb-1">
-            <span className="inline-flex items-center text-[11px] font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-black/5 dark:bg-white/10 backdrop-blur-sm px-2.5 py-0.5 rounded-full">
+            <span className="inline-flex items-center text-[11px] font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wider bg-black/5 dark:bg-white/10 backdrop-blur-sm px-3 py-0.5 rounded-full">
               {article['Sources'] ?? '—'}
             </span>
             {date && <span className="text-xs text-slate-400 dark:text-slate-500">{date}{time ? <> · <span>{time}</span></> : ''}</span>}
             {hasEntities && (
-              <span className="inline-flex items-center gap-1 text-[11px] text-[#5856D6] dark:text-[#5E5CE6] bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
+              <span className="inline-flex items-center gap-1 text-[11px] text-[#5856D6] dark:text-[#5E5CE6] bg-violet-50 dark:bg-violet-900/30 px-2 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
                 <Tag size={9} />{count} entités
               </span>
             )}
@@ -558,7 +558,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
             </h3>
           )}
           {/* Boutons d'action — pleine largeur sous le titre */}
-          <div className="flex items-center gap-0.5 mt-2 -ml-1.5">
+          <div className="flex items-center gap-1 mt-2 -ml-2">
             {onAnnotate && url && (
               <>
                 <button onClick={() => toggle('is_important')}
@@ -663,7 +663,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
 
         {/* Affichage note si fermé */}
         {!noteOpen && hasNote && (
-          <div className="mt-2 px-3 py-1.5 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/60">
+          <div className="mt-2 px-3 py-2 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800/60">
             <p className="text-xs text-amber-800 dark:text-amber-200 leading-relaxed line-clamp-2">
               {annotation.notes}
             </p>
@@ -672,7 +672,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, a
 
         {/* Badges rapports exportés */}
         {allRapports.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 mt-2">
+          <div className="flex flex-wrap gap-2 mt-2">
             {allRapports.map((rap, idx) => (
               <span
                 key={idx}
@@ -731,7 +731,7 @@ function TimelineItem({ article }) {
           </span>
           {date && <span className="text-xs text-slate-400 dark:text-slate-500">{date}{time ? <> · <span>{time}</span></> : ''}</span>}
           {hasEntities && (
-            <span className="inline-flex items-center gap-1 text-[11px] text-[#5856D6] dark:text-[#5E5CE6] bg-violet-50 dark:bg-violet-900/30 px-1.5 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
+            <span className="inline-flex items-center gap-1 text-[11px] text-[#5856D6] dark:text-[#5E5CE6] bg-violet-50 dark:bg-violet-900/30 px-2 py-0.5 rounded-full border border-violet-200 dark:border-violet-800">
               <Tag size={9} />{count}
             </span>
           )}
@@ -965,18 +965,18 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
   }, [displayedArticles, viewStyle])
 
   // Calcule l'URL du premier article non lu à l'ouverture du fichier.
-  // Intentionnellement limité à [articles] : on ne recalcule PAS quand les annotations changent
-  // pour éviter un nouveau défilement automatique à chaque marque-lu.
-  // useMemo (synchrone) garantit que la valeur est disponible dès le rendu courant,
-  // ce qui permet à ArticleCard d'appliquer data-first-unread avant que les effets de scroll s'exécutent.
+  // Dépend de [articles, annotations] : on attend que les annotations soient chargées
+  // (annotations === null tant que le fetch initial n'est pas terminé) pour éviter de
+  // défiler vers le premier article de la liste quand toutes les annotations semblent absentes.
+  // Le re-défilement automatique à chaque marque-lu est bloqué par hasScrolledRef.current.
   const firstUnreadUrl = useMemo(() => {
-    if (!articles) return null
+    if (!articles || annotations === null) return null
     const sorted = [...articles].sort(
       (a, b) => toTimestamp(b['Date de publication']) - toTimestamp(a['Date de publication'])
     )
-    const first = sorted.find(a => !annotationsRef.current?.[a['URL']]?.is_read)
+    const first = sorted.find(a => !annotations?.[a['URL']]?.is_read)
     return first?.['URL'] ?? null
-  }, [articles]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [articles, annotations]) // eslint-disable-line react-hooks/exhaustive-deps
 
   // Réinitialise les filtres et le flag de scroll à chaque changement de fichier
   useEffect(() => {
@@ -1119,7 +1119,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
 
           {/* Barre filtre : favoris ── */}
           {mobileFilterMode === 'star' && (
-            <div className="flex items-center gap-3 px-4 py-2.5 bg-amber-50 dark:bg-amber-900/20 border-b-2 border-amber-400 shadow-md">
+            <div className="flex items-center gap-3 px-4 py-3 bg-amber-50 dark:bg-amber-900/20 border-b-2 border-amber-400 shadow-md">
               <Star size={15} className="text-amber-500 shrink-0" />
               <span className="flex-1 text-sm font-medium text-amber-700 dark:text-amber-300">
                 Favoris uniquement
@@ -1138,12 +1138,12 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
           {mobileFilterMode === 'source' && (
             <div className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-slate-900 border-b-2 border-slate-400 dark:border-slate-500 shadow-md">
               <Newspaper size={14} className="text-slate-400 shrink-0" />
-              <div className="flex-1 flex items-center gap-1.5 overflow-x-auto py-0.5" style={{ scrollbarWidth: 'none' }}>
+              <div className="flex-1 flex items-center gap-2 overflow-x-auto py-0.5" style={{ scrollbarWidth: 'none' }}>
                 {availableSources.map(([src, count]) => {
                   const active = selectedSources.has(src)
                   return (
                     <button key={src} onClick={() => toggleSource(src)}
-                      className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border shrink-0 transition-all active:scale-95 ${
+                      className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[11px] font-medium border shrink-0 transition-all active:scale-95 ${
                         active
                           ? 'bg-slate-700 dark:bg-slate-200 text-white dark:text-slate-800 border-slate-700 dark:border-slate-200'
                           : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600'
@@ -1167,13 +1167,13 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
           {mobileFilterMode === 'entity' && (
             <div className="flex items-center gap-2 px-3 py-2 bg-white dark:bg-slate-900 border-b-2 border-violet-400 dark:border-violet-500 shadow-md">
               <Filter size={14} className="text-violet-400 shrink-0" />
-              <div className="flex-1 flex items-center gap-1.5 overflow-x-auto py-0.5" style={{ scrollbarWidth: 'none' }}>
+              <div className="flex-1 flex items-center gap-2 overflow-x-auto py-0.5" style={{ scrollbarWidth: 'none' }}>
                 {availableTypes.map(([type, count]) => {
                   const colors = CHIP_COLORS[type] ?? FALLBACK_CHIP
                   const active = selectedTypes.has(type)
                   return (
                     <button key={type} onClick={() => toggleType(type)}
-                      className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-[11px] font-medium border shrink-0 transition-all active:scale-95 ${active ? colors.on : colors.idle}`}>
+                      className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-[11px] font-medium border shrink-0 transition-all active:scale-95 ${active ? colors.on : colors.idle}`}>
                       {type}
                       <span className={`tabular-nums text-[11px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
                     </button>
@@ -1191,7 +1191,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
 
           {/* Barre filtre : rapport Obsidian ── */}
           {mobileFilterMode === 'obsidian' && (
-            <div className="flex items-center gap-3 px-4 py-2.5 bg-violet-50 dark:bg-violet-900/20 border-b-2 border-violet-500 shadow-md">
+            <div className="flex items-center gap-3 px-4 py-3 bg-violet-50 dark:bg-violet-900/20 border-b-2 border-violet-500 shadow-md">
               <BookOpen size={15} className="text-violet-500 shrink-0" />
               <span className="flex-1 text-sm font-medium text-violet-700 dark:text-violet-300">
                 Rapport Obsidian
@@ -1208,7 +1208,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
 
           {/* Barre filtre : articles masqués ── */}
           {mobileFilterMode === 'hidden' && (
-            <div className="flex items-center gap-3 px-4 py-2.5 bg-slate-100 dark:bg-slate-800/60 border-b-2 border-slate-400 dark:border-slate-500 shadow-md">
+            <div className="flex items-center gap-3 px-4 py-3 bg-slate-100 dark:bg-slate-800/60 border-b-2 border-slate-400 dark:border-slate-500 shadow-md">
               <EyeOff size={15} className="text-slate-500 shrink-0" />
               <span className="flex-1 text-sm font-medium text-slate-700 dark:text-slate-300">
                 Articles masqués
@@ -1258,7 +1258,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
               <button
                 key={key}
                 onClick={() => setAnnotFilter(key)}
-                className={`px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors ${
+                className={`px-3 py-2 rounded-lg text-xs font-medium border transition-colors ${
                   annotFilter === key
                     ? 'bg-amber-500 text-white border-amber-600'
                     : 'bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-amber-400 dark:hover:border-amber-600 hover:text-amber-600 dark:hover:text-amber-400'
@@ -1275,7 +1275,7 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
           <button
             onClick={() => setFilterObsidian(v => !v)}
             title={filterObsidian ? 'Désactiver le filtre Obsidian' : `Afficher uniquement les ${obsidianCount} article${obsidianCount > 1 ? 's' : ''} avec rapport Obsidian`}
-            className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-colors shrink-0 ${
+            className={`inline-flex items-center gap-2 px-3 py-2 rounded-lg text-xs font-medium border transition-colors shrink-0 ${
               filterObsidian
                 ? 'bg-violet-600 text-white border-violet-700'
                 : 'bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-violet-400 dark:hover:border-violet-600 hover:text-[#5856D6] dark:hover:text-[#5E5CE6]'
@@ -1300,22 +1300,22 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
           {/* Bascule vue grille / timeline */}
           <div className="flex items-center rounded-lg border border-slate-200 dark:border-slate-700 overflow-hidden shrink-0">
             <button onClick={() => setViewStyle('grid')} title="Vue grille"
-              className={`px-2.5 py-2 transition-colors ${viewStyle === 'grid' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
+              className={`px-3 py-2 transition-colors ${viewStyle === 'grid' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
               <LayoutGrid size={13} />
             </button>
             <button onClick={() => setViewStyle('large')} title="Vue large (1 article / ligne)"
-              className={`px-2.5 py-2 transition-colors ${viewStyle === 'large' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
+              className={`px-3 py-2 transition-colors ${viewStyle === 'large' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
               <LayoutList size={13} />
             </button>
             <button onClick={() => setViewStyle('timeline')} title="Vue timeline"
-              className={`px-2.5 py-2 transition-colors ${viewStyle === 'timeline' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
+              className={`px-3 py-2 transition-colors ${viewStyle === 'timeline' ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white' : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'}`}>
               <AlignLeft size={13} />
             </button>
           </div>
 
           {/* Export */}
           <button onClick={handleExport} title={`Exporter ${displayedArticles.length} article(s) en JSON`}
-            className="px-2.5 py-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 hover:text-[#007AFF] dark:hover:text-[#0A84FF] hover:border-[#007AFF] dark:hover:border-[#0A84FF] bg-white dark:bg-slate-800 transition-all shrink-0">
+            className="px-3 py-2 rounded-lg border border-slate-200 dark:border-slate-700 text-slate-500 dark:text-slate-400 hover:text-[#007AFF] dark:hover:text-[#0A84FF] hover:border-[#007AFF] dark:hover:border-[#0A84FF] bg-white dark:bg-slate-800 transition-all shrink-0">
             <Download size={13} />
           </button>
         </div>
@@ -1326,12 +1326,12 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
         <div className="hidden md:block mb-3 bg-white/70 dark:bg-slate-800/40 backdrop-blur-sm border border-white/40 dark:border-slate-700/60 rounded-xl overflow-hidden">
           <button
             onClick={() => setTypesOpen(v => !v)}
-            className="w-full flex items-center gap-2 px-3 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-700/40 transition-colors"
+            className="w-full flex items-center gap-2 px-3 py-3 hover:bg-slate-50 dark:hover:bg-slate-700/40 transition-colors"
           >
             <Filter size={12} className="text-slate-400 dark:text-slate-500 shrink-0" />
             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Type d'entité</span>
             {selectedTypes.size > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-[#007AFF] dark:text-[#0A84FF]">{selectedTypes.size}</span>
+              <span className="ml-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-[#007AFF] dark:text-[#0A84FF]">{selectedTypes.size}</span>
             )}
             {selectedTypes.size > 0 && (
               <span
@@ -1346,14 +1346,14 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
             {typesOpen ? <ChevronUp size={12} className="text-slate-400 shrink-0" /> : <ChevronDown size={12} className="text-slate-400 shrink-0" />}
           </button>
           {typesOpen && (
-            <div className="px-3 pb-3 pt-1 flex flex-wrap gap-1.5">
+            <div className="px-3 pb-3 pt-1 flex flex-wrap gap-2">
               {availableTypes.map(([type, count]) => {
                 const colors = CHIP_COLORS[type] ?? FALLBACK_CHIP
                 const active = selectedTypes.has(type)
                 return (
                   <button key={type} onClick={() => toggleType(type)}
                     title={`Filtrer les articles avec des entités de type ${type}`}
-                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-all hover:scale-105 active:scale-95 ${active ? colors.on : colors.idle}`}>
+                    className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-[11px] font-medium border transition-all hover:scale-105 active:scale-95 ${active ? colors.on : colors.idle}`}>
                     {type}
                     <span className={`tabular-nums text-[11px] ${active ? 'opacity-80' : 'opacity-55'}`}>{count}</span>
                   </button>
@@ -1369,12 +1369,12 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
         <div className="hidden md:block mb-5 bg-white/70 dark:bg-slate-800/40 backdrop-blur-sm border border-white/40 dark:border-slate-700/60 rounded-xl overflow-hidden">
           <button
             onClick={() => setSourcesOpen(v => !v)}
-            className="w-full flex items-center gap-2 px-3 py-2.5 hover:bg-slate-50 dark:hover:bg-slate-700/40 transition-colors"
+            className="w-full flex items-center gap-2 px-3 py-3 hover:bg-slate-50 dark:hover:bg-slate-700/40 transition-colors"
           >
             <Newspaper size={12} className="text-slate-400 dark:text-slate-500 shrink-0" />
             <span className="text-xs font-medium text-slate-500 dark:text-slate-400">Source</span>
             {selectedSources.size > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-[#007AFF] dark:text-[#0A84FF]">{selectedSources.size}</span>
+              <span className="ml-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-blue-100 dark:bg-blue-900/50 text-[#007AFF] dark:text-[#0A84FF]">{selectedSources.size}</span>
             )}
             {selectedSources.size > 0 && (
               <span
@@ -1389,12 +1389,12 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
             {sourcesOpen ? <ChevronUp size={12} className="text-slate-400 shrink-0" /> : <ChevronDown size={12} className="text-slate-400 shrink-0" />}
           </button>
           {sourcesOpen && (
-            <div className="px-3 pb-3 pt-1 flex flex-wrap gap-1.5">
+            <div className="px-3 pb-3 pt-1 flex flex-wrap gap-2">
               {availableSources.map(([src, count]) => {
                 const active = selectedSources.has(src)
                 return (
                   <button key={src} onClick={() => toggleSource(src)}
-                    className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-[11px] font-medium border transition-all hover:scale-105 active:scale-95 ${
+                    className={`inline-flex items-center gap-2 px-3 py-1 rounded-full text-[11px] font-medium border transition-all hover:scale-105 active:scale-95 ${
                       active
                         ? 'bg-slate-700 dark:bg-slate-200 text-white dark:text-slate-800 border-slate-700 dark:border-slate-200'
                         : 'bg-slate-100 dark:bg-slate-700/60 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-600 hover:border-slate-400 dark:hover:border-slate-400'

--- a/viewer/src/components/FileViewer.jsx
+++ b/viewer/src/components/FileViewer.jsx
@@ -63,7 +63,7 @@ function ImageGallery({ content }) {
         <span className="text-sm font-semibold text-slate-700 dark:text-slate-300">
           Images
         </span>
-        <span className="text-xs text-slate-500 dark:text-slate-600 bg-slate-100 dark:bg-slate-800 px-1.5 py-0.5 rounded-full">
+        <span className="text-xs text-slate-500 dark:text-slate-600 bg-slate-100 dark:bg-slate-800 px-2 py-0.5 rounded-full">
           {visible.length}
         </span>
       </div>
@@ -89,7 +89,7 @@ function ImageGallery({ content }) {
             </div>
             {/* Méta */}
             {(img.source || img.date) && (
-              <div className="px-2.5 py-2">
+              <div className="px-3 py-2">
                 {img.source && (
                   <div className="text-[11px] text-slate-700 dark:text-slate-300 truncate font-medium">{img.source}</div>
                 )}
@@ -336,9 +336,9 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
         style={{ bottom: 'calc(4rem + env(safe-area-inset-bottom))' }}
       >
         {/* Fil d'Ariane — desktop uniquement */}
-        <div className="hidden md:flex items-center gap-0.5 min-w-0 flex-1 text-xs text-slate-400 dark:text-slate-500 overflow-hidden">
+        <div className="hidden md:flex items-center gap-1 min-w-0 flex-1 text-xs text-slate-400 dark:text-slate-500 overflow-hidden">
           {pathParts.map((part, i) => (
-            <span key={i} className="flex items-center gap-0.5 shrink-0">
+            <span key={i} className="flex items-center gap-1 shrink-0">
               {i > 0 && <ChevronRight size={10} className="text-slate-300 dark:text-slate-700" />}
               <span className={i === pathParts.length - 1 ? 'text-slate-700 dark:text-slate-300 font-medium' : ''}>
                 {part}
@@ -375,7 +375,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
             <button
               onClick={() => setViewMode('articles')}
               title="Vue articles annotés"
-              className={`flex items-center gap-1 px-2 py-1.5 text-xs transition-colors ${
+              className={`flex items-center gap-1 px-2 py-2 text-xs transition-colors ${
                 viewMode === 'articles'
                   ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'
@@ -387,7 +387,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
             <button
               onClick={() => setViewMode('json')}
               title="Vue JSON brut"
-              className={`flex items-center gap-1 px-2 py-1.5 text-xs transition-colors ${
+              className={`flex items-center gap-1 px-2 py-2 text-xs transition-colors ${
                 viewMode === 'json'
                   ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'text-slate-500 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-700'
@@ -405,7 +405,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
         <div ref={exportRef} className="hidden shrink-0">
           <button
             onClick={() => setExportOpen(v => !v)}
-            className={`flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium rounded-lg border transition-colors ${
+            className={`flex items-center gap-1 px-3 py-2 text-xs font-medium rounded-lg border transition-colors ${
               exportOpen
                 ? 'bg-blue-50 dark:bg-blue-900/30 border-blue-300 dark:border-blue-700 text-blue-700 dark:text-blue-300'
                 : 'bg-slate-100 dark:bg-slate-700/70 border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300'
@@ -417,11 +417,11 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
           </button>
 
           {exportOpen && (
-            <div className="absolute bottom-full mb-2 right-0 glass-panel rounded-xl border border-white/40 dark:border-slate-700/60 shadow-2xl z-[200] py-1.5 min-w-[9.5rem] overflow-hidden">
+            <div className="absolute bottom-full mb-2 right-0 glass-panel rounded-xl border border-white/40 dark:border-slate-700/60 shadow-2xl z-[200] py-2 min-w-[9.5rem] overflow-hidden">
               {/* JSON brut */}
               <button
                 onClick={() => { onDownload(); setExportOpen(false) }}
-                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
               >
                 <Download size={13} className="text-blue-500 shrink-0" />
                 <span>JSON</span>
@@ -433,7 +433,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
                   href={`/api/export/csv?path=${encodeURIComponent(file.path)}`}
                   download
                   onClick={() => setExportOpen(false)}
-                  className="flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
+                  className="flex items-center gap-3 px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
                 >
                   <Download size={13} className="text-green-500 shrink-0" />
                   <span>CSV</span>
@@ -446,7 +446,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
                   href={`/api/export/xlsx?path=${encodeURIComponent(file.path)}`}
                   download
                   onClick={() => setExportOpen(false)}
-                  className="flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
+                  className="flex items-center gap-3 px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
                 >
                   <Download size={13} className="text-emerald-500 shrink-0" />
                   <span>XLSX</span>
@@ -456,7 +456,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
               {/* PDF / impression */}
               <button
                 onClick={() => { window.print(); setExportOpen(false) }}
-                className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
+                className="w-full flex items-center gap-3 px-4 py-3 text-sm text-slate-700 dark:text-slate-200 hover:bg-slate-100/70 dark:hover:bg-slate-700/70 active:bg-slate-200/70 transition-colors"
               >
                 <Printer size={13} className="text-purple-500 shrink-0" />
                 <span>PDF</span>
@@ -469,7 +469,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
         <button
           onClick={onDownload}
           title="Télécharger le fichier JSON"
-          className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] active:bg-blue-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+          className="hidden md:flex items-center gap-2 px-3 py-2 bg-[#007AFF] hover:bg-[#0071EB] dark:bg-[#0A84FF] dark:hover:bg-[#1E8FFF] active:bg-blue-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
         >
           <Download size={12} />
           JSON
@@ -481,7 +481,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
               href={`/api/export/csv?path=${encodeURIComponent(file.path)}`}
               download
               title="Exporter en CSV"
-              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-green-700 hover:bg-green-600 active:bg-green-800 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+              className="hidden md:flex items-center gap-2 px-3 py-2 bg-green-700 hover:bg-green-600 active:bg-green-800 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
             >
               <Download size={12} /> CSV
             </a>
@@ -489,7 +489,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
               href={`/api/export/xlsx?path=${encodeURIComponent(file.path)}`}
               download
               title="Exporter en Excel (XLSX)"
-              className="hidden md:flex items-center gap-1.5 px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 active:bg-emerald-800 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+              className="hidden md:flex items-center gap-2 px-3 py-2 bg-emerald-700 hover:bg-emerald-600 active:bg-emerald-800 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
             >
               <Download size={12} /> XLSX
             </a>
@@ -500,7 +500,7 @@ export default function FileViewer({ file, content, loading, loadingProgress, on
         <button
           onClick={() => window.print()}
           title="Imprimer / Exporter en PDF"
-          className="flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-500 active:bg-purple-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
+          className="flex items-center gap-2 px-3 py-2 bg-purple-600 hover:bg-purple-500 active:bg-purple-700 text-white text-xs font-medium rounded-lg transition-colors shrink-0"
         >
           <Printer size={12} />
           <span className="hidden sm:inline">PDF</span>

--- a/viewer/src/components/Sidebar.jsx
+++ b/viewer/src/components/Sidebar.jsx
@@ -65,7 +65,7 @@ export default function Sidebar({
         </button>
       </div>
       {/* ── Filtres ── visibles sur mobile et desktop */}
-      <div className="p-3 border-b border-slate-200 dark:border-slate-700 space-y-2.5">
+      <div className="p-3 border-b border-slate-200 dark:border-slate-700 space-y-3">
         {/* Boutons type */}
         <div className="flex gap-1">
           {[
@@ -76,7 +76,7 @@ export default function Sidebar({
             <button
               key={key}
               onClick={() => onTypeFilterChange(key)}
-              className={`flex-1 py-1.5 text-hig-caption1 font-medium rounded transition-colors ${
+              className={`flex-1 py-2 text-hig-caption1 font-medium rounded transition-colors ${
                 typeFilter === key
                   ? 'bg-[#007AFF] dark:bg-[#0A84FF] text-white'
                   : 'bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-600 hover:text-slate-700 dark:hover:text-slate-200'
@@ -89,13 +89,13 @@ export default function Sidebar({
 
         {/* Recherche par nom */}
         <div className="relative">
-          <Search size={13} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+          <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
           <input
             type="text"
             value={nameSearch}
             onChange={e => onNameSearchChange(e.target.value)}
             placeholder="Filtrer par nom…"
-            className="w-full pl-8 pr-7 py-1.5 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-[#007AFF] transition-colors"
+            className="w-full pl-8 pr-7 py-2 bg-slate-100 dark:bg-slate-700 border border-slate-200 dark:border-slate-600 rounded text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-[#007AFF] transition-colors"
           />
           {nameSearch && (
             <button
@@ -130,7 +130,7 @@ export default function Sidebar({
         {grouped.map(([flux, fluxFiles]) => (
           <div key={flux}>
             {/* En-tête de groupe */}
-            <div className="sticky top-0 z-10 bg-white/95 dark:bg-slate-800/95 px-3 py-1.5 flex items-center gap-1.5 border-b border-slate-200/60 dark:border-slate-700/60 backdrop-blur-sm">
+            <div className="sticky top-0 z-10 bg-white/95 dark:bg-slate-800/95 px-3 py-2 flex items-center gap-2 border-b border-slate-200/60 dark:border-slate-700/60 backdrop-blur-sm">
               <Folder size={11} className="text-slate-400 dark:text-slate-500" />
               <span className="text-hig-caption2 font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wider truncate">
                 {flux}
@@ -145,7 +145,7 @@ export default function Sidebar({
                 <button
                   key={file.path}
                   onClick={() => onSelect(file)}
-                  className={`w-full text-left px-3 py-2.5 flex items-start gap-2.5 border-b border-slate-200/30 dark:border-slate-700/30 transition-colors ${
+                  className={`w-full text-left px-3 py-3 flex items-start gap-3 border-b border-slate-200/30 dark:border-slate-700/30 transition-colors ${
                     isSelected
                       ? 'bg-[#007AFF]/10 dark:bg-[#0A84FF]/15 border-l-2 border-l-[#007AFF] dark:border-l-[#0A84FF] pl-[10px]'
                       : 'hover:bg-slate-100/50 dark:hover:bg-slate-700/50'
@@ -156,16 +156,16 @@ export default function Sidebar({
                     : <FileText size={14} className="shrink-0 mt-0.5 text-[#007AFF] dark:text-[#0A84FF]" />
                   }
                   <div className="min-w-0 flex-1">
-                    <div className="text-xs font-medium text-slate-800 dark:text-slate-200 truncate leading-snug flex items-center gap-1.5">
+                    <div className="text-xs font-medium text-slate-800 dark:text-slate-200 truncate leading-snug flex items-center gap-2">
                       <span className="truncate">{file.name}</span>
                       {isToday(file.modified) && (
-                        <span className="shrink-0 text-[11px] font-bold uppercase tracking-wide px-1.5 py-0.5 rounded bg-orange-500 text-white leading-none">
+                        <span className="shrink-0 text-[11px] font-bold uppercase tracking-wide px-2 py-0.5 rounded bg-orange-500 text-white leading-none">
                           new
                         </span>
                       )}
                     </div>
                     <div className="flex items-center gap-2 mt-1">
-                      <span className={`text-[11px] px-1.5 rounded font-mono leading-4 ${
+                      <span className={`text-[11px] px-2 rounded font-mono leading-4 ${
                         file.type === 'json'
                           ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-400'
                           : 'bg-blue-100 dark:bg-blue-900/40 text-blue-700 dark:text-blue-400'

--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -660,7 +660,7 @@ export default function TopArticlesPanel({ onClose, annotations = {}, onAnnotate
                     rank={i + 1}
                     isCurrentPodcast={playing && currentIdx === i}
                     onEntityClick={(type, value) => setSelectedEntity({ type, value })}
-                    annotation={artUrl ? annotations[artUrl] : undefined}
+                    annotation={artUrl ? annotations?.[artUrl] : undefined}
                     onAnnotate={onAnnotate}
                     availableProviders={availableProviders}
                     onReport={a => setReportArticle(a)}


### PR DESCRIPTION
Bugfix scroll-to-first-unread :
- annotations initialisé à null (au lieu de {}) pour distinguer «pas encore chargé» de «chargé mais vide»
- handleAnnotate gère prev===null avec (prev ?? {})
- firstUnreadUrl attend annotations non-null avant de calculer → évite le scroll prématuré vers l'article 1 quand toutes les annotations semblaient absentes (race condition fetch content < fetch annotations)
- TopArticlesPanel : annotations?.[artUrl] (optional chaining)

Axe 3 — grille 8pt (112→0 violations) :
- py-1.5→py-2, px-1.5→px-2, px-2.5→px-3, py-2.5→py-3, gap-1.5→gap-2, gap-0.5→gap-1, gap-2.5→gap-3, space-y-2.5→space-y-3, py-3.5→py-4
- Fichiers : Sidebar, AlertsPanel, FileViewer, App (navbar + mobile drawer), ArticleListViewer (cards, toolbar, filtres, badges, actions)