### PR TITLE
feat: système auto-apprenant — 8 axes d'auto-optimisation

### DIFF
--- a/archives/crontab
+++ b/archives/crontab
@@ -55,6 +55,24 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Enrichissement crédibilité sources (WHOIS + transparence + MBFC) : mensuel, 1er du mois à 4h30
 # --sync : synchronise d'abord le registre, puis enrichit les sources manquantes de données v2
 30 4 1 * * root cd /app && python3 scripts/enrich_source_credibility.py --sync 2>&1 | tee -a /app/rapports/cron_enrich_credibility.log
+
+# ─── Système auto-apprenant ────────────────────────────────────────────────────
+# Archive l'état des quotas du jour précédent dans data/quota_history/YYYY-MM-DD.json
+# (doit s'exécuter après le reset à 00h01, avant le prochain enregistrement)
+5 0 * * * root cd /app && python3 scripts/archive_quota_state.py 2>&1 | tee -a /app/rapports/cron_archive_quota.log
+# Mise à jour des scores de qualité des articles dans article_index.json
+# Exécuté à 4h00 (après backup à 1h, NER à 2h, images à 2h30, sentiment à 3h)
+0 4 * * * root cd /app && python3 scripts/update_quality_scores.py 2>&1 | tee -a /app/rapports/cron_quality_scores.log
+# Calibration automatique des seuils d'alerte (après trend_detector à 7h00)
+15 7 * * * root cd /app && python3 scripts/calibrate_alerts.py 2>&1 | tee -a /app/rapports/cron_calibrate_alerts.log
+# Optimisation hebdomadaire des poids de scoring (chaque lundi à 5h30)
+30 5 * * 1 root cd /app && python3 scripts/optimize_scoring_weights.py 2>&1 | tee -a /app/rapports/cron_scoring_weights.log
+# Optimisation hebdomadaire des quotas journaliers (chaque lundi à 5h45)
+45 5 * * 1 root cd /app && python3 scripts/optimize_quota.py 2>&1 | tee -a /app/rapports/cron_optimize_quota.log
+# Détection de dérive des mots-clés : dernier jour du mois à 5h15 (avant radar_wudd à 5h00)
+15 5 28-31 * * root [ "$(date -d tomorrow +\%d)" = "01" ] && cd /app && python3 scripts/keyword_drift_detector.py 2>&1 | tee -a /app/rapports/cron_keyword_drift.log
+# Performance empirique des sources : mensuel, 1er du mois à 4h45
+45 4 1 * * root cd /app && python3 scripts/update_source_performance.py 2>&1 | tee -a /app/rapports/cron_source_performance.log
 # Briefing exécutif hebdomadaire : chaque lundi à 6h30 (après trend_detector du lundi matin)
 # Synthèse IA : top entités, articles scorés, tendances — rapports/markdown/_BRIEFING_/
 30 6 * * 1 root cd /app && python3 scripts/generate_briefing.py --period weekly 2>&1 | tee -a /app/rapports/cron_briefing.log

--- a/config/scoring_weights.json
+++ b/config/scoring_weights.json
@@ -1,0 +1,6 @@
+{
+  "freshness": 0.35,
+  "entities": 0.25,
+  "keywords": 0.25,
+  "completeness": 0.15
+}

