### PR TITLE
fix(direct): articles immédiats + accessibilité mobile

### DIFF
--- a/viewer/routes/rss_direct.py
+++ b/viewer/routes/rss_direct.py
@@ -159,8 +159,20 @@ def api_rss_direct_stream():
             articles = _fetch_feed_articles(feed_url)
 
             if feed_url not in last_seen:
-                # Premier passage : mémoriser les URLs existantes sans les émettre
+                # Premier passage : émettre les 3 articles les plus récents pour
+                # peupler immédiatement le log, puis mémoriser toutes les URLs.
                 last_seen[feed_url] = {a["url"] for a in articles}
+                recent = sorted(articles, key=lambda a: a.get("pubDateParsed", ""), reverse=True)[:3]
+                for art in reversed(recent):  # chronologique dans le log
+                    yield "data: " + json.dumps({
+                        "type":          "article",
+                        "title":         art["title"],
+                        "url":           art["url"],
+                        "pubDate":       art["pubDate"],
+                        "pubDateParsed": art["pubDateParsed"],
+                        "feedTitle":     art["feedTitle"],
+                        "description":   art["description"],
+                    }) + "\n\n"
             else:
                 seen         = last_seen[feed_url]
                 new_articles = [a for a in articles if a["url"] not in seen]

--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -697,7 +697,7 @@ function DirectMode({ onReport }) {
       </div>
 
       {/* ── Barre inférieure : article sélectionné + bouton ── */}
-      <div className="shrink-0 flex items-center gap-3 px-4 py-3" style={{ borderTop: '1px solid #30363d' }}>
+      <div className="shrink-0 flex items-center gap-3 px-4 py-3" style={{ borderTop: '1px solid #30363d', paddingBottom: 'max(12px, env(safe-area-inset-bottom))' }}>
         <div className="flex-1 min-w-0">
           {selectedEntry ? (
             <>
@@ -732,7 +732,7 @@ export default function TopArticlesPanel({ onClose, annotations = {}, onAnnotate
   const [error, setError]       = useState(null)
   const [hours, setHours]       = useState(48)
   const [topN, setTopN]         = useState(10)
-  const [isMaximized, setIsMaximized] = useState(false)
+  const [isMaximized, setIsMaximized] = useState(() => window.innerWidth < 768)
   const [selectedEntity, setSelectedEntity] = useState(null)
   const [reportArticle, setReportArticle] = useState(null)
 
@@ -895,7 +895,8 @@ export default function TopArticlesPanel({ onClose, annotations = {}, onAnnotate
         )}
 
         {/* ── Tab-bar ── */}
-        <div className="shrink-0 flex border-t border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl overflow-hidden rounded-b-2xl">
+        <div className="shrink-0 flex border-t border-slate-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/80 backdrop-blur-xl overflow-hidden rounded-b-2xl"
+          style={isMaximized ? { paddingBottom: 'env(safe-area-inset-bottom)' } : {}}>
           <button
             onClick={() => setActiveTab('top')}
             className={`flex-1 flex items-center justify-center gap-2 py-3 text-xs font-medium transition-colors ${


### PR DESCRIPTION
Problème 1 — aucun article affiché :
  Le premier passage SSE marquait tous les articles comme "vus" sans en
  émettre. L'utilisateur devait attendre un cycle complet × nb de flux.
  Fix : émet les 3 articles les plus récents de chaque flux dès le premier
  passage pour peupler immédiatement le log.

Problème 2 — option Direct non visible sur mobile :
  TopArticlesPanel s'ouvrait en mode fenêtré (non maximisé) : sur petits
  écrans la tab-bar "Direct" pouvait être tronquée.
  Fix : isMaximized initialisé à true si window.innerWidth < 768 (mobile).
  + paddingBottom safe-area-inset sur la tab-bar et la barre ◆ Article.

https://claude.ai/code/session_01NYhkswMmhjGKFx1pwCENDD