### PR TITLE
fix: ajouter catégorie 'Système auto-apprenant' dans SchedulerPanel

### DIFF
--- a/viewer/src/components/SchedulerPanel.jsx
+++ b/viewer/src/components/SchedulerPanel.jsx
@@ -2,10 +2,11 @@ import { useEffect, useState, useCallback } from 'react'
 import { X, Clock, Calendar, RefreshCw, CheckCircle2, HelpCircle } from 'lucide-react'
 
 const CRON_CATEGORIES = [
-  { id: "Surveillance en continu", label: "Surveillance en continu",   desc: "Tâches fréquentes : chaque 5 min, 10 min ou toutes les 2h" },
-  { id: "Enrichissement nocturne", label: "Enrichissement nocturne",   desc: "Pipeline 01h–04h30 : backup, NER, images, sentiment, réparation, crédibilité sources" },
-  { id: "Rapports & digests",      label: "Rapports & digests",        desc: "Digests quotidiens, briefing hebdomadaire et collecte multi-flux" },
-  { id: "Pipeline mensuel",        label: "Pipeline mensuel",          desc: "Radar, Markdown et rapports générés le dernier jour du mois" },
+  { id: "Surveillance en continu",   label: "Surveillance en continu",   desc: "Tâches fréquentes : chaque 5 min, 10 min ou toutes les 2h" },
+  { id: "Enrichissement nocturne",   label: "Enrichissement nocturne",   desc: "Pipeline 01h–04h30 : backup, NER, images, sentiment, réparation, crédibilité sources" },
+  { id: "Rapports & digests",        label: "Rapports & digests",        desc: "Digests quotidiens, briefing hebdomadaire et collecte multi-flux" },
+  { id: "Pipeline mensuel",          label: "Pipeline mensuel",          desc: "Radar, Markdown et rapports générés le dernier jour du mois" },
+  { id: "Système auto-apprenant",    label: "Système auto-apprenant",    desc: "Optimisation des poids, calibration alertes, qualité articles, dérive mots-clés" },
 ]
 
 function formatDateTime(isoStr) {


### PR DESCRIPTION
CRON_CATEGORIES était hardcodé avec 4 entrées — les 7 nouvelles tâches auto-apprenantes n'apparaissaient pas dans l'onglet Planification. Ajout de la 5e catégorie + rebuild du frontend (dist/ ignoré par git).

https://claude.ai/code/session_01CxrGHRBFCzoMjcNCVFxkBL