### PR TITLE
fix: ajouter 'Système auto-apprenant' dans SettingsPanel.jsx (copie d…

### DIFF
--- a/viewer/src/components/SettingsPanel.jsx
+++ b/viewer/src/components/SettingsPanel.jsx
@@ -151,6 +151,7 @@ const CRON_CATEGORIES = [
   { id: "Enrichissement nocturne", label: "Enrichissement nocturne",   desc: "Pipeline 01h–04h30 : backup, NER, images, sentiment, réparation, crédibilité sources" },
   { id: "Rapports & digests",      label: "Rapports & digests",        desc: "Digests quotidiens, briefing hebdomadaire et collecte multi-flux" },
   { id: "Pipeline mensuel",        label: "Pipeline mensuel",          desc: "Radar, Markdown et rapports générés le dernier jour du mois" },
+  { id: "Système auto-apprenant",  label: "Système auto-apprenant",   desc: "Optimisation des poids, calibration alertes, qualité articles, dérive mots-clés" },
 ]
 
 function SchedulerTab() {


### PR DESCRIPTION
…upliquée)

CRON_CATEGORIES existait en double — dans SchedulerPanel.jsx (déjà corrigé) ET dans SettingsPanel.jsx (la version effectivement rendue dans l'onglet Planification). Correction de la source réelle + rebuild frontend.

https://claude.ai/code/session_01CxrGHRBFCzoMjcNCVFxkBL