### PR TITLE
fix(direct): isolation: isolate sur la carte pour que EntityArticlePa…

### DIFF
--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -952,7 +952,7 @@ function DirectMode({ onReport }) {
 
       {/* ── Carte monde (desktop uniquement — 45% de la hauteur disponible) ── */}
       {mapVisible && (
-        <div className="shrink-0" style={{ height: '45%', minHeight: 180, borderBottom: '1px solid #30363d' }}>
+        <div className="shrink-0" style={{ height: '45%', minHeight: 180, borderBottom: '1px solid #30363d', isolation: 'isolate' }}>
           <DirectMapOverlay markers={mapMarkers} onEntityClick={(type, name) => setSelectedEntityFromMap({ type, value: name })} />
         </div>
       )}


### PR DESCRIPTION
…nel passe au-dessus

Les panes Leaflet ont des z-index internes jusqu'à 700 (markers: 600, tooltips: 650, popups: 700) qui masquaient EntityArticlePanel (z-60/z-61). isolation: 'isolate' crée un nouveau contexte de stacking contenant les z-index Leaflet, ce qui permet à EntityArticlePanel de s'afficher correctement au-dessus.

https://claude.ai/code/session_01NYhkswMmhjGKFx1pwCENDD