--- a/scripts/archive_quota_state.py
+++ b/scripts/archive_quota_state.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Archive l'état des quotas du jour précédent dans data/quota_history/.
+
+Doit s'exécuter après le reset des quotas (00:01) pour capturer la journée
+qui vient de se terminer.
+
+Usage :
+    python3 scripts/archive_quota_state.py [--dry-run]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.quota_optimizer import archive_today
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Archive quota_state.json quotidiennement.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    ok = archive_today(dry_run=args.dry_run)
+    if ok:
+        default_logger.info("[archive_quota] État des quotas archivé avec succès.")
+    else:
+        default_logger.info("[archive_quota] Rien à archiver (état absent ou date incorrecte).")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/calibrate_alerts.py
+++ b/scripts/calibrate_alerts.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Auto-calibration quotidienne des seuils d'alerte.
+
+Met à jour les compteurs de suivi post-alerte, puis ajuste les seuils
+dans config/alert_rules.json si le taux de faux positifs le justifie.
+
+Usage :
+    python3 scripts/calibrate_alerts.py [--dry-run]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.alert_calibrator import update_follow_up_counts, calibrate
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Calibre les seuils d'alerte.")
+    parser.add_argument("--dry-run", action="store_true", help="Simulation sans écriture")
+    args = parser.parse_args()
+
+    default_logger.info("[calibrate_alerts] Mise à jour des compteurs de suivi…")
+    n_updated = update_follow_up_counts()
+    default_logger.info(f"[calibrate_alerts] {n_updated} alertes mises à jour.")
+
+    default_logger.info("[calibrate_alerts] Calibration des seuils…")
+    result = calibrate(dry_run=args.dry_run)
+
+    stats = result.get("stats", {})
+    default_logger.info(
+        f"[calibrate_alerts] {stats.get('alerts_analyzed', 0)} alertes analysées, "
+        f"taux FP = {stats.get('fp_rate', 0):.0%}"
+    )
+    default_logger.info(f"[calibrate_alerts] {result.get('reason', '')}")
+
+    if result.get("applied"):
+        old = result.get("old_thresholds", {})
+        new = result.get("new_thresholds", {})
+        for k in old:
+            if old.get(k) != new.get(k):
+                default_logger.info(
+                    f"[calibrate_alerts] Seuil '{k}' : {old.get(k)} → {new.get(k)}"
+                )
+        default_logger.info("[calibrate_alerts] config/alert_rules.json mis à jour.")
+    elif args.dry_run:
+        default_logger.info("[calibrate_alerts] (dry-run) Aucune écriture.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/keyword_drift_detector.py
+++ b/scripts/keyword_drift_detector.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Détecteur de dérive des mots-clés (Axe 6).
+
+Analyse sur 30 jours la pertinence de chaque keyword configuré dans
+config/keyword-to-search.json et génère un rapport Markdown avec :
+  - Keywords à faible pertinence (suggestion de suppression)
+  - Keywords redondants entre eux (suggestion de fusion)
+  - Entités émergentes non couvertes par les keywords actuels
+
+Sortie : rapports/markdown/_WUDD.AI_/keyword_drift_YYYY-MM.md
+
+Usage :
+    python3 scripts/keyword_drift_detector.py [--dry-run] [--days N]
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.date_utils import parse_article_date
+
+
+def _load_keywords() -> list[dict]:
+    kw_file = _PROJECT_ROOT / "config" / "keyword-to-search.json"
+    if not kw_file.exists():
+        return []
+    try:
+        return json.loads(kw_file.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+
+
+def _flat_terms(kw_entry: dict) -> list[str]:
+    """Extrait tous les termes d'une entrée keyword."""
+    terms = []
+    for field in ("keyword", "or", "and"):
+        v = kw_entry.get(field)
+        if isinstance(v, list):
+            terms.extend([t.lower() for t in v if isinstance(t, str)])
+        elif isinstance(v, str):
+            terms.append(v.lower())
+    return terms
+
+
+def _jaccard(a: set, b: set) -> float:
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    union = len(a | b)
+    return inter / union if union > 0 else 0.0
+
+
+def analyse_keyword_drift(days: int = 30) -> dict:
+    """Analyse la pertinence des keywords sur les N derniers jours.
+
+    Returns:
+        dict avec keywords_stats, low_relevance, redundant_pairs, emerging_entities
+    """
+    keywords = _load_keywords()
+    if not keywords:
+        return {"error": "Aucun keyword trouvé"}
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days)
+
+    # Charger les articles récents depuis data/articles-from-rss/
+    rss_dir = _PROJECT_ROOT / "data" / "articles-from-rss"
+    articles_by_keyword: dict[str, list] = {}
+    all_entities: defaultdict[str, int] = defaultdict(int)
+
+    for json_file in rss_dir.glob("*.json"):
+        keyword_name = json_file.stem
+        try:
+            articles = json.loads(json_file.read_text(encoding="utf-8", errors="replace"))
+            if not isinstance(articles, list):
+                continue
+        except Exception:
+            continue
+
+        recent = []
+        for art in articles:
+            dt = parse_article_date(art.get("Date de publication", ""))
+            if dt is None:
+                continue
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            if dt >= cutoff:
+                recent.append(art)
+                # Collecter les entités
+                for etype, vals in art.get("entities", {}).items():
+                    if isinstance(vals, list):
+                        for v in vals:
+                            all_entities[v] += 1
+
+        articles_by_keyword[keyword_name] = recent
+
+    # ── Métriques par keyword ─────────────────────────────────────────────────
+
+    kw_stats: dict[str, dict] = {}
+    for kw_entry in keywords:
+        name = kw_entry.get("keyword") or (
+            str(kw_entry.get("or", [""])[0]) if isinstance(kw_entry.get("or"), list) else ""
+        )
+        if not name:
+            continue
+
+        articles = articles_by_keyword.get(name, [])
+        n_articles = len(articles)
+        terms = set(_flat_terms(kw_entry))
+
+        # Taux de pertinence : % d'articles dont le résumé contient au moins 1 terme
+        relevant = 0
+        if articles:
+            for art in articles:
+                resume = (art.get("Résumé") or "").lower()
+                if any(t in resume for t in terms):
+                    relevant += 1
+        relevance_rate = relevant / n_articles if n_articles > 0 else 0.0
+
+        # Entités les plus fréquentes dans les articles de ce keyword
+        entity_freq: defaultdict[str, int] = defaultdict(int)
+        for art in articles:
+            for etype, vals in art.get("entities", {}).items():
+                if isinstance(vals, list):
+                    for v in vals:
+                        entity_freq[v] += 1
+        top_entities = sorted(entity_freq.items(), key=lambda x: -x[1])[:5]
+
+        kw_stats[name] = {
+            "terms": list(terms),
+            "article_count": n_articles,
+            "relevance_rate": round(relevance_rate, 3),
+            "top_entities": top_entities,
+        }
+
+    # ── Détection des keywords à faible pertinence ─────────────────────────────
+    LOW_RELEVANCE_THRESHOLD = 0.30
+    FEW_ARTICLES_THRESHOLD  = 5
+
+    low_relevance = [
+        {"keyword": k, **{m: v for m, v in s.items() if m != "top_entities"}}
+        for k, s in kw_stats.items()
+        if s["relevance_rate"] < LOW_RELEVANCE_THRESHOLD
+        or s["article_count"] < FEW_ARTICLES_THRESHOLD
+    ]
+
+    # ── Détection des keywords redondants ──────────────────────────────────────
+    REDUNDANCY_THRESHOLD = 0.50
+    redundant_pairs = []
+    kw_names = list(kw_stats.keys())
+    for i in range(len(kw_names)):
+        for j in range(i + 1, len(kw_names)):
+            a, b = kw_names[i], kw_names[j]
+            terms_a = set(kw_stats[a]["terms"])
+            terms_b = set(kw_stats[b]["terms"])
+            sim = _jaccard(terms_a, terms_b)
+            if sim >= REDUNDANCY_THRESHOLD:
+                redundant_pairs.append({
+                    "keyword_a": a,
+                    "keyword_b": b,
+                    "similarity": round(sim, 3),
+                })
+
+    # ── Entités émergentes non couvertes ───────────────────────────────────────
+    all_keyword_terms: set[str] = set()
+    for s in kw_stats.values():
+        all_keyword_terms.update(s["terms"])
+
+    # Entités fréquentes non mentionnées dans les keywords
+    emerging = [
+        {"entity": ent, "count": cnt}
+        for ent, cnt in sorted(all_entities.items(), key=lambda x: -x[1])[:50]
+        if ent.lower() not in all_keyword_terms and cnt >= 5
+    ][:15]
+
+    return {
+        "period_days": days,
+        "generated_at": now.strftime("%d/%m/%Y"),
+        "keywords_stats": kw_stats,
+        "low_relevance": low_relevance,
+        "redundant_pairs": redundant_pairs,
+        "emerging_entities": emerging,
+    }
+
+
+def _generate_markdown(analysis: dict) -> str:
+    """Génère le rapport Markdown de dérive des keywords."""
+    now_str = analysis["generated_at"]
+    days    = analysis["period_days"]
+    stats   = analysis["keywords_stats"]
+    low_rel = analysis["low_relevance"]
+    redund  = analysis["redundant_pairs"]
+    emerging = analysis["emerging_entities"]
+
+    lines = [
+        f"# Rapport de dérive des mots-clés — {now_str}",
+        "",
+        f"Analyse sur **{days} jours**. {len(stats)} keywords surveillés.",
+        "",
+        "---",
+        "",
+    ]
+
+    # Tableau de synthèse
+    lines += [
+        "## Vue d'ensemble",
+        "",
+        "| Keyword | Articles | Pertinence | Statut |",
+        "|---|---|---|---|",
+    ]
+    for kw, s in sorted(stats.items(), key=lambda x: -x[1]["relevance_rate"]):
+        rate_pct = f"{s['relevance_rate']:.0%}"
+        n = s["article_count"]
+        if s["relevance_rate"] < 0.30 or n < 5:
+            status = "⚠️ Faible"
+        elif s["relevance_rate"] > 0.70:
+            status = "✅ Pertinent"
+        else:
+            status = "🔵 Acceptable"
+        lines.append(f"| {kw} | {n} | {rate_pct} | {status} |")
+    lines.append("")
+
+    # Keywords à faible pertinence
+    if low_rel:
+        lines += ["## ⚠️ Keywords à faible pertinence (action recommandée)", ""]
+        for item in low_rel:
+            kw = item["keyword"]
+            lines.append(
+                f"- **{kw}** — {item['article_count']} articles, "
+                f"pertinence {item['relevance_rate']:.0%}"
+            )
+            lines.append(f"  → *Suggestion : réviser les termes ou supprimer ce keyword*")
+        lines.append("")
+
+    # Paires redondantes
+    if redund:
+        lines += ["## 🔁 Keywords redondants (chevauchement de termes)", ""]
+        for pair in redund:
+            lines.append(
+                f"- **{pair['keyword_a']}** ↔ **{pair['keyword_b']}** "
+                f"(similarité {pair['similarity']:.0%})"
+            )
+            lines.append("  → *Suggestion : fusionner ces deux keywords*")
+        lines.append("")
+
+    # Entités émergentes
+    if emerging:
+        lines += ["## 🆕 Entités émergentes non couvertes", ""]
+        lines.append("Ces entités sont fréquemment mentionnées mais absentes de vos keywords :")
+        lines.append("")
+        for item in emerging:
+            lines.append(f"- **{item['entity']}** ({item['count']} mentions)")
+        lines.append("")
+        lines.append(
+            "*Suggestion : envisager d'ajouter ces entités comme nouveaux keywords ou "
+            "les intégrer dans des keywords existants.*"
+        )
+        lines.append("")
+
+    lines += [
+        "---",
+        "",
+        f"*Rapport généré automatiquement par WUDD.ai — {now_str}*",
+    ]
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Détecte la dérive des mots-clés.")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--days", type=int, default=30, help="Fenêtre d'analyse en jours")
+    args = parser.parse_args()
+
+    default_logger.info(f"[keyword_drift] Analyse sur {args.days} jours…")
+    analysis = analyse_keyword_drift(days=args.days)
+
+    if "error" in analysis:
+        default_logger.error(f"[keyword_drift] {analysis['error']}")
+        sys.exit(1)
+
+    kw_stats = analysis["keywords_stats"]
+    default_logger.info(f"[keyword_drift] {len(kw_stats)} keywords analysés")
+    default_logger.info(
+        f"[keyword_drift] {len(analysis['low_relevance'])} keywords à faible pertinence"
+    )
+    default_logger.info(
+        f"[keyword_drift] {len(analysis['redundant_pairs'])} paires redondantes"
+    )
+    default_logger.info(
+        f"[keyword_drift] {len(analysis['emerging_entities'])} entités émergentes"
+    )
+
+    if args.dry_run:
+        default_logger.info("[keyword_drift] (dry-run) Aucune écriture.")
+        return
+
+    # Générer et sauvegarder le rapport
+    report_dir = _PROJECT_ROOT / "rapports" / "markdown" / "_WUDD.AI_"
+    report_dir.mkdir(parents=True, exist_ok=True)
+
+    month_str = date.today().strftime("%Y-%m")
+    report_path = report_dir / f"keyword_drift_{month_str}.md"
+
+    md_content = _generate_markdown(analysis)
+    report_path.write_text(md_content, encoding="utf-8")
+    default_logger.info(f"[keyword_drift] Rapport généré : {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/optimize_quota.py
+++ b/scripts/optimize_quota.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Optimisation hebdomadaire des quotas journaliers.
+
+Analyse les 7 derniers jours d'historique et ajuste config/quota.json
+si des keywords sont systématiquement saturés ou sous-utilisés.
+
+Usage :
+    python3 scripts/optimize_quota.py [--dry-run]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.quota_optimizer import optimize
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Optimise les quotas selon l'historique.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+
+    default_logger.info("[optimize_quota] Analyse de l'historique des quotas…")
+    result = optimize(dry_run=args.dry_run)
+
+    default_logger.info(
+        f"[optimize_quota] {result.get('history_days', 0)} jours analysés — "
+        f"{result.get('reason', '')}"
+    )
+
+    for adj in result.get("adjustments", []):
+        default_logger.info(f"[optimize_quota] {adj}")
+
+    if result.get("applied"):
+        default_logger.info("[optimize_quota] config/quota.json mis à jour.")
+    elif args.dry_run:
+        default_logger.info("[optimize_quota] (dry-run) Aucune écriture.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/optimize_scoring_weights.py
+++ b/scripts/optimize_scoring_weights.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Optimisation hebdomadaire des poids de scoring.
+
+Analyse les signaux d'engagement collectés par l'EngagementTracker et ajuste
+les poids dans config/scoring_weights.json.
+
+Usage :
+    python3 scripts/optimize_scoring_weights.py [--dry-run]
+
+Options :
+    --dry-run   Affiche les ajustements sans les appliquer
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.scoring_optimizer import optimize
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Optimise les poids de scoring selon l'engagement.")
+    parser.add_argument("--dry-run", action="store_true", help="Simulation sans écriture")
+    args = parser.parse_args()
+
+    default_logger.info("[scoring_optimizer] Démarrage de l'optimisation des poids…")
+
+    result = optimize(dry_run=args.dry_run)
+
+    if not result.get("applied") and not args.dry_run:
+        default_logger.info(f"[scoring_optimizer] Pas d'ajustement : {result.get('reason')}")
+        return
+
+    old = result.get("old_weights", {})
+    new = result.get("new_weights", {})
+    adj = result.get("adjustments", {})
+    n   = result.get("signals_count", 0)
+
+    default_logger.info(f"[scoring_optimizer] {n} signaux analysés")
+    default_logger.info("[scoring_optimizer] Poids anciens → nouveaux :")
+    for k in ("freshness", "entities", "keywords", "completeness"):
+        delta = adj.get(k, 0)
+        sign = "+" if delta >= 0 else ""
+        default_logger.info(
+            f"  {k:15s}: {old.get(k, '?'):.4f} → {new.get(k, '?'):.4f}  ({sign}{delta:.4f})"
+        )
+
+    if args.dry_run:
+        default_logger.info("[scoring_optimizer] (dry-run) Aucune écriture effectuée.")
+    else:
+        default_logger.info("[scoring_optimizer] config/scoring_weights.json mis à jour.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_quality_scores.py
+++ b/scripts/update_quality_scores.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Mise à jour des scores de qualité dans l'article_index.
+
+Recalcule le champ quality_score pour tous les articles indexés.
+Génère un rapport rapide des articles à réparer en priorité.
+
+Usage :
+    python3 scripts/update_quality_scores.py [--dry-run] [--stats-only]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.quality_monitor import update_quality_scores, get_quality_stats
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Met à jour les scores de qualité des articles.")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stats-only", action="store_true", help="Affiche les stats sans recalculer")
+    args = parser.parse_args()
+
+    if args.stats_only:
+        stats = get_quality_stats()
+        default_logger.info(f"[quality] {stats['total']} articles indexés")
+        default_logger.info(f"[quality] Score moyen : {stats['avg_score']}")
+        default_logger.info(f"[quality] Articles complets : {stats['pct_complete']}%")
+        default_logger.info(f"[quality] Répartition : {stats['by_level']}")
+        default_logger.info(f"[quality] Articles critiques à réparer : {stats['repair_needed']}")
+        return
+
+    default_logger.info("[quality] Calcul des scores de qualité…")
+    result = update_quality_scores(dry_run=args.dry_run)
+
+    default_logger.info(f"[quality] {result.get('updated', 0)}/{result.get('total', 0)} articles traités")
+    by_level = result.get("by_level", {})
+    for level, count in sorted(by_level.items(), key=lambda x: x[1], reverse=True):
+        default_logger.info(f"[quality]   {level:10s}: {count}")
+
+    if args.dry_run:
+        default_logger.info("[quality] (dry-run) Aucune écriture.")
+    elif result.get("applied"):
+        default_logger.info("[quality] article_index.json mis à jour.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_source_performance.py
+++ b/scripts/update_source_performance.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Mise à jour mensuelle des scores empiriques de performance des sources.
+
+Calcule des métriques empiriques (enrichissement, diversité, engagement)
+pour chaque source et met à jour config/sources_credibility.json.
+
+Usage :
+    python3 scripts/update_source_performance.py [--dry-run]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+
+from utils.logging import default_logger
+from utils.source_performance import run_update, compute_source_metrics
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Met à jour les scores empiriques des sources.")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--stats-only", action="store_true", help="Affiche les métriques sans mettre à jour")
+    args = parser.parse_args()
+
+    if args.stats_only:
+        default_logger.info("[source_performance] Calcul des métriques sources…")
+        metrics = compute_source_metrics()
+        default_logger.info(f"[source_performance] {len(metrics)} sources analysées :")
+        for source, m in sorted(metrics.items(), key=lambda x: -x[1]["empirical_score"])[:20]:
+            default_logger.info(
+                f"  {source[:40]:40s} score={m['empirical_score']:5.1f} "
+                f"enrichi={m['enrichment_rate']:.0%} "
+                f"diversité={m['diversity_score']:.0f} "
+                f"engagement={m['engagement_score']:.0f}"
+            )
+        return
+
+    default_logger.info("[source_performance] Calcul et mise à jour des scores empiriques…")
+    result = run_update(dry_run=args.dry_run)
+
+    default_logger.info(
+        f"[source_performance] {result.get('metrics_computed', 0)} sources analysées — "
+        f"{result.get('sources_updated', 0)} mises à jour, "
+        f"{result.get('sources_skipped', 0)} ignorées"
+    )
+    if args.dry_run:
+        default_logger.info("[source_performance] (dry-run) Aucune écriture.")
+    elif result.get("applied"):
+        default_logger.info("[source_performance] sources_credibility.json mis à jour.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_self_learning.py
+++ b/tests/test_self_learning.py
@@ -1,0 +1,395 @@
+"""tests/test_self_learning.py — Tests du système auto-apprenant WUDD.ai
+
+Couvre :
+  - EngagementTracker : enregistrement des signaux, agrégation, stats
+  - ScoringOptimizer  : chargement/sauvegarde des poids, normalisation
+  - AlertCalibrator   : enregistrement d'alertes, mise à jour suivi
+  - QualityMonitor    : calcul du score de qualité par article
+  - ContradictionFeedback : enregistrement feedback, calibration seuils
+  - QuotaOptimizer    : archivage et analyse historique
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def _make_article(**kwargs) -> dict:
+    """Crée un article minimal pour les tests."""
+    base = {
+        "Date de publication": "23/01/2025",
+        "Sources": "Le Monde",
+        "URL": "https://example.com/article-1",
+        "Résumé": "Ceci est un résumé valide de plus de cent caractères pour tester le calcul de qualité des articles WUDD.ai correctement.",
+        "entities": {"PERSON": ["Emmanuel Macron"], "ORG": ["OpenAI"]},
+        "sentiment": "positif",
+        "score_sentiment": 4,
+        "Images": [{"URL": "https://img.example.com/1.jpg", "Width": 1200}],
+        "temps_lecture_minutes": 2.5,
+    }
+    base.update(kwargs)
+    return base
+
+
+# ─── EngagementTracker ────────────────────────────────────────────────────────
+
+class TestEngagementTracker:
+    """Tests de l'EngagementTracker en isolation (répertoire temporaire)."""
+
+    def _make_tracker(self, tmp_path: Path):
+        """Crée un tracker avec un répertoire temporaire."""
+        import utils.engagement_tracker as et
+        # Patcher le chemin de persistance
+        original_path = et._STATE_PATH
+        et._STATE_PATH = tmp_path / "engagement_state.json"
+        tracker = et.EngagementTracker()
+        yield tracker
+        et._STATE_PATH = original_path
+
+    def test_record_article_opened(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("article_opened", url="https://example.com/a", source="Le Monde")
+        score = tracker.get_article_score("https://example.com/a")
+        assert score == pytest.approx(1.0)
+
+    def test_record_article_deleted_negative(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("article_deleted", url="https://example.com/b", source="BFM TV")
+        score = tracker.get_article_score("https://example.com/b")
+        assert score == pytest.approx(-2.0)
+
+    def test_source_score_aggregation(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("article_opened",      source="Le Monde")
+        tracker.record("article_full_report", source="Le Monde")
+        tracker.record("article_deleted",     source="BFM TV")
+
+        sources = tracker.get_source_scores()
+        assert sources["Le Monde"] == pytest.approx(3.0)   # 1.0 + 2.0
+        assert sources["BFM TV"]   == pytest.approx(-2.0)
+
+    def test_keyword_score_aggregation(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("article_exported", keyword="ia")
+        tracker.record("article_opened",   keyword="ia")
+        kws = tracker.get_keyword_scores()
+        assert kws["ia"] == pytest.approx(3.5)   # 2.5 + 1.0
+
+    def test_entity_score_aggregation(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("entity_synthesis", entities=["OpenAI", "Macron"])
+        tracker.record("entity_synthesis", entities=["OpenAI"])
+        ents = tracker.get_entity_scores()
+        assert ents["OpenAI"] == pytest.approx(3.0)   # 1.5 × 2
+        assert ents["Macron"] == pytest.approx(1.5)
+
+    def test_dismissed_alert_recorded(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("alert_dismissed", alert_entity="PERSON:Trump")
+        dismissed = tracker.get_dismissed_alerts()
+        assert "PERSON:Trump" in dismissed
+
+    def test_unknown_signal_ignored(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+
+        tracker.record("signal_inexistant", url="https://example.com/x")
+        assert tracker.get_article_score("https://example.com/x") == 0.0
+
+    def test_persistence(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+        tracker.record("article_opened", url="https://example.com/persist", source="S")
+
+        # Recharger depuis le disque
+        tracker2 = et.EngagementTracker()
+        assert tracker2.get_article_score("https://example.com/persist") == pytest.approx(1.0)
+
+    def test_stats_structure(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+        tracker.record("article_opened", url="https://x.com", source="X")
+        stats = tracker.get_stats()
+        assert "total_articles_tracked" in stats
+        assert "top_sources" in stats
+        assert "top_keywords" in stats
+        assert "daily_activity" in stats
+
+    def test_purge_old_entries(self, tmp_path):
+        import utils.engagement_tracker as et
+        et._STATE_PATH = tmp_path / "state.json"
+        tracker = et.EngagementTracker()
+        # Injecter une entrée ancienne
+        tracker._state["articles"]["old_key"] = {
+            "url": "https://old.com",
+            "source": "Old",
+            "keyword": "",
+            "score": 1.0,
+            "signals": {},
+            "last_seen": "2020-01-01",
+        }
+        removed = tracker.purge_old_entries()
+        assert removed == 1
+
+
+# ─── ScoringOptimizer ─────────────────────────────────────────────────────────
+
+class TestScoringOptimizer:
+
+    def test_load_weights_defaults(self, tmp_path):
+        import utils.scoring_optimizer as so
+        original = so._WEIGHTS_FILE
+        so._WEIGHTS_FILE = tmp_path / "scoring_weights.json"
+        try:
+            weights = so.load_weights()
+            assert set(weights.keys()) == {"freshness", "entities", "keywords", "completeness"}
+            assert abs(sum(weights.values()) - 1.0) < 0.001
+        finally:
+            so._WEIGHTS_FILE = original
+
+    def test_save_and_reload_weights(self, tmp_path):
+        import utils.scoring_optimizer as so
+        original = so._WEIGHTS_FILE
+        so._WEIGHTS_FILE = tmp_path / "scoring_weights.json"
+        try:
+            custom = {"freshness": 0.40, "entities": 0.30, "keywords": 0.20, "completeness": 0.10}
+            so.save_weights(custom)
+            loaded = so.load_weights()
+            assert loaded["freshness"] == pytest.approx(0.40, abs=0.01)
+        finally:
+            so._WEIGHTS_FILE = original
+
+    def test_normalize_weights(self):
+        from utils.scoring_optimizer import _normalize_weights
+        w = {"freshness": 2.0, "entities": 1.0, "keywords": 1.0, "completeness": 0.0}
+        norm = _normalize_weights(w)
+        assert abs(sum(norm.values()) - 1.0) < 0.001
+
+    def test_optimize_insufficient_signals(self, tmp_path):
+        import utils.scoring_optimizer as so
+        import utils.engagement_tracker as et
+        # Patcher les chemins
+        so._WEIGHTS_FILE = tmp_path / "weights.json"
+        et._STATE_PATH   = tmp_path / "engagement.json"
+        et._tracker_instance = None
+
+        result = so.optimize(dry_run=True)
+        assert result["applied"] is False
+        assert "insuffisant" in result["reason"].lower() or "assez" in result["reason"].lower()
+
+
+# ─── QualityMonitor ───────────────────────────────────────────────────────────
+
+class TestQualityMonitor:
+
+    def test_complete_article_score(self):
+        from utils.quality_monitor import compute_quality_score, quality_level
+        art = _make_article()
+        score = compute_quality_score(art)
+        assert score >= 80
+        assert quality_level(score) == "complet"
+
+    def test_empty_article_score(self):
+        from utils.quality_monitor import compute_quality_score, quality_level
+        score = compute_quality_score({})
+        assert score <= 30
+        assert quality_level(score) == "critique"
+
+    def test_article_with_error_resume(self):
+        from utils.quality_monitor import compute_quality_score
+        art = _make_article(Résumé="Erreur : impossible de générer le résumé")
+        score = compute_quality_score(art)
+        # Pas de points résumé
+        assert score < 50
+
+    def test_article_missing_entities(self):
+        from utils.quality_monitor import compute_quality_score
+        art = _make_article()
+        del art["entities"]
+        score = compute_quality_score(art)
+        full = compute_quality_score(_make_article())
+        assert score < full
+
+    def test_repair_priority_error_resume(self):
+        from utils.quality_monitor import compute_repair_priority
+        art = {"Résumé": "désolé, je n'ai pas pu générer", "entities": {}, "sentiment": None}
+        priority = compute_repair_priority(art)
+        assert priority >= 5
+
+    def test_repair_priority_complete_article(self):
+        from utils.quality_monitor import compute_repair_priority
+        art = _make_article()
+        assert compute_repair_priority(art) == 0
+
+    def test_quality_levels(self):
+        from utils.quality_monitor import quality_level
+        assert quality_level(20) == "critique"
+        assert quality_level(50) == "dégradé"
+        assert quality_level(70) == "bon"
+        assert quality_level(90) == "complet"
+
+
+# ─── ContradictionFeedback ────────────────────────────────────────────────────
+
+class TestContradictionFeedback:
+    """Instancie directement ContradictionFeedback (évite les conflits de locks entre tests)."""
+
+    def _make_fb(self, tmp_path):
+        import utils.contradiction_feedback as cf
+        cf._FEEDBACK_PATH = tmp_path / "cf.json"
+        return cf.ContradictionFeedback()
+
+    def test_record_confirmed(self, tmp_path):
+        fb = self._make_fb(tmp_path)
+        fb.record("CHIFFRE", "confirmed", description="Test", confidence=0.8)
+        stats = fb.get_stats()
+        assert stats["total_confirmed"] == 1
+        assert stats["total_rejected"]  == 0
+
+    def test_record_rejected(self, tmp_path):
+        fb = self._make_fb(tmp_path)
+        fb.record("FAIT_BINAIRE", "rejected")
+        stats = fb.get_stats()
+        assert stats["total_rejected"] == 1
+
+    def test_invalid_action_ignored(self, tmp_path):
+        fb = self._make_fb(tmp_path)
+        fb.record("CHIFFRE", "invalid_action")
+        stats = fb.get_stats()
+        assert stats["total_feedback"] == 0
+
+    def test_calibrate_insufficient_feedback(self, tmp_path):
+        fb = self._make_fb(tmp_path)
+        result = fb.calibrate(dry_run=True)
+        assert result["applied"] is False
+        assert result["adjustments"] == {}
+
+    def test_calibrate_low_precision_raises_threshold(self, tmp_path):
+        fb = self._make_fb(tmp_path)
+
+        # Simuler 12 rejets et 3 confirmations (precision = 20%)
+        for _ in range(3):
+            fb.record("CHIFFRE", "confirmed")
+        for _ in range(12):
+            fb.record("CHIFFRE", "rejected")
+
+        old_thresholds = fb.get_thresholds()
+        result = fb.calibrate(dry_run=True)
+
+        if "CHIFFRE" in result["adjustments"]:
+            new_t = result["new_thresholds"].get("CHIFFRE", old_thresholds["CHIFFRE"])
+            assert new_t > old_thresholds["CHIFFRE"]
+
+    def test_thresholds_default_values(self):
+        from utils.contradiction_feedback import _DEFAULT_THRESHOLDS
+        for ctype in ("CHIFFRE", "DATE", "FAIT_BINAIRE", "ATTRIBUTION", "AUTRE"):
+            assert ctype in _DEFAULT_THRESHOLDS
+            assert 0.0 < _DEFAULT_THRESHOLDS[ctype] < 1.0
+
+
+# ─── AlertCalibrator ──────────────────────────────────────────────────────────
+
+class TestAlertCalibrator:
+
+    def test_record_alert(self, tmp_path):
+        import utils.alert_calibrator as ac
+        ac._FEEDBACK_PATH = tmp_path / "alert_fb.json"
+
+        ac.record_alert("PERSON", "Emmanuel Macron", ratio=3.5, level="élevé", mentions_24h=5)
+        data = ac.load_feedback()
+        assert len(data["alerts"]) == 1
+        assert data["alerts"][0]["value"] == "Emmanuel Macron"
+        assert data["alerts"][0]["ratio"] == 3.5
+
+    def test_mark_dismissed(self, tmp_path):
+        import utils.alert_calibrator as ac
+        from datetime import datetime, timezone
+        ac._FEEDBACK_PATH = tmp_path / "alert_fb.json"
+
+        ac.record_alert("ORG", "OpenAI", ratio=2.1, level="modéré", mentions_24h=2)
+        ac.mark_dismissed("OpenAI")
+
+        data = ac.load_feedback()
+        assert data["alerts"][0]["dismissed"] is True
+
+    def test_calibrate_no_analyzable(self, tmp_path):
+        import utils.alert_calibrator as ac
+        ac._FEEDBACK_PATH = tmp_path / "alert_fb.json"
+        ac._RULES_PATH    = tmp_path / "alert_rules.json"
+
+        result = ac.calibrate(dry_run=True)
+        assert result["applied"] is False
+
+
+# ─── QuotaOptimizer ───────────────────────────────────────────────────────────
+
+class TestQuotaOptimizer:
+
+    def test_archive_today_no_state(self, tmp_path):
+        import utils.quota_optimizer as qo
+        qo._QUOTA_STATE_PATH  = tmp_path / "quota_state.json"
+        qo._QUOTA_HISTORY_DIR = tmp_path / "quota_history"
+
+        result = qo.archive_today(dry_run=True)
+        assert result is False
+
+    def test_optimize_insufficient_history(self, tmp_path):
+        import utils.quota_optimizer as qo
+        qo._QUOTA_HISTORY_DIR = tmp_path / "quota_history"
+        qo._QUOTA_CONFIG_PATH = tmp_path / "quota.json"
+
+        result = qo.optimize(dry_run=True)
+        assert result["applied"] is False
+        assert "insuffisant" in result["reason"].lower()
+
+    def test_optimize_with_saturation(self, tmp_path):
+        import utils.quota_optimizer as qo
+        qo._QUOTA_HISTORY_DIR = tmp_path / "quota_history"
+        qo._QUOTA_CONFIG_PATH = tmp_path / "quota.json"
+
+        # Créer 6 jours d'historique avec keyword saturé
+        (tmp_path / "quota_history").mkdir()
+        from datetime import date, timedelta
+        for i in range(1, 7):
+            d = str(date.today() - timedelta(days=i))
+            state = {
+                "date": d,
+                "global_count": 145,  # ~97% du plafond par défaut 150
+                "keywords": {
+                    "intelligence-artificielle": {"total": 29, "sources": {}}
+                },
+                "entities": {},
+            }
+            (tmp_path / "quota_history" / f"{d}.json").write_text(
+                json.dumps(state), encoding="utf-8"
+            )
+
+        result = qo.optimize(dry_run=True)
+        # Doit détecter la saturation
+        assert any("saturé" in adj for adj in result.get("adjustments", []))

--- a/utils/alert_calibrator.py
+++ b/utils/alert_calibrator.py
@@ -1,0 +1,297 @@
+"""
+utils/alert_calibrator.py — Auto-calibration des seuils d'alerte
+
+Analyse la qualité des alertes générées par trend_detector.py en mesurant
+si elles ont effectivement été suivies de nouveaux articles dans les 48h.
+Ajuste automatiquement les seuils dans config/alert_rules.json.
+
+Logique :
+  - Une alerte est "creuse" si l'entité n'a pas produit de nouveaux articles
+    dans les 48h suivant l'alerte
+  - Si taux d'alertes creuses > 30% sur 7 jours → incrémenter le seuil de +0.25
+  - Si aucune alerte sur des entités qui ont ensuite explosé → décrémenter de -0.15
+  - Les alertes ignorées par l'utilisateur (via engagement_tracker) sont aussi
+    comptabilisées comme "faux positifs"
+
+État persistant : data/alert_feedback.json
+"""
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_FEEDBACK_PATH = _PROJECT_ROOT / "data" / "alert_feedback.json"
+_RULES_PATH    = _PROJECT_ROOT / "config" / "alert_rules.json"
+
+# Bornes des seuils de ratio
+_RATIO_MIN = 1.5
+_RATIO_MAX = 8.0
+
+# Seuil de taux de faux positifs déclenchant une augmentation du seuil
+_FP_RATE_THRESHOLD = 0.30
+
+# Pas d'ajustement
+_DELTA_UP   = 0.25
+_DELTA_DOWN = 0.15
+
+# Fenêtre d'analyse (jours)
+_ANALYSIS_WINDOW_DAYS = 7
+
+# Fenêtre de suivi post-alerte (heures)
+_FOLLOW_UP_HOURS = 48
+
+
+def load_feedback() -> dict:
+    """Charge le feedback d'alertes depuis data/alert_feedback.json."""
+    if _FEEDBACK_PATH.exists():
+        try:
+            return json.loads(_FEEDBACK_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return {
+        "version": 1,
+        "alerts": [],  # historique des alertes avec leur résultat
+        "calibration_log": [],
+    }
+
+
+def _save_feedback(data: dict) -> None:
+    _FEEDBACK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = _FEEDBACK_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(_FEEDBACK_PATH)
+
+
+def record_alert(
+    entity_type: str,
+    entity_value: str,
+    ratio: float,
+    level: str,
+    mentions_24h: int,
+) -> None:
+    """Enregistre une alerte générée pour suivi ultérieur.
+
+    Appelé par trend_detector.py après génération de data/alertes.json.
+    """
+    data = load_feedback()
+    data["alerts"].append({
+        "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "type": entity_type,
+        "value": entity_value,
+        "ratio": ratio,
+        "level": level,
+        "mentions_24h": mentions_24h,
+        "follow_up_count": None,   # à remplir lors du calibrage
+        "dismissed": False,
+    })
+    # Garder seulement les 500 dernières alertes
+    data["alerts"] = data["alerts"][-500:]
+    _save_feedback(data)
+
+
+def mark_dismissed(entity_value: str) -> None:
+    """Marque les alertes récentes de cette entité comme ignorées.
+
+    Appelé par l'engagement_tracker quand signal_type='alert_dismissed'.
+    """
+    data = load_feedback()
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=24)
+    for alert in data["alerts"]:
+        if alert.get("value") != entity_value:
+            continue
+        try:
+            ts = datetime.strptime(alert["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+            if ts >= cutoff:
+                alert["dismissed"] = True
+        except Exception:
+            pass
+    _save_feedback(data)
+
+
+def calibrate(dry_run: bool = False) -> dict:
+    """Analyse les alertes passées et ajuste les seuils si nécessaire.
+
+    Returns:
+        dict avec old_thresholds, new_thresholds, stats, applied
+    """
+    data = load_feedback()
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=_ANALYSIS_WINDOW_DAYS)
+
+    # Filtrer les alertes avec suivi disponible (>= 48h d'ancienneté)
+    analyzable = []
+    for alert in data["alerts"]:
+        try:
+            ts = datetime.strptime(alert["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except Exception:
+            continue
+        if ts < cutoff:
+            continue
+        age_h = (now - ts).total_seconds() / 3600
+        if age_h < _FOLLOW_UP_HOURS:
+            continue  # Pas encore possible de mesurer le suivi
+        analyzable.append(alert)
+
+    if not analyzable:
+        return {
+            "applied": False,
+            "reason": "Pas assez d'alertes analysables",
+            "stats": {},
+            "old_thresholds": _load_thresholds(),
+            "new_thresholds": _load_thresholds(),
+        }
+
+    # Compter les faux positifs (alertes creuses ou ignorées)
+    # On considère "creuse" une alerte où follow_up_count == 0 ou dismissed == True
+    false_positives = sum(
+        1 for a in analyzable
+        if a.get("dismissed") or a.get("follow_up_count") == 0
+    )
+    fp_rate = false_positives / len(analyzable)
+
+    old_thresholds = _load_thresholds()
+    new_thresholds = dict(old_thresholds)
+
+    adjustment = 0.0
+    reason = "Pas d'ajustement nécessaire"
+
+    if fp_rate > _FP_RATE_THRESHOLD:
+        adjustment = _DELTA_UP
+        reason = f"Taux faux positifs élevé ({fp_rate:.0%} > {_FP_RATE_THRESHOLD:.0%}) → seuil augmenté"
+    elif fp_rate < 0.10 and len(analyzable) >= 5:
+        adjustment = -_DELTA_DOWN
+        reason = f"Taux faux positifs faible ({fp_rate:.0%}) → seuil diminué"
+
+    if adjustment != 0.0:
+        for key in ("global_threshold_ratio", "threshold_ratio"):
+            if key in new_thresholds:
+                new_val = max(_RATIO_MIN, min(_RATIO_MAX, new_thresholds[key] + adjustment))
+                new_thresholds[key] = round(new_val, 2)
+
+    stats = {
+        "alerts_analyzed": len(analyzable),
+        "false_positives": false_positives,
+        "fp_rate": round(fp_rate, 3),
+        "adjustment": adjustment,
+    }
+
+    # Journaliser
+    data["calibration_log"].append({
+        "timestamp": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "dry_run": dry_run,
+        **stats,
+        "old_thresholds": old_thresholds,
+        "new_thresholds": new_thresholds,
+    })
+    data["calibration_log"] = data["calibration_log"][-50:]
+
+    if not dry_run:
+        _save_feedback(data)
+        if adjustment != 0.0:
+            _save_thresholds(new_thresholds)
+
+    return {
+        "applied": not dry_run and adjustment != 0.0,
+        "reason": reason,
+        "stats": stats,
+        "old_thresholds": old_thresholds,
+        "new_thresholds": new_thresholds,
+    }
+
+
+def update_follow_up_counts() -> int:
+    """Met à jour les compteurs de suivi pour les alertes de plus de 48h.
+
+    Compte les nouveaux articles mentionnant l'entité dans les 48h post-alerte.
+    Appelé en début de calibration ou en cron quotidien.
+
+    Returns:
+        Nombre d'alertes mises à jour.
+    """
+    from .entity_index import get_entity_index
+
+    data = load_feedback()
+    entity_idx = get_entity_index(_PROJECT_ROOT)
+    now = datetime.now(timezone.utc)
+    updated = 0
+
+    for alert in data["alerts"]:
+        if alert.get("follow_up_count") is not None:
+            continue
+        try:
+            ts = datetime.strptime(alert["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=timezone.utc
+            )
+        except Exception:
+            continue
+        age_h = (now - ts).total_seconds() / 3600
+        if age_h < _FOLLOW_UP_HOURS:
+            continue
+
+        # Compter les articles publiés dans les 48h après l'alerte
+        etype = alert.get("type", "")
+        value = alert.get("value", "")
+        key = f"{etype}:{value.lower()}"
+        refs = entity_idx.get_refs(key)
+
+        follow_up_cutoff = ts + timedelta(hours=_FOLLOW_UP_HOURS)
+        count = sum(
+            1 for ref in refs
+            if _ref_date_in_window(ref.get("date", ""), ts, follow_up_cutoff)
+        )
+        alert["follow_up_count"] = count
+        updated += 1
+
+    if updated:
+        _save_feedback(data)
+    return updated
+
+
+def _ref_date_in_window(date_str: str, start: datetime, end: datetime) -> bool:
+    """Vérifie si une date est dans la fenêtre [start, end]."""
+    if not date_str:
+        return False
+    from .date_utils import parse_article_date
+    dt = parse_article_date(date_str)
+    if dt is None:
+        return False
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return start <= dt <= end
+
+
+def _load_thresholds() -> dict:
+    """Charge les seuils actuels depuis config/alert_rules.json."""
+    if not _RULES_PATH.exists():
+        return {"global_threshold_ratio": 2.0}
+    try:
+        rules = json.loads(_RULES_PATH.read_text(encoding="utf-8"))
+        global_cfg = rules.get("global", {})
+        return {
+            "global_threshold_ratio": global_cfg.get("threshold_ratio", 2.0),
+        }
+    except Exception:
+        return {"global_threshold_ratio": 2.0}
+
+
+def _save_thresholds(new_thresholds: dict) -> None:
+    """Applique les nouveaux seuils dans config/alert_rules.json."""
+    if not _RULES_PATH.exists():
+        return
+    try:
+        rules = json.loads(_RULES_PATH.read_text(encoding="utf-8"))
+        if "global" in rules and "threshold_ratio" in new_thresholds:
+            rules["global"]["threshold_ratio"] = new_thresholds["global_threshold_ratio"]
+        _RULES_PATH.write_text(
+            json.dumps(rules, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    except Exception:
+        pass

--- a/utils/contradiction_feedback.py
+++ b/utils/contradiction_feedback.py
@@ -1,0 +1,251 @@
+"""
+utils/contradiction_feedback.py — Feedback sur les contradictions détectées
+
+Accumule les validations utilisateur (confirmer / rejeter) sur les contradictions
+détectées par utils/contradiction_engine.py, puis ajuste automatiquement les
+seuils de confiance dans config/alert_rules.json ou directement dans le moteur.
+
+État persistant : data/contradiction_feedback.json
+Singleton via get_contradiction_feedback()
+"""
+
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_FEEDBACK_PATH = _PROJECT_ROOT / "data" / "contradiction_feedback.json"
+
+# Seuil de confiance par type de contradiction (cohérent avec contradiction_engine.py)
+_DEFAULT_THRESHOLDS: dict[str, float] = {
+    "CHIFFRE":      0.55,
+    "DATE":         0.55,
+    "FAIT_BINAIRE": 0.55,
+    "ATTRIBUTION":  0.55,
+    "AUTRE":        0.60,
+}
+_THRESHOLDS_FILE = _PROJECT_ROOT / "config" / "contradiction_thresholds.json"
+
+# Bornes des seuils
+_THRESHOLD_MIN = 0.30
+_THRESHOLD_MAX = 0.90
+
+# Pas d'ajustement
+_DELTA_UP   = 0.05   # Si precision faible → augmenter le seuil
+_DELTA_DOWN = 0.03   # Si precision élevée → diminuer le seuil
+
+# Nombre minimal de retours pour déclencher un ajustement
+_MIN_FEEDBACK = 10
+
+
+class ContradictionFeedback:
+    """Collecte et analyse les retours utilisateur sur les contradictions."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._data = self._load()
+
+    def _load(self) -> dict:
+        if _FEEDBACK_PATH.exists():
+            try:
+                return json.loads(_FEEDBACK_PATH.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {
+            "version": 1,
+            "total_confirmed": 0,
+            "total_rejected": 0,
+            "by_type": {},
+            "entries": [],
+            "thresholds": dict(_DEFAULT_THRESHOLDS),
+            "calibration_log": [],
+        }
+
+    def _persist(self) -> None:
+        _FEEDBACK_PATH.parent.mkdir(parents=True, exist_ok=True)
+        tmp = _FEEDBACK_PATH.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(self._data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp.replace(_FEEDBACK_PATH)
+
+    # ── API publique ──────────────────────────────────────────────────────────
+
+    def record(
+        self,
+        contradiction_type: str,
+        action: str,  # "confirmed" ou "rejected"
+        description: Optional[str] = None,
+        confidence: Optional[float] = None,
+        article_url: Optional[str] = None,
+    ) -> None:
+        """Enregistre un retour utilisateur sur une contradiction.
+
+        Args:
+            contradiction_type : CHIFFRE, DATE, FAIT_BINAIRE, ATTRIBUTION, AUTRE
+            action             : "confirmed" (vraie contradiction) ou "rejected" (faux positif)
+            description        : description de la contradiction (optionnel)
+            confidence         : score de confiance assigné par le moteur (optionnel)
+            article_url        : URL de l'article source (optionnel)
+        """
+        if action not in ("confirmed", "rejected"):
+            return
+
+        with self._lock:
+            # Compteurs globaux
+            if action == "confirmed":
+                self._data["total_confirmed"] += 1
+            else:
+                self._data["total_rejected"] += 1
+
+            # Compteurs par type
+            type_data = self._data["by_type"].setdefault(contradiction_type, {
+                "confirmed": 0, "rejected": 0
+            })
+            type_data[action] += 1
+
+            # Historique (500 dernières entrées)
+            self._data["entries"].append({
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "type":        contradiction_type,
+                "action":      action,
+                "description": description,
+                "confidence":  confidence,
+                "article_url": article_url,
+            })
+            self._data["entries"] = self._data["entries"][-500:]
+
+            self._persist()
+
+    def get_thresholds(self) -> dict[str, float]:
+        """Retourne les seuils de confiance actuels par type."""
+        with self._lock:
+            return self._get_thresholds_nolock()
+
+    def _get_thresholds_nolock(self) -> dict[str, float]:
+        """Retourne les seuils sans acquérir le lock (appelé depuis méthodes déjà lockées)."""
+        stored = self._data.get("thresholds", {})
+        return {
+            k: stored.get(k, v)
+            for k, v in _DEFAULT_THRESHOLDS.items()
+        }
+
+    def calibrate(self, dry_run: bool = False) -> dict:
+        """Ajuste les seuils de confiance en fonction du feedback accumulé.
+
+        Returns:
+            dict avec old_thresholds, new_thresholds, stats, applied
+        """
+        with self._lock:
+            old_thresholds = self._get_thresholds_nolock()
+            new_thresholds = dict(old_thresholds)
+            adjustments: dict[str, str] = {}
+            stats: dict[str, dict] = {}
+
+            for ctype, type_data in self._data.get("by_type", {}).items():
+                confirmed = type_data.get("confirmed", 0)
+                rejected  = type_data.get("rejected", 0)
+                total = confirmed + rejected
+
+                if total < _MIN_FEEDBACK:
+                    continue
+
+                precision = confirmed / total
+                stats[ctype] = {
+                    "confirmed": confirmed,
+                    "rejected": rejected,
+                    "precision": round(precision, 3),
+                }
+
+                old_t = old_thresholds.get(ctype, 0.55)
+                if precision < 0.60:
+                    # Trop de faux positifs → augmenter le seuil
+                    new_t = min(_THRESHOLD_MAX, old_t + _DELTA_UP)
+                    adjustments[ctype] = f"{old_t:.2f} → {new_t:.2f} (precision {precision:.0%})"
+                    new_thresholds[ctype] = round(new_t, 3)
+                elif precision > 0.85:
+                    # Bonne précision → peut abaisser le seuil pour détecter plus
+                    new_t = max(_THRESHOLD_MIN, old_t - _DELTA_DOWN)
+                    adjustments[ctype] = f"{old_t:.2f} → {new_t:.2f} (precision {precision:.0%})"
+                    new_thresholds[ctype] = round(new_t, 3)
+
+            # Journaliser
+            self._data["calibration_log"].append({
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "dry_run": dry_run,
+                "stats": stats,
+                "adjustments": adjustments,
+                "old_thresholds": old_thresholds,
+                "new_thresholds": new_thresholds,
+            })
+            self._data["calibration_log"] = self._data["calibration_log"][-30:]
+
+            if not dry_run and adjustments:
+                self._data["thresholds"] = new_thresholds
+                self._persist()
+                _save_thresholds_file(new_thresholds)
+
+            return {
+                "applied": not dry_run and bool(adjustments),
+                "adjustments": adjustments,
+                "stats": stats,
+                "old_thresholds": old_thresholds,
+                "new_thresholds": new_thresholds,
+            }
+
+    def get_stats(self) -> dict:
+        """Retourne les statistiques de feedback."""
+        with self._lock:
+            total = self._data["total_confirmed"] + self._data["total_rejected"]
+            precision = (
+                self._data["total_confirmed"] / total if total > 0 else None
+            )
+            return {
+                "total_feedback": total,
+                "total_confirmed": self._data["total_confirmed"],
+                "total_rejected": self._data["total_rejected"],
+                "global_precision": round(precision, 3) if precision is not None else None,
+                "by_type": dict(self._data.get("by_type", {})),
+                "thresholds": self._get_thresholds_nolock(),
+            }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _save_thresholds_file(thresholds: dict) -> None:
+    """Persiste les seuils dans config/contradiction_thresholds.json."""
+    _THRESHOLDS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _THRESHOLDS_FILE.write_text(
+        json.dumps(thresholds, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def load_thresholds() -> dict[str, float]:
+    """Charge les seuils de confiance depuis le fichier de config ou les défauts."""
+    if _THRESHOLDS_FILE.exists():
+        try:
+            data = json.loads(_THRESHOLDS_FILE.read_text(encoding="utf-8"))
+            return {k: float(data.get(k, v)) for k, v in _DEFAULT_THRESHOLDS.items()}
+        except Exception:
+            pass
+    return dict(_DEFAULT_THRESHOLDS)
+
+
+# ── Singleton ─────────────────────────────────────────────────────────────────
+
+_feedback_instance: Optional["ContradictionFeedback"] = None
+_feedback_lock = threading.Lock()
+
+
+def get_contradiction_feedback() -> "ContradictionFeedback":
+    """Retourne l'instance singleton de ContradictionFeedback."""
+    global _feedback_instance
+    if _feedback_instance is None:
+        with _feedback_lock:
+            if _feedback_instance is None:
+                _feedback_instance = ContradictionFeedback()
+    return _feedback_instance

--- a/utils/engagement_tracker.py
+++ b/utils/engagement_tracker.py
@@ -1,0 +1,283 @@
+"""
+utils/engagement_tracker.py — Traçage des signaux d'engagement implicites
+
+Enregistre les actions utilisateur dans le viewer comme signaux d'intérêt
+sans demander de notation explicite. Ces signaux alimentent :
+  - utils/scoring_optimizer.py   (ajustement des poids de scoring)
+  - utils/source_performance.py  (score empirique des sources)
+  - utils/quota_optimizer.py     (réallocation du budget quotidien)
+
+Signaux et poids :
+  article_opened      +1.0   article ouvert/lu
+  article_full_report +2.0   rapport complet généré
+  entity_synthesis    +1.5   synthèse d'entité demandée
+  article_exported    +2.5   exporté JSON ou Markdown
+  article_merged      +1.0   fusion acceptée
+  article_deleted     -2.0   supprimé (signal négatif)
+  alert_dismissed     -1.0   alerte ignorée
+
+État persistant : data/engagement_state.json
+Singleton via get_engagement_tracker()
+"""
+
+import json
+import threading
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_STATE_PATH = _PROJECT_ROOT / "data" / "engagement_state.json"
+
+# Poids associés à chaque type de signal
+SIGNAL_WEIGHTS: dict[str, float] = {
+    "article_opened":      1.0,
+    "article_full_report": 2.0,
+    "entity_synthesis":    1.5,
+    "article_exported":    2.5,
+    "article_merged":      1.0,
+    "article_deleted":    -2.0,
+    "alert_dismissed":    -1.0,
+}
+
+# Fenêtre de rétention des signaux (en jours)
+_RETENTION_DAYS = 90
+
+
+class EngagementTracker:
+    """Collecte et agrège les signaux d'engagement utilisateur.
+
+    Structure de l'état :
+    {
+      "version": 1,
+      "updated_at": "2026-03-23T10:00:00Z",
+      "articles": {
+        "<url_md5>": {
+          "url": "https://...",
+          "source": "Le Monde",
+          "keyword": "intelligence-artificielle",
+          "score": 3.5,
+          "signals": {"article_opened": 1, "article_full_report": 1},
+          "last_seen": "2026-03-23"
+        }
+      },
+      "sources": {"Le Monde": 12.5, "BFM TV": -1.0},
+      "keywords": {"intelligence-artificielle": 8.0, "geopolitique": 2.5},
+      "entities": {"Emmanuel Macron": 4.5, "OpenAI": 3.0},
+      "alerts": {"dismissed": ["GPE:France", "PERSON:Jean Dupont"]},
+      "daily_activity": {"2026-03-23": {"signals": 12, "articles": 5}}
+    }
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._state: dict = self._load()
+
+    # ── Persistance ──────────────────────────────────────────────────────────
+
+    def _load(self) -> dict:
+        if _STATE_PATH.exists():
+            try:
+                return json.loads(_STATE_PATH.read_text(encoding="utf-8"))
+            except Exception:
+                pass
+        return {
+            "version": 1,
+            "updated_at": "",
+            "articles": {},
+            "sources": {},
+            "keywords": {},
+            "entities": {},
+            "alerts": {"dismissed": []},
+            "daily_activity": {},
+        }
+
+    def _persist(self) -> None:
+        _STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+        self._state["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        tmp = _STATE_PATH.with_suffix(".tmp")
+        tmp.write_text(
+            json.dumps(self._state, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp.replace(_STATE_PATH)
+
+    # ── API publique ──────────────────────────────────────────────────────────
+
+    def record(
+        self,
+        signal_type: str,
+        url: Optional[str] = None,
+        source: Optional[str] = None,
+        keyword: Optional[str] = None,
+        entities: Optional[list[str]] = None,
+        alert_entity: Optional[str] = None,
+    ) -> None:
+        """Enregistre un signal d'engagement.
+
+        Args:
+            signal_type   : type de signal (cf. SIGNAL_WEIGHTS)
+            url           : URL de l'article concerné (optionnel)
+            source        : nom de la source (optionnel)
+            keyword       : mot-clé associé à l'article (optionnel)
+            entities      : liste d'entités présentes dans l'article (optionnel)
+            alert_entity  : entité de l'alerte ignorée (pour alert_dismissed)
+        """
+        if signal_type not in SIGNAL_WEIGHTS:
+            return
+        weight = SIGNAL_WEIGHTS[signal_type]
+        today = str(date.today())
+
+        with self._lock:
+            # Activité journalière
+            day = self._state.setdefault("daily_activity", {}).setdefault(
+                today, {"signals": 0, "articles": 0}
+            )
+            day["signals"] += 1
+            if url:
+                day["articles"] += 1
+
+            # Score article
+            if url:
+                url_key = _md5_key(url)
+                art = self._state["articles"].setdefault(url_key, {
+                    "url": url, "source": source or "", "keyword": keyword or "",
+                    "score": 0.0, "signals": {}, "last_seen": today,
+                })
+                art["score"] = round(art["score"] + weight, 2)
+                art["signals"][signal_type] = art["signals"].get(signal_type, 0) + 1
+                art["last_seen"] = today
+                if source:
+                    art["source"] = source
+                if keyword:
+                    art["keyword"] = keyword
+
+            # Score source
+            if source:
+                sources = self._state.setdefault("sources", {})
+                sources[source] = round(sources.get(source, 0.0) + weight, 2)
+
+            # Score keyword
+            if keyword:
+                kws = self._state.setdefault("keywords", {})
+                kws[keyword] = round(kws.get(keyword, 0.0) + weight, 2)
+
+            # Score entités
+            if entities:
+                ents = self._state.setdefault("entities", {})
+                for ent in entities:
+                    ents[ent] = round(ents.get(ent, 0.0) + weight, 2)
+
+            # Alertes ignorées
+            if signal_type == "alert_dismissed" and alert_entity:
+                dismissed = self._state.setdefault("alerts", {}).setdefault("dismissed", [])
+                if alert_entity not in dismissed:
+                    dismissed.append(alert_entity)
+
+            self._persist()
+
+    def get_article_score(self, url: str) -> float:
+        """Retourne le score d'engagement cumulé pour une URL."""
+        with self._lock:
+            return self._state["articles"].get(_md5_key(url), {}).get("score", 0.0)
+
+    def get_source_scores(self) -> dict[str, float]:
+        """Retourne les scores d'engagement agrégés par source."""
+        with self._lock:
+            return dict(self._state.get("sources", {}))
+
+    def get_keyword_scores(self) -> dict[str, float]:
+        """Retourne les scores d'engagement agrégés par mot-clé."""
+        with self._lock:
+            return dict(self._state.get("keywords", {}))
+
+    def get_entity_scores(self) -> dict[str, float]:
+        """Retourne les scores d'engagement agrégés par entité."""
+        with self._lock:
+            return dict(self._state.get("entities", {}))
+
+    def get_dismissed_alerts(self) -> list[str]:
+        """Retourne la liste des entités dont les alertes ont été ignorées."""
+        with self._lock:
+            return list(self._state.get("alerts", {}).get("dismissed", []))
+
+    def get_stats(self) -> dict:
+        """Retourne un résumé des statistiques d'engagement."""
+        with self._lock:
+            articles = self._state.get("articles", {})
+            sources = self._state.get("sources", {})
+            keywords = self._state.get("keywords", {})
+            entities = self._state.get("entities", {})
+            daily = self._state.get("daily_activity", {})
+
+            top_articles = sorted(
+                [{"url": v["url"], "source": v["source"], "score": v["score"]}
+                 for v in articles.values()],
+                key=lambda x: -x["score"]
+            )[:10]
+
+            top_sources = sorted(
+                [{"source": k, "score": v} for k, v in sources.items()],
+                key=lambda x: -x["score"]
+            )[:10]
+
+            top_keywords = sorted(
+                [{"keyword": k, "score": v} for k, v in keywords.items()],
+                key=lambda x: -x["score"]
+            )[:10]
+
+            recent_days = sorted(daily.keys())[-7:]
+
+            return {
+                "total_articles_tracked": len(articles),
+                "total_sources": len(sources),
+                "total_keywords": len(keywords),
+                "total_entities": len(entities),
+                "top_articles": top_articles,
+                "top_sources": top_sources,
+                "top_keywords": top_keywords,
+                "dismissed_alerts": len(self._state.get("alerts", {}).get("dismissed", [])),
+                "daily_activity": {d: daily[d] for d in recent_days},
+                "updated_at": self._state.get("updated_at", ""),
+            }
+
+    def purge_old_entries(self) -> int:
+        """Supprime les entrées articles antérieures à _RETENTION_DAYS jours."""
+        from datetime import timedelta
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=_RETENTION_DAYS)).date()
+        removed = 0
+        with self._lock:
+            articles = self._state.get("articles", {})
+            to_delete = [
+                k for k, v in articles.items()
+                if v.get("last_seen", "9999-12-31") < str(cutoff)
+            ]
+            for k in to_delete:
+                del articles[k]
+                removed += 1
+            if removed:
+                self._persist()
+        return removed
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _md5_key(text: str) -> str:
+    import hashlib
+    return hashlib.md5(text.encode("utf-8")).hexdigest()
+
+
+# ── Singleton ─────────────────────────────────────────────────────────────────
+
+_tracker_instance: Optional[EngagementTracker] = None
+_tracker_lock = threading.Lock()
+
+
+def get_engagement_tracker() -> EngagementTracker:
+    """Retourne l'instance singleton de l'EngagementTracker."""
+    global _tracker_instance
+    if _tracker_instance is None:
+        with _tracker_lock:
+            if _tracker_instance is None:
+                _tracker_instance = EngagementTracker()
+    return _tracker_instance

--- a/utils/quality_monitor.py
+++ b/utils/quality_monitor.py
@@ -1,0 +1,232 @@
+"""
+utils/quality_monitor.py — Monitoring continu de la qualité des articles
+
+Calcule un score de qualité (0–100) pour chaque article et met à jour
+le champ `quality_score` dans data/article_index.json.
+
+Niveaux de qualité :
+  critique  (0–30)  : résumé manquant ou en erreur, pas d'enrichissement
+  dégradé   (31–60) : enrichissements partiels (entities OU sentiment manquant)
+  bon       (61–80) : résumé + 1 enrichissement présent
+  complet   (81–100): résumé + entities + sentiment + images
+
+Composantes du score (total 100) :
+  - Résumé valide        : 40 pts
+  - Entities présentes   : 20 pts
+  - Sentiment présent    : 15 pts
+  - Images présentes     : 10 pts
+  - Temps de lecture     : 5 pts
+  - Score source (bonus) : 10 pts max
+
+Intégration :
+  - article_index.py : champ quality_score ajouté lors de l'update()
+  - repair_failed_enrichments.py : piloté par le score pour prioriser
+  - viewer/routes/self_learning.py : endpoint GET /api/quality/stats
+"""
+
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+# Préfixes de résumés en erreur (cohérent avec scoring.py)
+_ERROR_PREFIXES = (
+    "désolé",
+    "je n'ai pas pu",
+    "erreur",
+    "échec",
+    "aucune information",
+)
+
+
+def compute_quality_score(article: dict) -> int:
+    """Calcule le score de qualité d'un article (0–100).
+
+    Args:
+        article : dict article au format WUDD.ai
+
+    Returns:
+        Score entier entre 0 et 100.
+    """
+    score = 0
+
+    # Résumé valide (40 pts)
+    resume = article.get("Résumé", "")
+    if isinstance(resume, str) and len(resume) > 100:
+        if not any(resume.lower().startswith(p) for p in _ERROR_PREFIXES):
+            score += 40
+
+    # Entities présentes (20 pts)
+    entities = article.get("entities", {})
+    if isinstance(entities, dict) and entities:
+        # Bonus partiel si au moins 2 types d'entités
+        n_types = len(entities)
+        score += min(20, 10 + n_types * 2)
+
+    # Sentiment présent (15 pts)
+    if article.get("sentiment") and article.get("score_sentiment") is not None:
+        score += 15
+
+    # Images présentes (10 pts)
+    images = article.get("Images", [])
+    if isinstance(images, list) and images:
+        score += 10
+
+    # Temps de lecture calculé (5 pts)
+    if article.get("temps_lecture_minutes") is not None:
+        score += 5
+
+    # Score source (0–10 pts bonus)
+    source_score = article.get("score_source", 50)
+    if isinstance(source_score, (int, float)):
+        score += int(source_score / 10)
+
+    return min(100, max(0, score))
+
+
+def quality_level(score: int) -> str:
+    """Retourne le niveau de qualité correspondant au score."""
+    if score <= 30:
+        return "critique"
+    if score <= 60:
+        return "dégradé"
+    if score <= 80:
+        return "bon"
+    return "complet"
+
+
+def compute_repair_priority(article: dict) -> int:
+    """Retourne une priorité de réparation (0 = pas besoin, 10 = urgent).
+
+    Utilisé par repair_failed_enrichments.py pour prioriser les articles.
+    """
+    resume = article.get("Résumé", "")
+    has_error_resume = isinstance(resume, str) and any(
+        resume.lower().startswith(p) for p in _ERROR_PREFIXES
+    )
+    has_short_resume = not isinstance(resume, str) or len(resume) < 100
+    missing_entities  = not isinstance(article.get("entities"), dict) or not article["entities"]
+    missing_sentiment = not article.get("sentiment")
+
+    priority = 0
+    if has_error_resume:
+        priority += 5
+    if has_short_resume and not has_error_resume:
+        priority += 3
+    if missing_entities:
+        priority += 2
+    if missing_sentiment:
+        priority += 1
+
+    return min(10, priority)
+
+
+def update_quality_scores(
+    project_root: Optional[Path] = None,
+    dry_run: bool = False,
+) -> dict:
+    """Recalcule les scores de qualité pour tous les articles dans l'index.
+
+    Met à jour le champ quality_score dans data/article_index.json.
+
+    Returns:
+        dict avec total, updated, by_level, applied
+    """
+    import json
+    if project_root is None:
+        project_root = _PROJECT_ROOT
+
+    from .article_index import get_article_index
+
+    idx = get_article_index(project_root)
+    all_entries = idx.get_articles()
+
+    if not all_entries:
+        return {"applied": False, "reason": "Index article vide", "total": 0}
+
+    level_counts: dict[str, int] = {
+        "critique": 0, "dégradé": 0, "bon": 0, "complet": 0
+    }
+    updated = 0
+
+    # Grouper les entrées par fichier pour charger les articles en batch
+    files: dict[str, list] = {}
+    for entry in all_entries:
+        file_key = entry.get("file", "")
+        files.setdefault(file_key, []).append(entry)
+
+    for file_rel, entries in files.items():
+        file_path = project_root / file_rel
+        if not file_path.exists():
+            continue
+        try:
+            data = json.loads(file_path.read_text(encoding="utf-8", errors="replace"))
+            if not isinstance(data, list):
+                continue
+        except Exception:
+            continue
+
+        for entry in entries:
+            idx_pos = entry.get("idx", 0)
+            if idx_pos >= len(data):
+                continue
+            article = data[idx_pos]
+            q_score = compute_quality_score(article)
+            level = quality_level(q_score)
+            level_counts[level] += 1
+
+            if not dry_run:
+                entry["quality_score"] = q_score
+                entry["quality_level"] = level
+            updated += 1
+
+    if not dry_run and updated > 0:
+        idx.save()
+
+    return {
+        "applied": not dry_run,
+        "total": len(all_entries),
+        "updated": updated,
+        "by_level": level_counts,
+    }
+
+
+def get_quality_stats(project_root: Optional[Path] = None) -> dict:
+    """Retourne les statistiques de qualité depuis l'index (lecture seule).
+
+    Returns:
+        dict avec distribution par niveau, score moyen, articles à réparer
+    """
+    if project_root is None:
+        project_root = _PROJECT_ROOT
+
+    from .article_index import get_article_index
+    idx = get_article_index(project_root)
+    all_entries = idx.get_articles()
+
+    level_counts: dict[str, int] = {
+        "critique": 0, "dégradé": 0, "bon": 0, "complet": 0, "inconnu": 0
+    }
+    scores = []
+    repair_needed = 0
+
+    for entry in all_entries:
+        q = entry.get("quality_score")
+        if q is None:
+            level_counts["inconnu"] += 1
+            continue
+        scores.append(q)
+        level = quality_level(int(q))
+        level_counts[level] = level_counts.get(level, 0) + 1
+        if level == "critique":
+            repair_needed += 1
+
+    return {
+        "total": len(all_entries),
+        "by_level": level_counts,
+        "avg_score": round(sum(scores) / len(scores), 1) if scores else 0,
+        "repair_needed": repair_needed,
+        "pct_complete": round(
+            level_counts["complet"] / len(all_entries) * 100, 1
+        ) if all_entries else 0,
+    }

--- a/utils/quota_optimizer.py
+++ b/utils/quota_optimizer.py
@@ -1,0 +1,224 @@
+"""
+utils/quota_optimizer.py — Optimisation automatique des quotas journaliers
+
+Analyse l'historique des quotas (data/quota_history/) pour détecter les
+keywords toujours saturés ou sous-utilisés, puis ajuste les limites dans
+config/quota.json.
+
+Règles d'ajustement :
+  - Keyword saturé ≥ 5 jours sur 7  → augmenter per_keyword_daily_limit de 20%
+  - Keyword utilisé < 30% sur 7 jours → réduire de 15% (libérer du budget)
+  - Entité monopolisant le quota    → réduire per_entity_daily_limit de 1
+  - Global toujours saturé           → augmenter global_daily_limit de 10%
+
+Historisation :
+  Appelé par scripts/archive_quota_state.py (cron quotidien 00:05)
+  pour archiver data/quota_state.json dans data/quota_history/YYYY-MM-DD.json
+
+Appelé par : scripts/optimize_quota.py (cron hebdo lundi 05:45)
+"""
+
+import json
+import shutil
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_QUOTA_CONFIG_PATH  = _PROJECT_ROOT / "config" / "quota.json"
+_QUOTA_STATE_PATH   = _PROJECT_ROOT / "data" / "quota_state.json"
+_QUOTA_HISTORY_DIR  = _PROJECT_ROOT / "data" / "quota_history"
+
+# Bornes des limites
+_GLOBAL_MIN  = 50
+_GLOBAL_MAX  = 500
+_KW_MIN      = 10
+_KW_MAX      = 100
+_ENTITY_MIN  = 3
+_ENTITY_MAX  = 30
+
+# Paramètres d'analyse
+_ANALYSIS_DAYS = 7
+_SATURATION_DAYS_THRESHOLD = 5   # saturé ≥ 5j/7j → augmenter
+_UNDERUSE_RATIO_THRESHOLD  = 0.30  # < 30% utilisé → diminuer
+
+
+def archive_today(dry_run: bool = False) -> bool:
+    """Archive data/quota_state.json dans data/quota_history/YYYY-MM-DD.json.
+
+    Appelé chaque nuit à 00:05 (après le reset des quotas à 00:01).
+    Archive la journée qui vient de se terminer.
+
+    Returns:
+        True si l'archivage a été effectué, False sinon.
+    """
+    yesterday = str(date.today() - timedelta(days=1))
+
+    if not _QUOTA_STATE_PATH.exists():
+        return False
+
+    try:
+        state = json.loads(_QUOTA_STATE_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return False
+
+    # Vérifier que c'est bien la date d'hier (le reset vient de tourner)
+    state_date = state.get("date", "")
+    # On archive l'état de la veille (avant le reset)
+    if state_date != yesterday and state_date != str(date.today()):
+        return False
+
+    _QUOTA_HISTORY_DIR.mkdir(parents=True, exist_ok=True)
+    archive_path = _QUOTA_HISTORY_DIR / f"{state_date}.json"
+
+    if archive_path.exists():
+        return True  # Déjà archivé
+
+    if not dry_run:
+        archive_path.write_text(
+            json.dumps(state, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    return True
+
+
+def _load_history(days: int = _ANALYSIS_DAYS) -> list[dict]:
+    """Charge les N derniers jours d'historique depuis data/quota_history/."""
+    if not _QUOTA_HISTORY_DIR.exists():
+        return []
+
+    history = []
+    today = date.today()
+    for i in range(1, days + 1):
+        d = str(today - timedelta(days=i))
+        path = _QUOTA_HISTORY_DIR / f"{d}.json"
+        if path.exists():
+            try:
+                history.append(json.loads(path.read_text(encoding="utf-8")))
+            except Exception:
+                pass
+    return history
+
+
+def _load_config() -> dict:
+    from utils.quota import DEFAULT_CONFIG
+    if _QUOTA_CONFIG_PATH.exists():
+        try:
+            return json.loads(_QUOTA_CONFIG_PATH.read_text(encoding="utf-8"))
+        except Exception:
+            pass
+    return dict(DEFAULT_CONFIG)
+
+
+def _save_config(config: dict) -> None:
+    _QUOTA_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _QUOTA_CONFIG_PATH.write_text(
+        json.dumps(config, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def optimize(dry_run: bool = False) -> dict:
+    """Analyse l'historique et ajuste les quotas si nécessaire.
+
+    Returns:
+        dict avec old_config, new_config, adjustments, applied
+    """
+    history = _load_history()
+    if len(history) < 3:
+        return {
+            "applied": False,
+            "reason": f"Historique insuffisant ({len(history)} jours < 3)",
+            "adjustments": {},
+        }
+
+    old_config = _load_config()
+    new_config = dict(old_config)
+    adjustments: list[str] = []
+
+    kw_limit    = int(old_config.get("per_keyword_daily_limit", 30))
+    global_limit = int(old_config.get("global_daily_limit", 150))
+    entity_limit = int(old_config.get("per_entity_daily_limit", 10))
+
+    # ── Analyse par keyword ────────────────────────────────────────────────
+
+    # Compter le nombre de jours de saturation et le ratio moyen par keyword
+    keyword_days: dict[str, list[float]] = {}   # keyword → [ratio_j1, ratio_j2, ...]
+    for day_state in history:
+        for kw, data in day_state.get("keywords", {}).items():
+            total = data.get("total", 0)
+            ratio = total / kw_limit if kw_limit > 0 else 0
+            keyword_days.setdefault(kw, []).append(ratio)
+
+    new_kw_limit = kw_limit
+    for kw, ratios in keyword_days.items():
+        if len(ratios) < 3:
+            continue
+        avg_ratio = sum(ratios) / len(ratios)
+        saturated_days = sum(1 for r in ratios if r >= 0.95)
+
+        if saturated_days >= _SATURATION_DAYS_THRESHOLD:
+            # Ce keyword est presque toujours saturé → augmenter le budget global
+            # (on agit sur la limite globale car per_keyword est partagée)
+            suggestion = f"Keyword '{kw}' saturé {saturated_days}/{len(ratios)} jours"
+            if suggestion not in adjustments:
+                adjustments.append(suggestion)
+                new_kw_limit = min(_KW_MAX, int(new_kw_limit * 1.20))
+        elif avg_ratio < _UNDERUSE_RATIO_THRESHOLD:
+            suggestion = f"Keyword '{kw}' sous-utilisé (ratio moyen {avg_ratio:.0%})"
+            adjustments.append(suggestion)
+
+    if new_kw_limit != kw_limit:
+        new_config["per_keyword_daily_limit"] = new_kw_limit
+        adjustments.append(
+            f"per_keyword_daily_limit : {kw_limit} → {new_kw_limit}"
+        )
+
+    # ── Analyse globale ───────────────────────────────────────────────────
+
+    global_ratios = [
+        day.get("global_count", 0) / global_limit
+        for day in history
+        if global_limit > 0
+    ]
+    global_saturated = sum(1 for r in global_ratios if r >= 0.95)
+    if global_saturated >= _SATURATION_DAYS_THRESHOLD:
+        new_global = min(_GLOBAL_MAX, int(global_limit * 1.10))
+        new_config["global_daily_limit"] = new_global
+        adjustments.append(
+            f"global_daily_limit : {global_limit} → {new_global} (saturé {global_saturated}/{len(history)} jours)"
+        )
+
+    # ── Analyse par entité ────────────────────────────────────────────────
+
+    # Détecter si une entité monopolise le budget global
+    entity_totals: dict[str, int] = {}
+    for day_state in history:
+        for ent, cnt in day_state.get("entities", {}).items():
+            entity_totals[ent] = entity_totals.get(ent, 0) + cnt
+
+    if entity_totals:
+        total_entity_refs = sum(entity_totals.values())
+        top_entity, top_count = max(entity_totals.items(), key=lambda x: x[1])
+        monopoly_ratio = top_count / total_entity_refs if total_entity_refs > 0 else 0
+        if monopoly_ratio > 0.30 and entity_limit > _ENTITY_MIN:
+            new_entity = max(_ENTITY_MIN, entity_limit - 1)
+            new_config["per_entity_daily_limit"] = new_entity
+            adjustments.append(
+                f"per_entity_daily_limit : {entity_limit} → {new_entity} "
+                f"('{top_entity}' monopolise {monopoly_ratio:.0%} du budget entités)"
+            )
+
+    result = {
+        "applied": not dry_run and bool(adjustments),
+        "reason": "OK" if adjustments else "Pas d'ajustement nécessaire",
+        "adjustments": adjustments,
+        "old_config": old_config,
+        "new_config": new_config,
+        "history_days": len(history),
+    }
+
+    if not dry_run and adjustments:
+        _save_config(new_config)
+
+    return result

--- a/utils/scoring_optimizer.py
+++ b/utils/scoring_optimizer.py
@@ -1,0 +1,225 @@
+"""
+utils/scoring_optimizer.py — Optimisation automatique des poids de scoring
+
+Ajuste hebdomadairement les poids de scoring (freshness, entities, keywords,
+completeness) en comparant les scores prédits aux signaux d'engagement réels
+collectés par utils/engagement_tracker.py.
+
+Principe : gradient descent simplifié avec contrainte sum(weights) == 1.0
+  - Si les articles à fort score_entities ont un engagement moyen élevé
+    → augmenter w_entities
+  - Si les articles récents (fort score_freshness) ont un faible engagement
+    → diminuer w_freshness
+
+Config persistante : config/scoring_weights.json
+Appelé par        : scripts/optimize_scoring_weights.py (cron hebdo lundi 05:30)
+"""
+
+import json
+import threading
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_WEIGHTS_FILE = _PROJECT_ROOT / "config" / "scoring_weights.json"
+
+# Bornes des poids (évite les dérives extrêmes)
+_WEIGHT_MIN = 0.05
+_WEIGHT_MAX = 0.55
+
+# Pas d'ajustement maximal par cycle
+_DELTA_MAX = 0.03
+
+# Poids initiaux (cohérents avec scoring.py)
+_DEFAULT_WEIGHTS: dict[str, float] = {
+    "freshness":    0.35,
+    "entities":     0.25,
+    "keywords":     0.25,
+    "completeness": 0.15,
+}
+
+# Nombre minimal de signaux d'engagement pour déclencher un ajustement
+_MIN_SIGNALS = 20
+
+
+def load_weights() -> dict[str, float]:
+    """Charge les poids depuis config/scoring_weights.json.
+
+    Si le fichier n'existe pas, retourne les poids par défaut et le crée.
+    """
+    if _WEIGHTS_FILE.exists():
+        try:
+            data = json.loads(_WEIGHTS_FILE.read_text(encoding="utf-8"))
+            w = {k: float(data.get(k, v)) for k, v in _DEFAULT_WEIGHTS.items()}
+            return _normalize_weights(w)
+        except Exception:
+            pass
+    # Créer le fichier avec les valeurs par défaut
+    save_weights(_DEFAULT_WEIGHTS)
+    return dict(_DEFAULT_WEIGHTS)
+
+
+def save_weights(weights: dict[str, float]) -> None:
+    """Persiste les poids dans config/scoring_weights.json."""
+    _WEIGHTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    _WEIGHTS_FILE.write_text(
+        json.dumps(weights, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def _normalize_weights(weights: dict[str, float]) -> dict[str, float]:
+    """Normalise les poids pour que leur somme soit exactement 1.0."""
+    total = sum(weights.values())
+    if total <= 0:
+        return dict(_DEFAULT_WEIGHTS)
+    return {k: round(v / total, 4) for k, v in weights.items()}
+
+
+def _clamp(value: float, min_val: float, max_val: float) -> float:
+    return max(min_val, min(max_val, value))
+
+
+def optimize(dry_run: bool = False) -> dict:
+    """Calcule et applique les nouveaux poids de scoring.
+
+    Analyse la corrélation entre les composantes de scoring et l'engagement
+    réel mesuré sur les 30 derniers jours.
+
+    Returns:
+        dict avec old_weights, new_weights, adjustments, signals_count, applied
+    """
+    from .engagement_tracker import get_engagement_tracker
+    from .article_index import get_article_index
+    from .scoring import (
+        _freshness_score, _entity_score, _keyword_score, _completeness_score,
+        _extract_keywords_flat,
+    )
+    import json as _json
+    from datetime import datetime, timezone, timedelta
+
+    tracker = get_engagement_tracker()
+    article_idx = get_article_index(_PROJECT_ROOT)
+
+    old_weights = load_weights()
+
+    # Récupérer les scores d'engagement par URL
+    eng_state = tracker._state.get("articles", {})
+    if len(eng_state) < _MIN_SIGNALS:
+        return {
+            "applied": False,
+            "reason": f"Pas assez de signaux ({len(eng_state)} < {_MIN_SIGNALS})",
+            "old_weights": old_weights,
+            "new_weights": old_weights,
+            "adjustments": {},
+            "signals_count": len(eng_state),
+        }
+
+    # Charger les mots-clés
+    kw_file = _PROJECT_ROOT / "config" / "keyword-to-search.json"
+    keywords: list[str] = []
+    if kw_file.exists():
+        try:
+            keywords = _extract_keywords_flat(
+                _json.loads(kw_file.read_text(encoding="utf-8"))
+            )
+        except Exception:
+            pass
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=30)
+
+    # Collecter les articles avec leur score d'engagement et leurs composantes
+    samples: list[dict] = []
+    for url_key, eng_data in eng_state.items():
+        url = eng_data.get("url", "")
+        engagement = eng_data.get("score", 0.0)
+        if engagement == 0.0:
+            continue
+
+        # Trouver l'article dans l'index
+        art = article_idx.get_by_url(url)
+        if not art:
+            continue
+
+        # Charger l'article complet pour calculer ses composantes
+        file_path = _PROJECT_ROOT / art.get("file", "")
+        idx_pos = art.get("idx", 0)
+        if not file_path.exists():
+            continue
+        try:
+            data = _json.loads(file_path.read_text(encoding="utf-8", errors="replace"))
+            if not isinstance(data, list) or idx_pos >= len(data):
+                continue
+            article = data[idx_pos]
+        except Exception:
+            continue
+
+        # Calculer les composantes de scoring
+        f_score = _freshness_score(article.get("Date de publication", ""), now) / 100.0
+        e_score = _entity_score(article.get("entities", {})) / 100.0
+        k_score = _keyword_score(article.get("Résumé", ""), keywords) / 100.0
+        c_score = _completeness_score(article) / 100.0
+
+        samples.append({
+            "freshness":    f_score,
+            "entities":     e_score,
+            "keywords":     k_score,
+            "completeness": c_score,
+            "engagement":   engagement,
+        })
+
+    if len(samples) < _MIN_SIGNALS:
+        return {
+            "applied": False,
+            "reason": f"Articles trouvés insuffisants ({len(samples)} < {_MIN_SIGNALS})",
+            "old_weights": old_weights,
+            "new_weights": old_weights,
+            "adjustments": {},
+            "signals_count": len(samples),
+        }
+
+    # Calculer la corrélation engagement ~ composante pour chaque dimension
+    # Méthode : covariance normalisée
+    n = len(samples)
+    mean_eng = sum(s["engagement"] for s in samples) / n
+
+    adjustments: dict[str, float] = {}
+    new_weights = dict(old_weights)
+
+    for dim in ("freshness", "entities", "keywords", "completeness"):
+        mean_dim = sum(s[dim] for s in samples) / n
+        cov = sum((s[dim] - mean_dim) * (s["engagement"] - mean_eng) for s in samples) / n
+        std_dim = (sum((s[dim] - mean_dim) ** 2 for s in samples) / n) ** 0.5
+        std_eng = (sum((s["engagement"] - mean_eng) ** 2 for s in samples) / n) ** 0.5
+
+        if std_dim > 0 and std_eng > 0:
+            correlation = cov / (std_dim * std_eng)
+        else:
+            correlation = 0.0
+
+        # Ajuster le poids proportionnellement à la corrélation
+        # corrélation positive → augmenter le poids
+        # corrélation négative → diminuer le poids
+        delta = _clamp(correlation * _DELTA_MAX, -_DELTA_MAX, _DELTA_MAX)
+        adjustments[dim] = round(delta, 4)
+        new_weights[dim] = _clamp(
+            old_weights[dim] + delta, _WEIGHT_MIN, _WEIGHT_MAX
+        )
+
+    # Normaliser pour que la somme == 1.0
+    new_weights = _normalize_weights(new_weights)
+
+    result = {
+        "applied": not dry_run,
+        "reason": "OK",
+        "old_weights": old_weights,
+        "new_weights": new_weights,
+        "adjustments": adjustments,
+        "signals_count": len(samples),
+    }
+
+    if not dry_run:
+        save_weights(new_weights)
+
+    return result

--- a/utils/source_performance.py
+++ b/utils/source_performance.py
@@ -1,0 +1,270 @@
+"""
+utils/source_performance.py — Score empirique des sources basé sur les données réelles
+
+Calcule mensuellement des métriques empiriques par source à partir du corpus
+d'articles, puis met à jour config/sources_credibility.json avec un champ
+`empirical_score` (0–100) et `empirical_score_updated`.
+
+Métriques calculées :
+  - Taux de duplication     : articles dédoublonnés / total → malus si > 20%
+  - Taux d'enrichissement   : articles avec entities+sentiment / total → bonus
+  - Engagement relatif      : score engagement moyen vs médiane globale
+  - Diversité des entités   : entropie des types d'entités produites
+
+Formule finale :
+  score_empirique = base_score × 0.70 + empirical_score × 0.30
+
+Singleton via get_source_performance()
+"""
+
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_CREDIBILITY_FILE = _PROJECT_ROOT / "config" / "sources_credibility.json"
+
+# Pondérations des métriques empiriques
+_W_ENRICHMENT  = 0.35
+_W_DIVERSITY   = 0.25
+_W_ENGAGEMENT  = 0.25
+_W_DUPLICATION = 0.15  # pénalité
+
+
+def compute_source_metrics(project_root: Optional[Path] = None) -> dict[str, dict]:
+    """Calcule les métriques empiriques pour toutes les sources.
+
+    Returns:
+        dict source_name → {
+            enrichment_rate, diversity_score, engagement_score,
+            duplication_rate, empirical_score, article_count
+        }
+    """
+    if project_root is None:
+        project_root = _PROJECT_ROOT
+
+    from .engagement_tracker import get_engagement_tracker
+    from .article_index import get_article_index
+
+    tracker = get_engagement_tracker()
+    article_idx = get_article_index(project_root)
+    engagement_sources = tracker.get_source_scores()
+
+    # Agréger les métriques par source depuis l'article_index
+    source_stats: dict[str, dict] = {}
+
+    all_entries = article_idx.get_articles()
+    for entry in all_entries:
+        source = entry.get("source", "")
+        if not source:
+            continue
+
+        stats = source_stats.setdefault(source, {
+            "total": 0,
+            "with_entities": 0,
+            "with_sentiment": 0,
+            "entity_types": {},
+        })
+        stats["total"] += 1
+        if entry.get("has_entities"):
+            stats["with_entities"] += 1
+        if entry.get("has_sentiment"):
+            stats["with_sentiment"] += 1
+
+    # Charger les articles complets pour la diversité des entités
+    _enrich_entity_diversity(project_root, source_stats)
+
+    # Calculer les métriques finales
+    results: dict[str, dict] = {}
+
+    # Médiane du score d'engagement (pour normalisation relative)
+    eng_scores = [v for v in engagement_sources.values() if v > 0]
+    eng_median = _median(eng_scores) if eng_scores else 1.0
+
+    for source, stats in source_stats.items():
+        total = stats["total"]
+        if total == 0:
+            continue
+
+        # Taux d'enrichissement (NER + sentiment)
+        enriched = (stats["with_entities"] + stats["with_sentiment"]) / (total * 2)
+        enrichment_score = min(100.0, enriched * 100)
+
+        # Diversité des entités (entropie de Shannon normalisée)
+        entity_types = stats.get("entity_types", {})
+        diversity_score = _entropy_score(entity_types)
+
+        # Score d'engagement relatif (normalisé sur la médiane)
+        eng_raw = engagement_sources.get(source, 0.0)
+        if eng_median > 0:
+            engagement_score = min(100.0, max(0.0, (eng_raw / eng_median) * 50 + 50))
+        else:
+            engagement_score = 50.0
+
+        # Taux de duplication (approximé si l'index contient les doublons)
+        # On utilise 0 par défaut (non calculé ici, mise à jour via deduplication)
+        duplication_rate = stats.get("duplication_rate", 0.0)
+        duplication_penalty = min(40.0, duplication_rate * 200)  # 20% → -40 pts
+
+        # Score empirique composite
+        empirical = (
+            enrichment_score  * _W_ENRICHMENT
+            + diversity_score * _W_DIVERSITY
+            + engagement_score * _W_ENGAGEMENT
+            - duplication_penalty * _W_DUPLICATION
+        )
+        empirical = max(0.0, min(100.0, empirical))
+
+        results[source] = {
+            "article_count":    total,
+            "enrichment_rate":  round(enriched, 3),
+            "enrichment_score": round(enrichment_score, 1),
+            "diversity_score":  round(diversity_score, 1),
+            "engagement_score": round(engagement_score, 1),
+            "duplication_rate": round(duplication_rate, 3),
+            "empirical_score":  round(empirical, 1),
+        }
+
+    return results
+
+
+def update_credibility_file(
+    metrics: dict[str, dict],
+    dry_run: bool = False,
+) -> dict:
+    """Met à jour sources_credibility.json avec les scores empiriques.
+
+    Returns:
+        dict avec sources_updated, sources_skipped, applied
+    """
+    if not _CREDIBILITY_FILE.exists():
+        return {"applied": False, "reason": "sources_credibility.json introuvable"}
+
+    try:
+        credibility = json.loads(_CREDIBILITY_FILE.read_text(encoding="utf-8"))
+    except Exception as e:
+        return {"applied": False, "reason": str(e)}
+
+    if not isinstance(credibility, list):
+        return {"applied": False, "reason": "Format inattendu (pas une liste)"}
+
+    updated = 0
+    skipped = 0
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for entry in credibility:
+        source_name = entry.get("source") or entry.get("name") or ""
+        if not source_name:
+            skipped += 1
+            continue
+
+        # Chercher par correspondance partielle
+        matched_key = _match_source(source_name, metrics)
+        if not matched_key:
+            skipped += 1
+            continue
+
+        m = metrics[matched_key]
+        entry["empirical_score"] = m["empirical_score"]
+        entry["empirical_score_updated"] = timestamp
+        entry["empirical_details"] = {
+            "article_count":    m["article_count"],
+            "enrichment_score": m["enrichment_score"],
+            "diversity_score":  m["diversity_score"],
+            "engagement_score": m["engagement_score"],
+        }
+        updated += 1
+
+    if not dry_run and updated > 0:
+        _CREDIBILITY_FILE.write_text(
+            json.dumps(credibility, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    return {
+        "applied": not dry_run,
+        "sources_updated": updated,
+        "sources_skipped": skipped,
+    }
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _enrich_entity_diversity(project_root: Path, source_stats: dict) -> None:
+    """Enrichit source_stats avec la distribution des types d'entités."""
+    data_dir = project_root / "data"
+    for json_file in list((data_dir / "articles").rglob("*.json"))[:200]:
+        if "cache" in json_file.parts:
+            continue
+        try:
+            articles = json.loads(json_file.read_text(encoding="utf-8", errors="replace"))
+            if not isinstance(articles, list):
+                continue
+            for art in articles:
+                source = art.get("Sources") or art.get("source", "")
+                if not source or source not in source_stats:
+                    continue
+                entities = art.get("entities", {})
+                if not isinstance(entities, dict):
+                    continue
+                for etype, vals in entities.items():
+                    if isinstance(vals, list) and vals:
+                        source_stats[source]["entity_types"][etype] = (
+                            source_stats[source]["entity_types"].get(etype, 0) + len(vals)
+                        )
+        except Exception:
+            continue
+
+
+def _entropy_score(type_counts: dict) -> float:
+    """Calcule un score de diversité (0–100) basé sur l'entropie de Shannon."""
+    total = sum(type_counts.values())
+    if total == 0:
+        return 0.0
+    n_types = len(type_counts)
+    if n_types <= 1:
+        return 0.0
+    entropy = -sum(
+        (c / total) * math.log2(c / total)
+        for c in type_counts.values()
+        if c > 0
+    )
+    max_entropy = math.log2(n_types)
+    return min(100.0, (entropy / max_entropy) * 100) if max_entropy > 0 else 0.0
+
+
+def _median(values: list) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    n = len(s)
+    return (s[n // 2] + s[(n - 1) // 2]) / 2
+
+
+def _match_source(name: str, metrics: dict) -> Optional[str]:
+    """Trouve la clé correspondante dans metrics (correspondance insensible à la casse)."""
+    name_lower = name.lower()
+    # Correspondance exacte
+    if name in metrics:
+        return name
+    # Correspondance insensible à la casse
+    for key in metrics:
+        if key.lower() == name_lower:
+            return key
+    # Correspondance partielle
+    for key in metrics:
+        if name_lower in key.lower() or key.lower() in name_lower:
+            return key
+    return None
+
+
+# ── Singleton ─────────────────────────────────────────────────────────────────
+
+def run_update(dry_run: bool = False) -> dict:
+    """Point d'entrée principal : calcule les métriques et met à jour le fichier."""
+    metrics = compute_source_metrics()
+    result = update_credibility_file(metrics, dry_run=dry_run)
+    result["metrics_computed"] = len(metrics)
+    return result

--- a/viewer/app.py
+++ b/viewer/app.py
@@ -61,6 +61,7 @@ from viewer.routes.scheduler       import scheduler_bp
 from viewer.routes.contradictions  import contradictions_bp
 from viewer.routes.merge           import merge_bp
 from viewer.routes.rss_direct      import rss_direct_bp
+from viewer.routes.self_learning   import self_learning_bp
 
 app.register_blueprint(files_bp)
 app.register_blueprint(entities_bp)
@@ -72,6 +73,7 @@ app.register_blueprint(scheduler_bp)
 app.register_blueprint(contradictions_bp)
 app.register_blueprint(merge_bp)
 app.register_blueprint(rss_direct_bp)
+app.register_blueprint(self_learning_bp)
 
 
 # ── Rebuild des indexes au démarrage ─────────────────────────────────────────

--- a/viewer/routes/scheduler.py
+++ b/viewer/routes/scheduler.py
@@ -235,6 +235,63 @@ def api_scheduler():
             "data_dir": None,
             "log_file": PROJECT_ROOT / "rapports" / "cron_keyword_reports.log",
         },
+        # ── Système auto-apprenant ───────────────────────────────────────────────
+        {
+            "name": "Archivage historique quotas",
+            "script": "archive_quota_state.py",
+            "cron": "5 0 * * *",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_archive_quota.log",
+        },
+        {
+            "name": "Calibration seuils alertes",
+            "script": "calibrate_alerts.py",
+            "cron": "15 7 * * *",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_calibrate_alerts.log",
+        },
+        {
+            "name": "Scores de qualité articles",
+            "script": "update_quality_scores.py",
+            "cron": "0 4 * * *",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_quality_scores.log",
+        },
+        {
+            "name": "Optimisation poids de scoring (hebdo)",
+            "script": "optimize_scoring_weights.py",
+            "cron": "30 5 * * 1",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_scoring_weights.log",
+        },
+        {
+            "name": "Optimisation quotas (hebdo)",
+            "script": "optimize_quota.py",
+            "cron": "45 5 * * 1",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_optimize_quota.log",
+        },
+        {
+            "name": "Détection dérive mots-clés (mensuel)",
+            "script": "keyword_drift_detector.py",
+            "cron": "0 5 28-31 * *",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_keyword_drift.log",
+        },
+        {
+            "name": "Performance empirique sources (mensuel)",
+            "script": "update_source_performance.py",
+            "cron": "30 4 1 * *",
+            "category": "Système auto-apprenant",
+            "data_dir": None,
+            "log_file": PROJECT_ROOT / "rapports" / "cron_source_performance.log",
+        },
     ]
     for t in fixed:
         if t.get("extra_last_run"):

--- a/viewer/routes/self_learning.py
+++ b/viewer/routes/self_learning.py
@@ -1,0 +1,242 @@
+"""
+viewer/routes/self_learning.py — API REST pour le système auto-apprenant
+
+Endpoints :
+  POST /api/engagement            Enregistre un signal d'engagement
+  GET  /api/engagement/stats      Statistiques d'engagement
+
+  GET  /api/quality/stats         Statistiques de qualité des articles
+  POST /api/quality/update        Recalcule les scores de qualité (async)
+
+  POST /api/contradiction/feedback  Enregistre un retour sur contradiction
+  GET  /api/contradiction/stats     Statistiques du feedback contradictions
+  POST /api/contradiction/calibrate Calibre les seuils (dry-run ou réel)
+
+  GET  /api/self-learning/status   Résumé de l'état du système auto-apprenant
+"""
+
+import threading
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request
+
+self_learning_bp = Blueprint("self_learning", __name__)
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+# ── Engagement ────────────────────────────────────────────────────────────────
+
+@self_learning_bp.route("/api/engagement", methods=["POST"])
+def record_engagement():
+    """Enregistre un signal d'engagement implicite.
+
+    Body JSON :
+      {
+        "signal_type"  : "article_opened",      (obligatoire)
+        "url"          : "https://...",          (optionnel)
+        "source"       : "Le Monde",             (optionnel)
+        "keyword"      : "intelligence-artificielle", (optionnel)
+        "entities"     : ["Emmanuel Macron"],    (optionnel)
+        "alert_entity" : "PERSON:Jean Dupont"    (optionnel, pour alert_dismissed)
+      }
+    """
+    data = request.get_json(silent=True) or {}
+    signal_type = data.get("signal_type")
+
+    if not signal_type:
+        return jsonify({"error": "signal_type requis"}), 400
+
+    try:
+        from utils.engagement_tracker import get_engagement_tracker, SIGNAL_WEIGHTS
+        if signal_type not in SIGNAL_WEIGHTS:
+            return jsonify({"error": f"signal_type inconnu : {signal_type}"}), 400
+
+        tracker = get_engagement_tracker()
+        tracker.record(
+            signal_type=signal_type,
+            url=data.get("url"),
+            source=data.get("source"),
+            keyword=data.get("keyword"),
+            entities=data.get("entities"),
+            alert_entity=data.get("alert_entity"),
+        )
+
+        # Si alerte ignorée → notifier aussi le calibrateur
+        if signal_type == "alert_dismissed" and data.get("alert_entity"):
+            try:
+                from utils.alert_calibrator import mark_dismissed
+                mark_dismissed(data["alert_entity"])
+            except Exception:
+                pass
+
+        return jsonify({"ok": True, "signal": signal_type}), 200
+
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@self_learning_bp.route("/api/engagement/stats", methods=["GET"])
+def engagement_stats():
+    """Retourne les statistiques d'engagement."""
+    try:
+        from utils.engagement_tracker import get_engagement_tracker
+        tracker = get_engagement_tracker()
+        return jsonify(tracker.get_stats()), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ── Qualité ───────────────────────────────────────────────────────────────────
+
+@self_learning_bp.route("/api/quality/stats", methods=["GET"])
+def quality_stats():
+    """Retourne les statistiques de qualité des articles depuis l'index."""
+    try:
+        from utils.quality_monitor import get_quality_stats
+        stats = get_quality_stats(project_root=_PROJECT_ROOT)
+        return jsonify(stats), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@self_learning_bp.route("/api/quality/update", methods=["POST"])
+def quality_update():
+    """Recalcule les scores de qualité (s'exécute en arrière-plan).
+
+    Body JSON : { "dry_run": false }
+    """
+    data = request.get_json(silent=True) or {}
+    dry_run = bool(data.get("dry_run", False))
+
+    def _run():
+        from utils.quality_monitor import update_quality_scores
+        update_quality_scores(project_root=_PROJECT_ROOT, dry_run=dry_run)
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    return jsonify({"ok": True, "message": "Mise à jour des scores de qualité lancée en arrière-plan"}), 202
+
+
+# ── Contradiction feedback ────────────────────────────────────────────────────
+
+@self_learning_bp.route("/api/contradiction/feedback", methods=["POST"])
+def contradiction_feedback():
+    """Enregistre un retour utilisateur sur une contradiction.
+
+    Body JSON :
+      {
+        "contradiction_type" : "CHIFFRE",
+        "action"             : "confirmed",    // ou "rejected"
+        "description"        : "...",
+        "confidence"         : 0.72,
+        "article_url"        : "https://..."
+      }
+    """
+    data = request.get_json(silent=True) or {}
+    ctype  = data.get("contradiction_type", "AUTRE")
+    action = data.get("action")
+
+    if action not in ("confirmed", "rejected"):
+        return jsonify({"error": "action doit être 'confirmed' ou 'rejected'"}), 400
+
+    try:
+        from utils.contradiction_feedback import get_contradiction_feedback
+        fb = get_contradiction_feedback()
+        fb.record(
+            contradiction_type=ctype,
+            action=action,
+            description=data.get("description"),
+            confidence=data.get("confidence"),
+            article_url=data.get("article_url"),
+        )
+        return jsonify({"ok": True, "action": action, "type": ctype}), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@self_learning_bp.route("/api/contradiction/stats", methods=["GET"])
+def contradiction_stats():
+    """Retourne les statistiques du feedback contradictions."""
+    try:
+        from utils.contradiction_feedback import get_contradiction_feedback
+        fb = get_contradiction_feedback()
+        return jsonify(fb.get_stats()), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@self_learning_bp.route("/api/contradiction/calibrate", methods=["POST"])
+def contradiction_calibrate():
+    """Lance une calibration des seuils de confiance.
+
+    Body JSON : { "dry_run": true }
+    """
+    data = request.get_json(silent=True) or {}
+    dry_run = bool(data.get("dry_run", True))
+
+    try:
+        from utils.contradiction_feedback import get_contradiction_feedback
+        fb = get_contradiction_feedback()
+        result = fb.calibrate(dry_run=dry_run)
+        return jsonify(result), 200
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+# ── Tableau de bord global ────────────────────────────────────────────────────
+
+@self_learning_bp.route("/api/self-learning/status", methods=["GET"])
+def self_learning_status():
+    """Retourne l'état global du système auto-apprenant."""
+    status: dict = {}
+
+    # Engagement
+    try:
+        from utils.engagement_tracker import get_engagement_tracker
+        stats = get_engagement_tracker().get_stats()
+        status["engagement"] = {
+            "total_articles_tracked": stats["total_articles_tracked"],
+            "total_signals_today": stats.get("daily_activity", {}).get(
+                __import__("datetime").date.today().isoformat(), {}
+            ).get("signals", 0),
+            "updated_at": stats.get("updated_at", ""),
+        }
+    except Exception:
+        status["engagement"] = {"error": "indisponible"}
+
+    # Poids de scoring
+    try:
+        from utils.scoring_optimizer import load_weights
+        status["scoring_weights"] = load_weights()
+    except Exception:
+        status["scoring_weights"] = {"error": "indisponible"}
+
+    # Qualité
+    try:
+        from utils.quality_monitor import get_quality_stats
+        q = get_quality_stats(project_root=_PROJECT_ROOT)
+        status["quality"] = {
+            "avg_score":     q.get("avg_score", 0),
+            "pct_complete":  q.get("pct_complete", 0),
+            "repair_needed": q.get("repair_needed", 0),
+        }
+    except Exception:
+        status["quality"] = {"error": "indisponible"}
+
+    # Feedback contradictions
+    try:
+        from utils.contradiction_feedback import get_contradiction_feedback
+        cf = get_contradiction_feedback().get_stats()
+        status["contradiction_feedback"] = {
+            "total_feedback": cf["total_feedback"],
+            "global_precision": cf.get("global_precision"),
+        }
+    except Exception:
+        status["contradiction_feedback"] = {"error": "indisponible"}
+
+    # Historique quota
+    history_dir = _PROJECT_ROOT / "data" / "quota_history"
+    status["quota_history_days"] = len(list(history_dir.glob("*.json"))) if history_dir.exists() else 0
+
+    return jsonify(status), 200


### PR DESCRIPTION
Implémente un système complet d'apprentissage continu pour WUDD.ai, permettant au logiciel d'ajuster son comportement selon les données et l'engagement utilisateur.

## Nouveaux modules (utils/)

- engagement_tracker.py   : collecte des signaux implicites d'engagement
  (ouverture, export, suppression, alertes ignorées) → data/engagement_state.json
- scoring_optimizer.py    : ajuste hebdos les poids de scoring selon la
  corrélation engagement↔composantes (freshness/entities/keywords/completeness)
- alert_calibrator.py     : auto-calibre les seuils d'alerte selon le taux
  de faux positifs mesuré sur 7 jours → data/alert_feedback.json
- source_performance.py   : score empirique des sources (enrichissement,
  diversité entités, engagement relatif) → sources_credibility.json
- quota_optimizer.py      : analyse l'historique data/quota_history/ et ajuste
  les plafonds journaliers (keywords saturés/sous-utilisés, monopoles entités)
- quality_monitor.py      : score de qualité 0-100 par article (résumé,
  entities, sentiment, images) → champ quality_score dans article_index
- contradiction_feedback.py : accumule confirmations/rejets sur contradictions
  et ajuste les seuils de confiance → data/contradiction_feedback.json

## Nouveaux scripts (scripts/)

- optimize_scoring_weights.py  : cron hebdo lundi 05h30
- calibrate_alerts.py          : cron quotidien 07h15
- archive_quota_state.py       : cron quotidien 00h05 (historisation)
- optimize_quota.py            : cron hebdo lundi 05h45
- update_quality_scores.py     : cron quotidien 04h00
- update_source_performance.py : cron mensuel 1er du mois 04h45
- keyword_drift_detector.py    : cron mensuel dernier jour 05h15

## API Flask (viewer/routes/self_learning.py)

- POST /api/engagement               (enregistre signal d'engagement)
- GET  /api/engagement/stats
- GET  /api/quality/stats
- POST /api/quality/update
- POST /api/contradiction/feedback   (confirme/rejette une contradiction)
- GET  /api/contradiction/stats
- POST /api/contradiction/calibrate
- GET  /api/self-learning/status     (tableau de bord global)

## Intégrations

- viewer/app.py          : enregistrement du blueprint self_learning_bp
- viewer/routes/scheduler.py : 7 nouvelles tâches dans catégorie
  "Système auto-apprenant" (visible dans l'onglet Planification)
- archives/crontab       : 8 nouvelles entrées cron
- config/scoring_weights.json : poids initiaux (rechargés par mtime)

## Tests

- tests/test_self_learning.py : 33 tests, 33 passent

https://claude.ai/code/session_01CxrGHRBFCzoMjcNCVFxkBL