### PR TITLE
fix(direct): fallback date actuelle + scroll toujours forcé vers la s…

### DIFF
--- a/viewer/routes/rss_direct.py
+++ b/viewer/routes/rss_direct.py
@@ -164,6 +164,13 @@ def _fetch_feed_articles(feed_url: str) -> list[dict]:
     except Exception:
         return []
 
+    # Heure actuelle UTC comme fallback si la date de l'article est manquante/illisible
+    now_iso = datetime.utcnow().isoformat()
+
+    def _resolved_date(pub_date: str) -> str:
+        dt = _parse_rss_date(pub_date)
+        return dt.isoformat() if dt != datetime.min else now_iso
+
     articles = []
 
     # ── RSS 2.0 ───────────────────────────────────────────────────────────────
@@ -190,12 +197,11 @@ def _fetch_feed_articles(feed_url: str) -> list[dict]:
             desc = _strip_html(raw)[:500] or title
             if not title and not desc:
                 continue   # article sans titre ni texte → ignoré
-            dt = _parse_rss_date(pub_date)
             articles.append({
                 "title":         title or desc[:80],
                 "url":           url,
                 "pubDate":       pub_date,
-                "pubDateParsed": dt.isoformat() if dt != datetime.min else None,
+                "pubDateParsed": _resolved_date(pub_date),
                 "description":   desc,
                 "feedTitle":     feed_title,
             })
@@ -220,12 +226,11 @@ def _fetch_feed_articles(feed_url: str) -> list[dict]:
         desc  = _strip_html(raw)[:500] or title
         if not url or (not title and not desc):
             continue   # article sans URL ou sans titre ni texte → ignoré
-        dt = _parse_rss_date(pub_date)
         articles.append({
             "title":         title or desc[:80],
             "url":           url,
             "pubDate":       pub_date,
-            "pubDateParsed": dt.isoformat() if dt != datetime.min else None,
+            "pubDateParsed": _resolved_date(pub_date),
             "description":   desc,
             "feedTitle":     feed_title,
         })

--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -562,9 +562,8 @@ function DirectMode({ onReport }) {
   const [loadingArticle, setLoadingArticle] = useState(false)
   const [keywords,       setKeywords]       = useState([])
   const esRef         = useRef(null)
-  const logRef        = useRef(null)
-  const endRef        = useRef(null)
-  const autoScrollRef = useRef(true)
+  const logRef = useRef(null)
+  const endRef = useRef(null)
 
   // Chargement des mots-clés une seule fois
   useEffect(() => {
@@ -617,18 +616,12 @@ function DirectMode({ onReport }) {
     return () => es.close()
   }, [interval, paused]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Auto-scroll fluide vers le dernier élément à chaque nouvel article
+  // Scroll toujours forcé vers la sentinelle de fin à chaque nouvel article
   useEffect(() => {
-    if (autoScrollRef.current && endRef.current) {
+    if (endRef.current) {
       endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' })
     }
   }, [logEntries])
-
-  const handleLogScroll = () => {
-    if (!logRef.current) return
-    const { scrollTop, scrollHeight, clientHeight } = logRef.current
-    autoScrollRef.current = scrollTop + clientHeight >= scrollHeight - 40
-  }
 
   const openArticle = async () => {
     if (!selectedEntry || loadingArticle) return
@@ -709,7 +702,7 @@ function DirectMode({ onReport }) {
       </div>
 
       {/* ── Log ── */}
-      <div ref={logRef} onScroll={handleLogScroll}
+      <div ref={logRef}
         className="flex-1 overflow-y-scroll p-3 pb-2"
         style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace', fontSize: '12px', WebkitOverflowScrolling: 'touch' }}>
         {logEntries.length === 0 && !scanning && (
@@ -717,11 +710,10 @@ function DirectMode({ onReport }) {
             Initialisation du Direct — les nouveaux articles apparaîtront ici
           </div>
         )}
-        {sortedEntries.map((entry, i) => {
+        {sortedEntries.map((entry) => {
           const isKw = matchesKeywords(entry.title, keywords)
           return (
-          <div key={entry._id ?? i}
-            ref={i === sortedEntries.length - 1 ? endRef : null}
+          <div key={entry._id}
             onClick={() => setSelectedEntry(e => e?._id === entry._id ? null : entry)}
             className="flex items-start gap-2 px-2 py-[3px] rounded cursor-pointer select-none"
             style={{
@@ -742,6 +734,8 @@ function DirectMode({ onReport }) {
           </div>
           )
         })}
+        {/* Sentinelle : cible du scroll automatique après chaque nouvel article */}
+        <div ref={endRef} />
       </div>
 
       {/* ── Barre inférieure : article sélectionné + bouton ── */}


### PR DESCRIPTION
…entinelle

Date CNN :
- Si aucun format ne parse (ex: format CNN inconnu), pubDateParsed = heure UTC actuelle → plus jamais de --:-- dans la liste
- _resolved_date() centralise la logique : date parsée ou datetime.utcnow()
- La sentinelle de tri (pubDateParsed non null) place ces articles en tête du prochain cycle (les plus récents en bas de liste)

Scroll forcé :
- Suppression de autoScrollRef : le scroll vers la sentinelle est TOUJOURS déclenché à chaque ajout d'article, sans exception
- <div ref={endRef} /> sentinelle fixe après la liste → cible stable pour scrollIntoView({ behavior: 'smooth', block: 'end' })
- Suppression de onScroll/handleLogScroll devenus inutiles
- Utilisation de entry._id comme key React (stable, pas d'index i)

https://claude.ai/code/session_01NYhkswMmhjGKFx1pwCENDD