### PR TITLE
docs: add native client specifications for macOS and iOS (SwiftUI/Xcode)

### DIFF
--- a/docs/CLIENT_SPEC_FONCTIONNELLE.md
+++ b/docs/CLIENT_SPEC_FONCTIONNELLE.md
@@ -1,0 +1,487 @@
+# WUDD.ai — Spécification Fonctionnelle Client Natif
+## Version 1.0 — Mars 2026
+
+---
+
+## 1. Vue d'ensemble
+
+### 1.1 Objectif
+
+L'application WUDD.ai Client est une application native universelle (macOS + iOS) permettant d'accéder à l'interface de veille intelligente d'actualités depuis n'importe quel appareil Apple. Elle communique exclusivement avec le backend Flask (port 5050) via réseau local ou Internet. La seule dépendance de configuration est l'URL/IP du serveur.
+
+### 1.2 Plateformes cibles
+
+| Plateforme | Version minimale | Format |
+|---|---|---|
+| iOS | 17.0+ | iPhone et iPad (Universal) |
+| macOS | 14.0 (Sonoma)+ | Application native (Mac Catalyst ou SwiftUI AppKit) |
+
+### 1.3 Principes UX
+
+- **Langue de l'interface :** Français (identique au backend)
+- **Thème :** Clair/Sombre automatique (suit les préférences système)
+- **Responsive :** Adaptatif sidebar-detail sur iPad/Mac, tab-based sur iPhone
+- **Offline-aware :** Affichage clair de l'état de connexion, gestion gracieuse des erreurs réseau
+- **Streaming natif :** Rendu progressif des synthèses IA (SSE)
+
+---
+
+## 2. Architecture de Navigation
+
+### 2.1 iPhone (Compact Width)
+
+```
+TabBar (5 onglets)
+├── 📰 Articles        → ArticlesTabView
+├── 🔍 Recherche       → SearchView
+├── 🏷️ Entités         → EntitiesTabView
+├── 🚨 Alertes         → AlertsTabView
+└── ⚙️ Paramètres      → SettingsTabView
+```
+
+### 2.2 iPad & macOS (Regular Width)
+
+```
+NavigationSplitView (3 colonnes)
+├── Sidebar (colonne 1)
+│   ├── Flux d'articles
+│   │   ├── [Nom du flux 1]
+│   │   ├── [Nom du flux 2]
+│   │   └── [Mots-clés RSS]
+│   ├── Tableaux de bord
+│   │   ├── Entités
+│   │   ├── Top Articles
+│   │   ├── Alertes
+│   │   └── Sources
+│   ├── Rapports
+│   │   ├── Markdown
+│   │   └── JSON brut
+│   ├── Outils
+│   │   ├── Chatbot IA
+│   │   ├── Planificateur
+│   │   └── Quotas
+│   └── Paramètres
+├── Liste/Détail (colonne 2)
+└── Détail contextuel (colonne 3, optionnelle)
+```
+
+---
+
+## 3. Écrans & Fonctionnalités
+
+### 3.1 Écran de Configuration Serveur
+
+**Déclencheur :** Premier lancement ou URL invalide/non joignable.
+
+**Éléments UI :**
+- Logo WUDD.ai + tagline "Votre veille intelligente"
+- Champ texte : `Adresse du serveur` (ex: `http://192.168.1.10:5050` ou `https://wudd.mondomaine.com`)
+- Bouton `Tester la connexion` → indicateur spinner + résultat OK/Erreur
+- Bouton `Enregistrer et continuer`
+- Lien `Aide` → description du format attendu
+
+**Comportement :**
+- L'URL est persistée dans `UserDefaults` (clé `serverURL`)
+- Test de connexion : `GET /api/files` → réponse 200 = succès
+- En cas d'erreur : message descriptif (ex: "Serveur inaccessible", "URL invalide")
+- Accessible ultérieurement via Paramètres → Serveur
+
+---
+
+### 3.2 Articles — Navigation par Flux
+
+**Vue Liste des Flux (`FluxListView`)**
+
+Affiche la liste des flux disponibles récupérés via `GET /api/flux-sources`.
+
+Éléments par flux :
+- Nom du flux
+- Badge : nombre d'articles (issu de `GET /api/files`)
+- Date de dernière mise à jour
+- Indicateur de nouveautés (si articles récents < 24h)
+
+**Vue Articles d'un Flux (`ArticleListView`)**
+
+Source : `GET /api/files` filtré par flux, puis lecture du JSON via `GET /api/content?path=...`
+
+Barre de filtres :
+- Tri : Date ↓ / Date ↑ / Score ↓
+- Sentiment : Tous / Positif / Neutre / Négatif
+- Source : Menu déroulant des sources présentes
+- Période : Ce mois / 7 jours / 30 jours / Tout
+
+Carte article (`ArticleCard`) :
+- Titre ou extrait du résumé (2 lignes max)
+- Source + date de publication
+- Badge sentiment (couleur : vert/gris/rouge)
+- Badge ton éditorial
+- Durée de lecture (icône horloge)
+- Vignette image (si disponible, `Images[0].URL`)
+- Score de pertinence (si présent)
+- Chips entités top 3 (PERSON, ORG, GPE)
+
+**Vue Détail Article (`ArticleDetailView`)**
+
+- Image pleine largeur en en-tête (si disponible)
+- Métadonnées : Source, Date, Durée de lecture, Sentiment, Ton
+- Résumé complet avec mise en évidence des entités (couleur par type)
+- Section Entités : chips groupées par type NER
+- Actions :
+  - `Rapport complet` → génère via SSE `/api/article/full-report`
+  - `Articles similaires` → panel flottant via `/api/articles/merge/search`
+  - `Annotations` → éditer notes + tags
+  - Partager (share sheet natif)
+  - Ouvrir URL originale dans Safari
+  - TTS (lecture à voix haute via AVSpeechSynthesizer)
+
+---
+
+### 3.3 Mots-clés RSS
+
+Même structure que les Flux mais pour `data/articles-from-rss/*.json`.
+
+Navigation : Sidebar → section "Mots-clés RSS" → liste alphabétique des keywords.
+
+Chaque keyword affiche son nombre d'articles et un indicateur de fraîcheur.
+
+---
+
+### 3.4 Recherche Globale (`SearchView`)
+
+Correspond à `GET /api/search` avec paramètres.
+
+**Interface :**
+- Champ de recherche avec suggestions en temps réel (debounce 300ms)
+- Filtres avancés (collapsible) :
+  - Type de fichier (articles / rapports)
+  - Sentiment
+  - Source
+  - Période (date_from / date_to avec date pickers natifs)
+- Liste de résultats groupés par fichier
+- Extrait avec terme surligné
+- Tap → ouvre ArticleDetailView ou MarkdownReportView
+
+**Recherche d'entités :**
+- Onglet "Entités" dans la vue recherche
+- Source : `GET /api/search/entity?q=...&type=...`
+- Résultats avec type NER + nb d'articles associés
+
+---
+
+### 3.5 Tableau de Bord Entités (`EntityDashboardView`)
+
+Source : `GET /api/entities/dashboard`
+
+**Sections :**
+
+**Statistiques globales :**
+- Total articles analysés
+- % avec entités extraites
+- Nb entités uniques
+
+**Distribution par type NER :**
+- Graphique barres horizontales (SwiftUI Charts)
+- Liste déroulante : top 20 entités par type avec compteur
+
+**Tabs :**
+- `Liste` : tableau trié par nb de mentions, filtrable par type
+- `Carte` : MapKit — pins géographiques pour GPE/LOC (source: `/api/entities/geocode`)
+- `Galerie` : grille d'images pour PERSON/ORG/PRODUCT (source: `/api/entities/images`)
+- `Chronologie` : timeline par date de mention (source: `/api/entities/timeline`)
+
+**Tap sur une entité → `EntityDetailView`**
+
+---
+
+### 3.6 Détail Entité (`EntityDetailView`)
+
+**En-tête :**
+- Image (Wikimedia si disponible)
+- Nom + type NER (badge coloré)
+- Nb d'articles + nb de sources
+- Bouton "Surveiller" (toggle watch list)
+
+**Tabs :**
+
+**Info :**
+- Synthèse IA streamée via SSE `/api/synthesize-topic?entity_type=...&entity_value=...`
+- Rendu Markdown progressif avec indicateur de chargement
+- Bouton "Régénérer"
+- Bouton "Rapport complet" → `EntityFullReportView`
+
+**Articles :**
+- Liste des articles mentionnant cette entité
+- Source : `/api/entities/articles?type=...&value=...`
+- Même format que `ArticleCard`
+
+**Graphe :**
+- Visualisation des co-occurrences (entités liées)
+- Source : `/api/entities/cooccurrences?type=...&value=...`
+- Représentation : liste avec force d'association (pas de WebGL requis)
+- Sur iPad/Mac : graphe force-directed (SwiftUI Canvas)
+
+**Calendrier :**
+- Grille mensuelle des mentions
+- Source : `/api/entities/timeline?type=...&value=...`
+- Intensité de couleur = nombre de mentions par jour
+
+---
+
+### 3.7 Rapport Complet Entité (`EntityFullReportView`)
+
+- Modal plein écran
+- Streaming progressif SSE en 3 phases (Info → RAG → Articles)
+- Rendu Markdown avec support Mermaid (WebView embarquée pour les diagrammes)
+- Actions : Copier texte, Partager, Exporter .md, Régénérer
+
+---
+
+### 3.8 Rapport Complet Article (`ArticleFullReportView`)
+
+- Modal plein écran
+- Streaming SSE depuis `/api/article/full-report`
+- Image article en en-tête
+- Band d'avatars entités
+- Rendu Markdown avec diagrammes Mermaid (WebView)
+- Actions : Copier, Partager, Télécharger .md, Imprimer, Régénérer
+
+---
+
+### 3.9 Alertes (`AlertsView`)
+
+Source : `GET /api/alerts`
+
+**Liste d'alertes :**
+- Badge niveau : CRITIQUE (rouge), ÉLEVÉ (orange), MODÉRÉ (jaune)
+- Entité concernée + type NER
+- Raison textuelle
+- Nombre d'articles liés
+- Date de détection
+- Tap → liste des articles liés
+
+**Actions :**
+- Filtrer par niveau (segmented control)
+- Bouton "Lancer détection" → `POST /api/alerts/run` avec spinner
+- Configurer règles → `AlertRulesView`
+
+**`AlertRulesView` :**
+- Seuils par type d'entité (PERSON / ORG / GPE / etc.)
+- Niveaux modéré / élevé / critique
+- Source/destination : `GET /POST /api/alerts/rules`
+
+---
+
+### 3.10 Top Articles (`TopArticlesView`)
+
+Source : `GET /api/articles/top?n=20&hours=48`
+
+- Podium visuel : rang 1, 2, 3 mis en avant
+- Liste numérotée pour les suivants
+- Carte avec score + composantes (pertinence, crédibilité, fraîcheur)
+- Sélecteur de fenêtre temporelle : 24h / 48h / 7j / Tout
+- Tap → `ArticleDetailView`
+
+---
+
+### 3.11 Sources (`SourceBiasView`)
+
+Source : `GET /api/sources/bias` + `GET /api/sources/credibility`
+
+- Score de crédibilité par source (0–100) avec jauge couleur
+- Indicateurs : Transparence éditoriale, Âge du domaine, Notation MBFC
+- Regroupement par score (Fiable ≥ 70 / Modéré 40–69 / À vérifier < 40)
+- Graphique en barres (SwiftUI Charts)
+
+---
+
+### 3.12 Visualiseur de Rapports Markdown (`MarkdownReportView`)
+
+Source : `GET /api/content?path=rapports/markdown/...`
+
+- Liste des rapports par flux/période
+- Rendu Markdown complet :
+  - Titres, paragraphes, tableaux, listes
+  - Images HTTP embarquées
+  - Blocs de code
+  - Blocs Mermaid → rendu via WKWebView avec bibliothèque mermaid.js
+  - Blocs `flux-chart` → rendu natif SwiftUI (barres horizontales)
+  - Blocs `keyword-graph` → liste SwiftUI des mots-clés
+- Actions : Partager, Imprimer, Copier
+
+---
+
+### 3.13 Chatbot IA (`ChatbotView`)
+
+Source : `POST /api/chat/stream` (SSE)
+
+- Interface conversation (bulles message)
+- Champ texte + bouton Envoyer
+- Streaming de la réponse en temps réel (tokens affichés progressivement)
+- Historique de conversation dans la session
+- Bouton "Nouvelle conversation"
+- Sélection de contexte : fichiers de référence (picker de fichiers data/)
+- Bouton "Sauvegarder" → `POST /api/chat/save`
+
+---
+
+### 3.14 Planificateur (`SchedulerView`)
+
+Source : `GET /api/scheduler`
+
+- Liste des tâches cron groupées par catégorie :
+  - Surveillance en continu
+  - Enrichissement nocturne
+  - Rapports matinaux
+  - Pipeline mensuel
+- Pour chaque tâche : nom, script, cron schedule, prochain passage, dernier passage
+- Indicateur de santé (vert si cron Docker actif)
+- Console script : `GET /api/scripts/keyword-rss/stream` (SSE logs)
+
+---
+
+### 3.15 Quotas (`QuotaView`)
+
+Source : `GET /api/quota/config` + `GET /api/quota/stats`
+
+- 4 sliders de configuration :
+  - Limite globale journalière
+  - Limite par mot-clé
+  - Limite par source
+  - Limite par entité nommée
+- Graphiques d'utilisation actuelle vs limite
+- Bouton "Réinitialiser compteurs" → `POST /api/quota/reset`
+- Sauvegarde → `POST /api/quota/config`
+
+---
+
+### 3.16 Paramètres (`SettingsView`)
+
+Sections :
+
+**Serveur :**
+- URL du serveur (modifiable + test de connexion)
+- Version du backend (affichée si accessible)
+- Statut de connexion (en ligne / hors ligne)
+
+**Flux RSS :**
+- Liste des flux (`GET /api/flux-sources`)
+- Ajouter / modifier / supprimer un flux
+- Validation URL avant sauvegarde
+
+**Mots-clés :**
+- Liste des keywords (`GET /api/keywords`)
+- Ajouter / modifier / supprimer
+
+**Sources RSS (OPML) :**
+- Liste des feeds (`GET /api/rss-feeds`)
+- Statistiques par feed
+- Ajouter feed (résolution URL → `POST /api/rss-feeds/resolve`)
+
+**Sources Web :**
+- Liste (`GET /api/web-sources`)
+- Ajouter / modifier
+
+**Fournisseur IA :**
+- Sélecteur EurIA / Claude
+- Test de connectivité (`POST /api/ai-check`)
+
+**Exports & Notifications :**
+- Configuration webhook (Discord / Slack / Ntfy)
+- Test webhook (`POST /api/export/webhook-test`)
+
+**Sauvegardes :**
+- Chemins BACKUP_L1 / BACKUP_L2 (lecture seule)
+
+**À propos :**
+- Version de l'app
+- Liens : GitHub, Documentation
+- Mentions légales / MIT License
+
+---
+
+### 3.17 Contradictions (`ContradictionsView`)
+
+Source : `GET /api/contradictions`
+
+- Liste des contradictions détectées
+- Pour chaque contradiction : entité, affirmation 1 vs affirmation 2, sources, score de confiance
+- Lancer une analyse sur un article : `GET /api/contradictions/stream?url=...` (SSE)
+- Feedback utilisateur : `POST /api/contradiction/feedback`
+
+---
+
+### 3.18 Clustering Thématique (`ClusterView`)
+
+Source : `GET /api/analytics/clusters?days=7`
+
+- Articles groupés par thème (IA, Géopolitique, Économie, etc.)
+- Nb d'articles + sentiment moyen par cluster
+- Expansion du cluster → liste des articles
+- Sélecteur de fenêtre : 7j / 14j / 30j
+
+---
+
+## 4. Interactions et Patterns Transversaux
+
+### 4.1 Gestion de Connexion
+
+- Indicateur de statut réseau permanent (barre de statut ou badge dans la sidebar)
+- En mode hors ligne : affichage des données en cache (NSCache / Core Data simple)
+- Timeout API : 30s pour les requêtes standard, illimité pour SSE
+- Retry automatique ×3 avec backoff exponentiel pour les erreurs 5xx
+
+### 4.2 Streaming SSE
+
+- Toutes les vues de rapport/synthèse utilisent `URLSession.dataTask` avec lecture chunked
+- Affichage progressif : le Markdown est rendu au fur et à mesure
+- Indicateur de chargement animé pendant le stream
+- Bouton d'arrêt pour interrompre un stream en cours
+
+### 4.3 Mise en Cache
+
+- Réponses de liste (fichiers, alertes) : cache mémoire TTL 5 minutes
+- Images articles et entités : cache disque (URLCache système)
+- Contenu des rapports lus : cache mémoire session
+
+### 4.4 Partage et Export
+
+- Share Sheet natif iOS/macOS pour tout contenu textuel
+- Export .md des rapports et synthèses
+- Copier dans le presse-papiers
+- Impression via UIPrintInteractionController / NSPrintOperation
+
+### 4.5 TTS (Lecture à voix haute)
+
+- AVSpeechSynthesizer avec langue fr-FR
+- Contrôles : play/pause/stop
+- Vitesse de lecture ajustable
+- Disponible sur tout contenu textuel
+
+### 4.6 Annotations
+
+- Notes et tags locaux sur les articles
+- Persistance via l'API backend : `POST /api/annotations`
+- Visible dans ArticleDetailView et ArticleCard (badge si annotée)
+
+---
+
+## 5. Gestion des Erreurs
+
+| Erreur | Affichage | Action proposée |
+|---|---|---|
+| Serveur inaccessible | Banner rouge + message | Aller aux Paramètres |
+| Erreur 401/403 | Alert | Vérifier la configuration |
+| Erreur 500 | Toast + log | Réessayer |
+| Timeout SSE | Toast | Bouton "Réessayer" |
+| Fichier JSON invalide | Message inline | Afficher le JSON brut |
+| Aucun article disponible | Illustration + texte | Lien vers la documentation |
+
+---
+
+## 6. Accessibilité
+
+- Support complet VoiceOver (labels, hints, traits)
+- Support Dynamic Type (toutes les tailles de police système)
+- Support du mode réduit de mouvement (pas d'animations si `reduceMotion` activé)
+- Contraste conforme WCAG AA
+- Navigation clavier complète (macOS + iPad hardware keyboard)

--- a/docs/CLIENT_SPEC_TECHNIQUE.md
+++ b/docs/CLIENT_SPEC_TECHNIQUE.md
@@ -1,0 +1,797 @@
+# WUDD.ai — Spécification Technique Client Natif
+## Version 1.0 — Mars 2026
+
+---
+
+## 1. Stack Technique
+
+| Composant | Technologie | Version minimale |
+|---|---|---|
+| Langage | Swift | 5.9+ |
+| Framework UI | SwiftUI | iOS 17 / macOS 14 |
+| Graphiques | Swift Charts | iOS 16 / macOS 13 |
+| Cartographie | MapKit (SwiftUI) | iOS 17 / macOS 14 |
+| Rendu Markdown | swift-markdown-ui (Gonzalo Nuñez) | 2.3+ |
+| Rendu Mermaid | WKWebView + mermaid.min.js (CDN local) | — |
+| HTTP / REST | URLSession (async/await) | — |
+| SSE Streaming | URLSession.bytes (AsyncSequence) | — |
+| Cache disque | URLCache (système) + FileManager | — |
+| Cache mémoire | NSCache | — |
+| Persistance config | UserDefaults | — |
+| Persistance légère | SwiftData (ou UserDefaults pour MVP) | iOS 17 / macOS 14 |
+| Gestion d'état | @Observable (Observation framework) | iOS 17 / macOS 14 |
+| Concurrence | Swift Concurrency (async/await, actors) | — |
+| Tests unitaires | XCTest | — |
+| Tests UI | XCUITest | — |
+
+---
+
+## 2. Architecture du Projet
+
+### 2.1 Pattern : MVVM + Services
+
+```
+WUDDClient/
+├── App/
+│   ├── WUDDClientApp.swift          # @main, AppDelegate si nécessaire
+│   └── AppState.swift               # Observable global state
+│
+├── Core/
+│   ├── Network/
+│   │   ├── APIClient.swift          # URLSession wrapper, base URL, headers
+│   │   ├── SSEClient.swift          # Server-Sent Events streaming client
+│   │   ├── NetworkMonitor.swift     # NWPathMonitor — statut réseau
+│   │   └── APIError.swift           # Types d'erreurs enum
+│   │
+│   ├── Models/                      # Structs Codable mappant le JSON backend
+│   │   ├── Article.swift
+│   │   ├── Entity.swift
+│   │   ├── Alert.swift
+│   │   ├── FluxSource.swift
+│   │   ├── QuotaConfig.swift
+│   │   ├── SchedulerTask.swift
+│   │   ├── SearchResult.swift
+│   │   └── ...
+│   │
+│   ├── Services/                    # Couche métier — appels API groupés
+│   │   ├── ArticleService.swift
+│   │   ├── EntityService.swift
+│   │   ├── AlertService.swift
+│   │   ├── ReportService.swift
+│   │   ├── SearchService.swift
+│   │   ├── SettingsService.swift
+│   │   ├── QuotaService.swift
+│   │   └── SchedulerService.swift
+│   │
+│   └── Persistence/
+│       ├── ServerConfig.swift       # UserDefaults wrapper pour l'URL serveur
+│       ├── CacheManager.swift       # NSCache + URLCache
+│       └── AnnotationStore.swift    # Cache local des annotations
+│
+├── Features/
+│   ├── Onboarding/
+│   │   ├── ServerSetupView.swift
+│   │   └── ServerSetupViewModel.swift
+│   │
+│   ├── Articles/
+│   │   ├── FluxListView.swift
+│   │   ├── ArticleListView.swift
+│   │   ├── ArticleDetailView.swift
+│   │   ├── ArticleCard.swift
+│   │   ├── ArticleFullReportView.swift
+│   │   ├── SimilarArticlesPanel.swift
+│   │   └── ViewModels/
+│   │       ├── FluxListViewModel.swift
+│   │       ├── ArticleListViewModel.swift
+│   │       └── ArticleDetailViewModel.swift
+│   │
+│   ├── Entities/
+│   │   ├── EntityDashboardView.swift
+│   │   ├── EntityDetailView.swift
+│   │   ├── EntityFullReportView.swift
+│   │   ├── EntityMapView.swift
+│   │   ├── EntityGalleryView.swift
+│   │   ├── EntityTimelineView.swift
+│   │   └── ViewModels/
+│   │       ├── EntityDashboardViewModel.swift
+│   │       └── EntityDetailViewModel.swift
+│   │
+│   ├── Search/
+│   │   ├── SearchView.swift
+│   │   └── SearchViewModel.swift
+│   │
+│   ├── Alerts/
+│   │   ├── AlertsView.swift
+│   │   ├── AlertRulesView.swift
+│   │   └── AlertsViewModel.swift
+│   │
+│   ├── Reports/
+│   │   ├── ReportListView.swift
+│   │   ├── MarkdownReportView.swift
+│   │   └── ViewModels/
+│   │       └── ReportViewModel.swift
+│   │
+│   ├── Chatbot/
+│   │   ├── ChatbotView.swift
+│   │   ├── ChatbotBubble.swift
+│   │   └── ChatbotViewModel.swift
+│   │
+│   ├── Scheduler/
+│   │   ├── SchedulerView.swift
+│   │   └── SchedulerViewModel.swift
+│   │
+│   ├── Settings/
+│   │   ├── SettingsView.swift
+│   │   ├── ServerSettingsView.swift
+│   │   ├── FluxSettingsView.swift
+│   │   ├── KeywordSettingsView.swift
+│   │   ├── RSSFeedSettingsView.swift
+│   │   ├── ProviderSettingsView.swift
+│   │   └── ViewModels/
+│   │       └── SettingsViewModel.swift
+│   │
+│   ├── Quota/
+│   │   ├── QuotaView.swift
+│   │   └── QuotaViewModel.swift
+│   │
+│   └── TopArticles/
+│       ├── TopArticlesView.swift
+│       └── TopArticlesViewModel.swift
+│
+├── Shared/
+│   ├── Components/
+│   │   ├── SentimentBadge.swift     # Badge coloré sentiment
+│   │   ├── EntityChip.swift         # Chip entité avec couleur NER
+│   │   ├── EntityHighlighter.swift  # Texte avec entités surlignées
+│   │   ├── MarkdownRenderer.swift   # Wrapper swift-markdown-ui
+│   │   ├── MermaidView.swift        # WKWebView pour diagrammes Mermaid
+│   │   ├── SSEProgressView.swift    # Indicateur streaming SSE
+│   │   ├── ConnectionStatusBar.swift
+│   │   ├── LoadingView.swift
+│   │   ├── ErrorView.swift
+│   │   └── ScoreGauge.swift
+│   │
+│   ├── Extensions/
+│   │   ├── Color+NER.swift          # Couleurs par type d'entité
+│   │   ├── Date+French.swift        # Formatage dates français
+│   │   ├── String+Markdown.swift
+│   │   └── View+Conditional.swift
+│   │
+│   └── Resources/
+│       ├── mermaid.min.js           # Copie locale (no CDN en prod)
+│       └── Localizable.strings      # Strings FR
+│
+└── Tests/
+    ├── WUDDClientTests/             # Tests unitaires (XCTest)
+    └── WUDDClientUITests/           # Tests UI (XCUITest)
+```
+
+---
+
+## 3. Modèles de Données (Swift Structs)
+
+### 3.1 Article
+
+```swift
+struct Article: Codable, Identifiable {
+    // Clés JSON françaises → CodingKeys
+    enum CodingKeys: String, CodingKey {
+        case datePublication = "Date de publication"
+        case sources         = "Sources"
+        case url             = "URL"
+        case resume          = "Résumé"
+        case images          = "Images"
+        case entities        = "entities"
+        case sentiment       = "sentiment"
+        case scoreSentiment  = "score_sentiment"
+        case tonEditorial    = "ton_editorial"
+        case scoreTon        = "score_ton"
+        case tempsLectureMin = "temps_lecture_minutes"
+        case tempsLectureLabel = "temps_lecture_label"
+        case scoreSource     = "score_source"
+        case titre           = "Titre"
+    }
+
+    var id: String { url }
+
+    let datePublication: String
+    let sources: String
+    let url: String
+    let resume: String
+    var images: [ArticleImage]?
+    var entities: [String: [String]]?
+    var sentiment: String?
+    var scoreSentiment: Int?
+    var tonEditorial: String?
+    var scoreTon: Int?
+    var tempsLectureMin: Double?
+    var tempsLectureLabel: String?
+    var scoreSource: Int?
+    var titre: String?
+}
+
+struct ArticleImage: Codable {
+    let url: String
+    let width: Int?
+    enum CodingKeys: String, CodingKey {
+        case url = "URL"
+        case width = "Width"
+    }
+}
+```
+
+### 3.2 Alerte
+
+```swift
+struct WuddAlert: Codable, Identifiable {
+    let entity: String
+    let type: String
+    let niveau: String          // "critique" | "élevé" | "modéré"
+    let raison: String
+    let articlesCount: Int
+    let articles: [String]      // URLs
+    let date: String
+
+    var id: String { "\(entity)-\(date)" }
+
+    enum CodingKeys: String, CodingKey {
+        case entity, type, niveau, raison
+        case articlesCount = "articles_count"
+        case articles, date
+    }
+}
+```
+
+### 3.3 Entité NER
+
+```swift
+struct EntityStat: Codable, Identifiable {
+    let type: String
+    let uniqueCount: Int
+    let mentionCount: Int
+    let top: [EntityEntry]
+
+    var id: String { type }
+}
+
+struct EntityEntry: Codable, Identifiable {
+    let value: String
+    let count: Int
+    var id: String { value }
+}
+
+enum NERType: String, CaseIterable {
+    case person = "PERSON"
+    case org    = "ORG"
+    case gpe    = "GPE"
+    case loc    = "LOC"
+    case product = "PRODUCT"
+    case event  = "EVENT"
+    case date   = "DATE"
+    case money  = "MONEY"
+    // ... 18 types total
+
+    var color: Color {
+        switch self {
+        case .person:  return .purple
+        case .org:     return .blue
+        case .gpe:     return .green
+        case .loc:     return .teal
+        case .product: return .orange
+        case .event:   return .pink
+        default:       return .gray
+        }
+    }
+}
+```
+
+### 3.4 Tâche Planificateur
+
+```swift
+struct SchedulerTask: Codable, Identifiable {
+    let name: String
+    let script: String
+    let cron: String
+    let category: String
+    let nextRun: String?
+    let lastRun: String?
+    let logFile: String?
+    let detail: String?
+
+    var id: String { name }
+}
+```
+
+### 3.5 FluxSource
+
+```swift
+struct FluxSource: Codable, Identifiable {
+    let title: String
+    let url: String
+    var cron: String?
+    var timeout: Int?
+
+    var id: String { title }
+}
+```
+
+---
+
+## 4. Couche Réseau
+
+### 4.1 APIClient
+
+```swift
+@Observable
+final class APIClient {
+    static let shared = APIClient()
+
+    var baseURL: URL {
+        get { URL(string: ServerConfig.shared.serverURL)! }
+    }
+
+    private let session: URLSession
+
+    init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        config.timeoutIntervalForResource = 300
+        config.urlCache = URLCache(
+            memoryCapacity: 20 * 1024 * 1024,   // 20 MB
+            diskCapacity: 100 * 1024 * 1024      // 100 MB
+        )
+        self.session = URLSession(configuration: config)
+    }
+
+    func get<T: Decodable>(_ path: String, query: [String: String] = [:]) async throws -> T {
+        let url = buildURL(path, query: query)
+        let (data, response) = try await session.data(from: url)
+        try validate(response)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func post<B: Encodable, T: Decodable>(_ path: String, body: B) async throws -> T {
+        var request = URLRequest(url: buildURL(path))
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(body)
+        let (data, response) = try await session.data(for: request)
+        try validate(response)
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private func buildURL(_ path: String, query: [String: String] = [:]) -> URL {
+        var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: true)!
+        if !query.isEmpty {
+            components.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        return components.url!
+    }
+
+    private func validate(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) else {
+            throw APIError.httpError((response as? HTTPURLResponse)?.statusCode ?? 0)
+        }
+    }
+}
+```
+
+### 4.2 SSEClient (Server-Sent Events)
+
+```swift
+final class SSEClient {
+    private var task: URLSessionDataTask?
+
+    /// Stream SSE depuis un endpoint GET, appelle onChunk pour chaque fragment Markdown reçu
+    func stream(url: URL, onChunk: @escaping (String) -> Void, onComplete: @escaping () -> Void) {
+        var request = URLRequest(url: url)
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = .infinity
+
+        let delegate = SSEDelegate(onChunk: onChunk, onComplete: onComplete)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        task = session.dataTask(with: request)
+        task?.resume()
+    }
+
+    /// Stream SSE depuis un endpoint POST (pour /api/chat/stream)
+    func streamPOST<B: Encodable>(url: URL, body: B, onChunk: @escaping (String) -> Void, onComplete: @escaping () -> Void) {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = .infinity
+        request.httpBody = try? JSONEncoder().encode(body)
+
+        let delegate = SSEDelegate(onChunk: onChunk, onComplete: onComplete)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        task = session.dataTask(with: request)
+        task?.resume()
+    }
+
+    func cancel() {
+        task?.cancel()
+    }
+}
+
+// Parsing du format SSE "data: ...\n\n"
+private class SSEDelegate: NSObject, URLSessionDataDelegate {
+    private var buffer = ""
+    let onChunk: (String) -> Void
+    let onComplete: () -> Void
+
+    init(onChunk: @escaping (String) -> Void, onComplete: @escaping () -> Void) {
+        self.onChunk = onChunk
+        self.onComplete = onComplete
+    }
+
+    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        guard let text = String(data: data, encoding: .utf8) else { return }
+        buffer += text
+        let events = buffer.components(separatedBy: "\n\n")
+        buffer = events.last ?? ""
+        for event in events.dropLast() {
+            for line in event.components(separatedBy: "\n") {
+                if line.hasPrefix("data: ") {
+                    let chunk = String(line.dropFirst(6))
+                    if chunk != "[DONE]" {
+                        DispatchQueue.main.async { self.onChunk(chunk) }
+                    }
+                }
+            }
+        }
+    }
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        DispatchQueue.main.async { self.onComplete() }
+    }
+}
+```
+
+### 4.3 Services — Exemples
+
+```swift
+// ArticleService.swift
+final class ArticleService {
+    private let api = APIClient.shared
+
+    func listFiles() async throws -> [FileMetadata] {
+        try await api.get("/api/files")
+    }
+
+    func loadArticles(path: String) async throws -> [Article] {
+        let response: FileContentResponse = try await api.get("/api/content", query: ["path": path])
+        let data = response.content.data(using: .utf8) ?? Data()
+        return try JSONDecoder().decode([Article].self, from: data)
+    }
+
+    func topArticles(n: Int = 20, hours: Int = 48) async throws -> [ScoredArticle] {
+        try await api.get("/api/articles/top", query: [
+            "n": String(n),
+            "hours": String(hours)
+        ])
+    }
+}
+
+// EntityService.swift
+final class EntityService {
+    private let api = APIClient.shared
+
+    func dashboard() async throws -> EntityDashboard {
+        try await api.get("/api/entities/dashboard")
+    }
+
+    func articles(type: String, value: String) async throws -> [Article] {
+        try await api.get("/api/entities/articles", query: ["type": type, "value": value])
+    }
+
+    func cooccurrences(type: String, value: String) async throws -> [CooccurrenceEntry] {
+        try await api.get("/api/entities/cooccurrences", query: ["type": type, "value": value])
+    }
+}
+```
+
+---
+
+## 5. Gestion de Configuration Serveur
+
+```swift
+// ServerConfig.swift — UserDefaults wrapper
+@Observable
+final class ServerConfig {
+    static let shared = ServerConfig()
+
+    private let key = "serverURL"
+    private let defaults = UserDefaults.standard
+
+    var serverURL: String {
+        get { defaults.string(forKey: key) ?? "" }
+        set { defaults.set(newValue, forKey: key) }
+    }
+
+    var isConfigured: Bool {
+        !serverURL.isEmpty && URL(string: serverURL) != nil
+    }
+
+    // Test de connexion
+    func testConnection() async -> Bool {
+        guard let url = URL(string: serverURL + "/api/files") else { return false }
+        do {
+            let (_, response) = try await URLSession.shared.data(from: url)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+}
+```
+
+---
+
+## 6. Rendu Mermaid (WKWebView)
+
+```swift
+// MermaidView.swift
+struct MermaidView: UIViewRepresentable {  // NSViewRepresentable sur macOS
+    let mermaidCode: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let escaped = mermaidCode
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "`", with: "\\`")
+
+        let html = """
+        <!DOCTYPE html>
+        <html>
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            body { margin: 0; background: transparent; }
+            .mermaid { font-family: -apple-system; }
+          </style>
+          <script src="mermaid.min.js"></script>
+        </head>
+        <body>
+          <div class="mermaid">\(escaped)</div>
+          <script>
+            mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+          </script>
+        </body>
+        </html>
+        """
+        webView.loadHTMLString(html, baseURL: Bundle.main.resourceURL)
+    }
+}
+```
+
+Note : `mermaid.min.js` doit être inclus dans le bundle de l'application (ajouter au target dans Xcode).
+
+---
+
+## 7. Rendu Markdown
+
+Utiliser le package [swift-markdown-ui](https://github.com/gonzalezreal/swift-markdown-ui) (SPM) :
+
+```swift
+// MarkdownRenderer.swift
+import MarkdownUI
+
+struct MarkdownRenderer: View {
+    let content: String
+    var isStreaming: Bool = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                // Décomposer le contenu pour détecter les blocs Mermaid
+                ForEach(parsedBlocks, id: \.id) { block in
+                    switch block.type {
+                    case .mermaid(let code):
+                        MermaidView(mermaidCode: code)
+                            .frame(height: 300)
+                    case .markdown(let text):
+                        Markdown(text)
+                            .markdownTheme(.gitHub)
+                    }
+                }
+
+                if isStreaming {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 4)
+                }
+            }
+            .padding()
+        }
+    }
+
+    private var parsedBlocks: [MarkdownBlock] { /* parse mermaid fences */ }
+}
+```
+
+---
+
+## 8. Gestion de l'État Global
+
+```swift
+// AppState.swift
+@Observable
+final class AppState {
+    // Configuration
+    let serverConfig = ServerConfig.shared
+
+    // Statut réseau
+    var isOnline: Bool = true
+
+    // Navigation
+    var selectedFlux: FluxSource?
+    var selectedFile: FileMetadata?
+    var selectedEntity: EntityEntry?
+
+    // Données partagées (cross-feature)
+    var alerts: [WuddAlert] = []
+    var alertsCount: Int { alerts.filter { $0.niveau == "critique" || $0.niveau == "élevé" }.count }
+
+    init() {
+        // Démarrer le moniteur réseau
+        NetworkMonitor.shared.start { [weak self] online in
+            self?.isOnline = online
+        }
+    }
+}
+```
+
+---
+
+## 9. Navigation Principale
+
+### iOS (TabView)
+
+```swift
+struct ContentView: View {
+    @State private var appState = AppState()
+    @State private var selectedTab = 0
+
+    var body: some View {
+        if !appState.serverConfig.isConfigured {
+            ServerSetupView()
+        } else {
+            TabView(selection: $selectedTab) {
+                ArticlesTabView()
+                    .tabItem { Label("Articles", systemImage: "newspaper") }
+                    .tag(0)
+
+                SearchView()
+                    .tabItem { Label("Recherche", systemImage: "magnifyingglass") }
+                    .tag(1)
+
+                EntityDashboardView()
+                    .tabItem { Label("Entités", systemImage: "tag") }
+                    .tag(2)
+
+                AlertsView()
+                    .badge(appState.alertsCount)
+                    .tabItem { Label("Alertes", systemImage: "bell") }
+                    .tag(3)
+
+                SettingsView()
+                    .tabItem { Label("Paramètres", systemImage: "gearshape") }
+                    .tag(4)
+            }
+            .environment(appState)
+        }
+    }
+}
+```
+
+### iPad / macOS (NavigationSplitView)
+
+```swift
+struct SplitContentView: View {
+    @State private var appState = AppState()
+    @State private var columnVisibility = NavigationSplitViewVisibility.all
+    @State private var sidebarSelection: SidebarItem? = .articles
+
+    var body: some View {
+        NavigationSplitView(columnVisibility: $columnVisibility) {
+            SidebarView(selection: $sidebarSelection)
+        } content: {
+            ContentListView(selection: sidebarSelection)
+        } detail: {
+            DetailView(selection: sidebarSelection)
+        }
+        .environment(appState)
+        .navigationSplitViewStyle(.balanced)
+    }
+}
+```
+
+---
+
+## 10. Cibles Xcode
+
+| Target | Identifiant | Plateformes |
+|---|---|---|
+| WUDDClient | com.wudd.client | iOS 17+, macOS 14+ (Universal) |
+| WUDDClientTests | com.wudd.client.tests | iOS, macOS |
+| WUDDClientUITests | com.wudd.client.uitests | iOS, macOS |
+
+**Approche recommandée :** Application SwiftUI universelle avec `#if os(iOS)` / `#if os(macOS)` pour les adaptations plateforme (pas Mac Catalyst).
+
+---
+
+## 11. Dépendances (Swift Package Manager)
+
+Ajouter dans Xcode via File → Add Package Dependencies :
+
+| Package | URL | Version | Usage |
+|---|---|---|---|
+| swift-markdown-ui | https://github.com/gonzalezreal/swift-markdown-ui | ≥ 2.3.0 | Rendu Markdown |
+| Kingfisher (optionnel) | https://github.com/onevcat/Kingfisher | ≥ 7.0.0 | Cache images avancé |
+
+Note : Swift Charts, MapKit, WKWebView, AVFoundation, URLSession sont tous des frameworks Apple inclus dans le SDK — aucune dépendance externe nécessaire pour ces fonctionnalités.
+
+---
+
+## 12. Permissions & Entitlements
+
+| Permission | Raison | Fichier |
+|---|---|---|
+| `NSAppTransportSecurity` → `NSAllowsArbitraryLoads: true` | Connexion HTTP locale (IP privée) | Info.plist |
+| `com.apple.security.network.client` | Connexions réseau sortantes | .entitlements (macOS) |
+| `NSSpeechRecognitionUsageDescription` | TTS (si reconnaissance vocale ajoutée plus tard) | Info.plist |
+| `NSMicrophoneUsageDescription` | Si fonctionnalité dictée ajoutée | Info.plist |
+
+**Info.plist — Transport Security :**
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <true/>
+</dict>
+```
+
+Ceci est nécessaire pour se connecter à `http://192.168.x.x:5050` (HTTP non-TLS sur réseau local).
+
+---
+
+## 13. Performances & Optimisations
+
+| Problème | Solution |
+|---|---|
+| Listes d'articles longues | `LazyVStack` + identifiants stables |
+| Images distantes | URLCache système (100 MB disque) + placeholder |
+| Dashboard entités lourd | Cache mémoire TTL 5 min dans le ViewModel |
+| Streaming SSE | `@MainActor` pour les updates UI, chunking du Markdown |
+| JSON larges fichiers | Décodage sur un thread background (`Task.detached`) |
+| Recherche en temps réel | Debounce 300ms avant envoi requête |
+
+---
+
+## 14. Tests
+
+### Unitaires (XCTest)
+
+- `APIClientTests` : mock URLSession, vérification encodage/décodage
+- `ArticleDecoderTests` : clés françaises CodingKeys
+- `SSEClientTests` : parsing chunks "data: ..."
+- `ServerConfigTests` : UserDefaults read/write
+
+### UI (XCUITest)
+
+- `OnboardingTest` : saisie URL + test connexion
+- `ArticleListTest` : chargement liste + tap article
+- `SearchTest` : saisie + résultats
+
+### Mocks
+
+Créer un `MockAPIClient` (protocol `APIClientProtocol`) pour les tests sans backend réel. Fournir des fixtures JSON dans `Tests/Fixtures/`.

--- a/docs/CLIENT_XCODE_GUIDE.md
+++ b/docs/CLIENT_XCODE_GUIDE.md
@@ -1,0 +1,738 @@
+# WUDD.ai Client — Guide Xcode : De la Spécification à l'Application
+## Version 1.0 — Mars 2026
+
+---
+
+## Prérequis
+
+| Outil | Version requise |
+|---|---|
+| macOS | 14.0 Sonoma ou plus récent |
+| Xcode | 15.0 ou plus récent |
+| Compte développeur Apple | Requis pour déploiement sur devices physiques |
+| Swift | 5.9+ (inclus avec Xcode 15) |
+
+---
+
+## Phase 1 — Création du Projet Xcode
+
+### Étape 1.1 — Nouveau projet
+
+1. Ouvrir Xcode → **File → New → Project**
+2. Choisir la plateforme : **Multiplatform** (onglet en haut)
+3. Sélectionner le template : **App**
+4. Cliquer **Next**
+
+### Étape 1.2 — Configuration du projet
+
+Remplir les champs :
+
+| Champ | Valeur |
+|---|---|
+| Product Name | `WUDDClient` |
+| Team | Votre compte développeur Apple |
+| Organization Identifier | `com.votredomaine` (ex: `com.wudd`) |
+| Bundle Identifier | `com.votredomaine.WUDDClient` (auto-rempli) |
+| Interface | **SwiftUI** |
+| Language | **Swift** |
+| Include Tests | **Cocher** (Unit Tests + UI Tests) |
+
+5. Cliquer **Next**
+6. Choisir un dossier de destination (ex: `~/Developer/WUDDClient`)
+7. Cliquer **Create**
+
+### Étape 1.3 — Configurer les cibles de déploiement
+
+Dans le **Project Navigator** (panneau gauche), cliquer sur `WUDDClient` (icône bleue en haut).
+
+Dans **TARGETS → WUDDClient** :
+- Onglet **General** → **Minimum Deployments** :
+  - iOS : `17.0`
+  - macOS : `14.0`
+
+Dans **PROJECT → WUDDClient** :
+- Onglet **Info** → même configuration
+
+---
+
+## Phase 2 — Structure des Dossiers
+
+### Étape 2.1 — Créer les groupes de dossiers
+
+Dans le Project Navigator, faire **clic droit sur WUDDClient** → **New Group** pour créer la hiérarchie suivante :
+
+```
+WUDDClient/
+├── App/
+├── Core/
+│   ├── Network/
+│   ├── Models/
+│   ├── Services/
+│   └── Persistence/
+├── Features/
+│   ├── Onboarding/
+│   ├── Articles/
+│   │   └── ViewModels/
+│   ├── Entities/
+│   │   └── ViewModels/
+│   ├── Search/
+│   ├── Alerts/
+│   ├── Reports/
+│   │   └── ViewModels/
+│   ├── Chatbot/
+│   ├── Scheduler/
+│   ├── Settings/
+│   │   └── ViewModels/
+│   ├── Quota/
+│   └── TopArticles/
+├── Shared/
+│   ├── Components/
+│   ├── Extensions/
+│   └── Resources/
+└── Tests/
+```
+
+**Conseil :** Créer les groupes sans créer les fichiers pour l'instant. Les fichiers seront ajoutés étape par étape.
+
+### Étape 2.2 — Vérifier la structure de fichiers sur disque
+
+Xcode crée les groupes comme des dossiers virtuels par défaut. Pour qu'ils correspondent à des vrais dossiers sur disque (recommandé) :
+
+1. Sélectionner tous les groupes créés
+2. Clic droit → **Convert to Folder** (ou lors de la création choisir **New Folder**)
+
+---
+
+## Phase 3 — Fichiers de Configuration Essentiels
+
+### Étape 3.1 — Info.plist : Transport Security
+
+Dans le **Project Navigator** → `WUDDClient/Info.plist` (ou via **TARGETS → WUDDClient → Info**) :
+
+Ajouter la clé `NSAppTransportSecurity` :
+
+1. Cliquer sur `+` pour ajouter une clé
+2. Taper `NSAppTransportSecurity` → choisir le type `Dictionary`
+3. Développer et ajouter :
+   - Clé : `NSAllowsArbitraryLoads` → Type : `Boolean` → Valeur : `YES`
+
+**Pourquoi :** Permet la connexion HTTP non-TLS vers l'adresse IP locale du serveur Flask (ex: `http://192.168.1.10:5050`).
+
+### Étape 3.2 — Entitlements macOS
+
+Dans **TARGETS → WUDDClient → Signing & Capabilities** :
+
+1. Cliquer **+ Capability**
+2. Ajouter **App Sandbox** (si pas déjà présent)
+3. Dans les entitlements, cocher :
+   - **Network → Outgoing Connections (Client)** : ON
+
+---
+
+## Phase 4 — Dépendances (Swift Package Manager)
+
+### Étape 4.1 — Ajouter swift-markdown-ui
+
+1. **File → Add Package Dependencies**
+2. Dans la barre de recherche, coller : `https://github.com/gonzalezreal/swift-markdown-ui`
+3. Choisir la version : **Up to Next Major Version** → `2.3.0`
+4. Cliquer **Add Package**
+5. Dans la fenêtre des targets, cocher `WUDDClient`
+6. Cliquer **Add Package**
+
+### Étape 4.2 — (Optionnel) Ajouter Kingfisher pour le cache d'images
+
+1. **File → Add Package Dependencies**
+2. Coller : `https://github.com/onevcat/Kingfisher`
+3. Version : **Up to Next Major** → `7.0.0`
+4. Ajouter au target `WUDDClient`
+
+### Étape 4.3 — Ajouter mermaid.min.js
+
+1. Télécharger `mermaid.min.js` depuis [https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js](https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js)
+2. Glisser le fichier dans `Shared/Resources/` dans le Project Navigator
+3. Dans la boîte de dialogue : vérifier que **Add to targets: WUDDClient** est coché
+4. Vérifier dans **TARGETS → WUDDClient → Build Phases → Copy Bundle Resources** que `mermaid.min.js` y figure
+
+---
+
+## Phase 5 — Implémentation par Couches
+
+L'ordre d'implémentation suit les dépendances : Core d'abord, puis Features, puis UI.
+
+### Étape 5.1 — Core/Persistence/ServerConfig.swift
+
+Créer le fichier `ServerConfig.swift` dans `Core/Persistence/` :
+
+```swift
+import Foundation
+import Observation
+
+@Observable
+final class ServerConfig {
+    static let shared = ServerConfig()
+    private init() {}
+
+    private let key = "serverURL"
+
+    var serverURL: String {
+        get { UserDefaults.standard.string(forKey: key) ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: key) }
+    }
+
+    var isConfigured: Bool {
+        !serverURL.isEmpty && URL(string: serverURL) != nil
+    }
+
+    func testConnection() async -> Bool {
+        guard let url = URL(string: serverURL + "/api/files") else { return false }
+        do {
+            let (_, response) = try await URLSession.shared.data(from: url)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+}
+```
+
+### Étape 5.2 — Core/Network/APIError.swift
+
+```swift
+import Foundation
+
+enum APIError: LocalizedError {
+    case invalidURL
+    case httpError(Int)
+    case decodingError(Error)
+    case networkError(Error)
+    case serverNotConfigured
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:           return "URL du serveur invalide"
+        case .httpError(let code):  return "Erreur serveur : \(code)"
+        case .decodingError(let e): return "Erreur de décodage : \(e.localizedDescription)"
+        case .networkError(let e):  return "Erreur réseau : \(e.localizedDescription)"
+        case .serverNotConfigured:  return "Serveur non configuré"
+        }
+    }
+}
+```
+
+### Étape 5.3 — Core/Network/APIClient.swift
+
+Créer le fichier selon la spécification technique (section 4.1).
+
+### Étape 5.4 — Core/Network/SSEClient.swift
+
+Créer le fichier selon la spécification technique (section 4.2).
+
+### Étape 5.5 — Core/Models/ — Tous les modèles
+
+Créer un fichier par modèle selon la spécification technique (section 3) :
+- `Article.swift`
+- `Alert.swift`
+- `EntityStat.swift`
+- `FluxSource.swift`
+- `SchedulerTask.swift`
+- `SearchResult.swift`
+- `QuotaConfig.swift`
+- `FileMetadata.swift`
+- `ScoredArticle.swift`
+- `CooccurrenceEntry.swift`
+
+### Étape 5.6 — Core/Services/
+
+Créer les services (section 4.3 de la spec technique) :
+- `ArticleService.swift`
+- `EntityService.swift`
+- `AlertService.swift`
+- `SearchService.swift`
+- `SettingsService.swift`
+- `QuotaService.swift`
+- `SchedulerService.swift`
+- `ReportService.swift`
+
+### Étape 5.7 — App/AppState.swift
+
+Créer le fichier selon la spécification technique (section 8).
+
+---
+
+## Phase 6 — Shared Components
+
+### Étape 6.1 — Shared/Extensions/Color+NER.swift
+
+```swift
+import SwiftUI
+
+extension Color {
+    static func nerColor(for type: String) -> Color {
+        switch type.uppercased() {
+        case "PERSON":   return .purple
+        case "ORG":      return .blue
+        case "GPE":      return .green
+        case "LOC":      return .teal
+        case "PRODUCT":  return .orange
+        case "EVENT":    return .pink
+        case "DATE":     return .gray
+        case "MONEY":    return Color(red: 0.1, green: 0.6, blue: 0.3)
+        default:         return .secondary
+        }
+    }
+}
+```
+
+### Étape 6.2 — Shared/Components/SentimentBadge.swift
+
+```swift
+import SwiftUI
+
+struct SentimentBadge: View {
+    let sentiment: String?
+
+    var body: some View {
+        if let sentiment {
+            Text(sentiment.capitalized)
+                .font(.caption2)
+                .fontWeight(.medium)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(color.opacity(0.15))
+                .foregroundStyle(color)
+                .clipShape(Capsule())
+        }
+    }
+
+    private var color: Color {
+        switch sentiment?.lowercased() {
+        case "positif":  return .green
+        case "négatif":  return .red
+        default:         return .gray
+        }
+    }
+}
+```
+
+### Étape 6.3 — Shared/Components/EntityChip.swift
+
+```swift
+import SwiftUI
+
+struct EntityChip: View {
+    let value: String
+    let type: String
+
+    var body: some View {
+        Text(value)
+            .font(.caption2)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(Color.nerColor(for: type).opacity(0.12))
+            .foregroundStyle(Color.nerColor(for: type))
+            .clipShape(RoundedRectangle(cornerRadius: 4))
+    }
+}
+```
+
+### Étape 6.4 — Shared/Components/MermaidView.swift
+
+Créer selon la spécification technique (section 6). Sur macOS, utiliser `NSViewRepresentable` au lieu de `UIViewRepresentable` :
+
+```swift
+#if os(iOS)
+import UIKit
+typealias PlatformViewRepresentable = UIViewRepresentable
+#else
+import AppKit
+typealias PlatformViewRepresentable = NSViewRepresentable
+#endif
+```
+
+### Étape 6.5 — Shared/Components/MarkdownRenderer.swift
+
+Créer selon la spécification technique (section 7). Import `MarkdownUI` (package ajouté à l'étape 4.1).
+
+---
+
+## Phase 7 — Feature : Onboarding (Configuration Serveur)
+
+### Étape 7.1 — Features/Onboarding/ServerSetupView.swift
+
+```swift
+import SwiftUI
+
+struct ServerSetupView: View {
+    @State private var urlInput: String = ""
+    @State private var isTesting = false
+    @State private var testResult: Bool? = nil
+    @State private var errorMessage: String? = nil
+
+    var body: some View {
+        VStack(spacing: 32) {
+            // Logo et titre
+            VStack(spacing: 8) {
+                Image(systemName: "newspaper.circle.fill")
+                    .font(.system(size: 64))
+                    .foregroundStyle(.blue)
+                Text("WUDD.ai")
+                    .font(.largeTitle.bold())
+                Text("Votre veille intelligente")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Formulaire
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Adresse du serveur")
+                    .font(.headline)
+
+                TextField("http://192.168.1.10:5050", text: $urlInput)
+                    .textFieldStyle(.roundedBorder)
+                    #if os(iOS)
+                    .keyboardType(.URL)
+                    .autocorrectionDisabled()
+                    .autocapitalization(.none)
+                    #endif
+
+                Text("Exemple : http://192.168.1.10:5050 ou https://wudd.mondomaine.com")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                if let error = errorMessage {
+                    Label(error, systemImage: "exclamationmark.triangle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+
+                if let result = testResult {
+                    Label(
+                        result ? "Connexion réussie" : "Serveur inaccessible",
+                        systemImage: result ? "checkmark.circle" : "xmark.circle"
+                    )
+                    .foregroundStyle(result ? .green : .red)
+                }
+            }
+            .padding()
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+
+            // Actions
+            VStack(spacing: 12) {
+                Button {
+                    Task { await testConnection() }
+                } label: {
+                    if isTesting {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Label("Tester la connexion", systemImage: "network")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(urlInput.isEmpty || isTesting)
+
+                Button("Enregistrer et continuer") {
+                    saveAndContinue()
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(testResult != true)
+            }
+        }
+        .padding(32)
+        .frame(maxWidth: 480)
+    }
+
+    private func testConnection() async {
+        isTesting = true
+        testResult = nil
+        errorMessage = nil
+        ServerConfig.shared.serverURL = urlInput.trimmingCharacters(in: .whitespaces)
+        testResult = await ServerConfig.shared.testConnection()
+        if testResult == false {
+            errorMessage = "Impossible de joindre le serveur. Vérifiez l'adresse et que le serveur est démarré."
+        }
+        isTesting = false
+    }
+
+    private func saveAndContinue() {
+        ServerConfig.shared.serverURL = urlInput.trimmingCharacters(in: .whitespaces)
+    }
+}
+```
+
+---
+
+## Phase 8 — Feature : Articles
+
+### Étape 8.1 — Implémenter ArticleListViewModel
+
+Dans `Features/Articles/ViewModels/ArticleListViewModel.swift` :
+
+```swift
+import Foundation
+import Observation
+
+@Observable
+final class ArticleListViewModel {
+    var articles: [Article] = []
+    var isLoading = false
+    var errorMessage: String?
+    var filterSentiment: String? = nil
+    var sortOrder: SortOrder = .dateDesc
+
+    enum SortOrder { case dateDesc, dateAsc, scoreDesc }
+
+    private let service = ArticleService()
+
+    func load(path: String) async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            articles = try await service.loadArticles(path: path)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    var filteredArticles: [Article] {
+        var result = articles
+        if let sentiment = filterSentiment {
+            result = result.filter { $0.sentiment == sentiment }
+        }
+        switch sortOrder {
+        case .dateDesc: result.sort { $0.datePublication > $1.datePublication }
+        case .dateAsc:  result.sort { $0.datePublication < $1.datePublication }
+        case .scoreDesc: result.sort { ($0.scoreSource ?? 0) > ($1.scoreSource ?? 0) }
+        }
+        return result
+    }
+}
+```
+
+### Étape 8.2 — Implémenter ArticleCard et ArticleListView
+
+Suivre les spécifications fonctionnelles (section 3.2) pour créer les composants visuels avec SwiftUI.
+
+---
+
+## Phase 9 — Feature : Streaming SSE dans les Views
+
+### Exemple : SynthèseView avec streaming
+
+```swift
+import SwiftUI
+
+struct EntitySynthesisView: View {
+    let entityType: String
+    let entityValue: String
+
+    @State private var content = ""
+    @State private var isStreaming = false
+    private let sseClient = SSEClient()
+
+    var body: some View {
+        ScrollView {
+            MarkdownRenderer(content: content, isStreaming: isStreaming)
+        }
+        .navigationTitle(entityValue)
+        .toolbar {
+            Button("Régénérer") { startStream() }
+                .disabled(isStreaming)
+        }
+        .task { startStream() }
+        .onDisappear { sseClient.cancel() }
+    }
+
+    private func startStream() {
+        content = ""
+        isStreaming = true
+
+        guard let url = URL(string: ServerConfig.shared.serverURL
+            + "/api/synthesize-topic"
+            + "?entity_type=\(entityType.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+            + "&entity_value=\(entityValue.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? "")"
+        ) else { return }
+
+        sseClient.stream(url: url) { chunk in
+            content += chunk
+        } onComplete: {
+            isStreaming = false
+        }
+    }
+}
+```
+
+---
+
+## Phase 10 — Navigation Principale (App Entry Point)
+
+### Étape 10.1 — App/WUDDClientApp.swift
+
+```swift
+import SwiftUI
+
+@main
+struct WUDDClientApp: App {
+    @State private var appState = AppState()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(appState)
+        }
+        #if os(macOS)
+        .defaultSize(width: 1200, height: 800)
+        #endif
+    }
+}
+```
+
+### Étape 10.2 — App/RootView.swift
+
+```swift
+import SwiftUI
+
+struct RootView: View {
+    @Environment(AppState.self) private var appState
+
+    var body: some View {
+        if !appState.serverConfig.isConfigured {
+            ServerSetupView()
+        } else {
+            #if os(iOS)
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                SplitContentView()
+            } else {
+                TabContentView()
+            }
+            #else
+            SplitContentView()  // macOS
+            #endif
+        }
+    }
+}
+```
+
+---
+
+## Phase 11 — Build et Tests
+
+### Étape 11.1 — Build pour le simulateur
+
+1. Dans la barre Xcode, sélectionner la cible :
+   - iOS : `iPhone 16 Pro` (simulateur)
+   - macOS : `My Mac`
+2. **Product → Build** (`⌘B`)
+3. Corriger les erreurs de compilation (normalement liées à des imports manquants)
+
+### Étape 11.2 — Run sur simulateur
+
+1. **Product → Run** (`⌘R`)
+2. L'app se lance — l'écran de configuration serveur apparaît
+3. Entrer l'URL du backend local : `http://localhost:5050` (si backend tourne sur la même machine)
+4. Tester la connexion → si OK, explorer les features
+
+### Étape 11.3 — Lancer les tests unitaires
+
+1. **Product → Test** (`⌘U`)
+2. Vérifier le rapport dans le **Report Navigator** (onglet 6)
+
+### Étape 11.4 — Run sur device physique
+
+1. Connecter l'iPhone ou iPad en USB
+2. Dans la barre Xcode, sélectionner le device physique
+3. Dans **TARGETS → Signing & Capabilities** : choisir votre Team
+4. **Product → Run** (`⌘R`)
+
+---
+
+## Phase 12 — Déploiement
+
+### Distribution ad-hoc (test interne)
+
+1. **Product → Archive** (`⌘⇧B` puis Archive)
+2. Dans **Organizer** → sélectionner l'archive → **Distribute App**
+3. Choisir **Ad Hoc** ou **Development**
+4. Exporter le `.ipa` et installer via **Apple Configurator** ou **TestFlight**
+
+### Distribution via TestFlight
+
+1. Créer l'app sur [App Store Connect](https://appstoreconnect.apple.com)
+2. **Product → Archive → Distribute App → App Store Connect**
+3. Uploader le build
+4. Sur App Store Connect → TestFlight → Ajouter testeurs
+
+### App Store
+
+1. Préparer les captures d'écran (6.5", 5.5", iPad Pro 12.9")
+2. Remplir la fiche App Store (description, catégorie, PEGI)
+3. Soumettre via **Distribute App → App Store Connect**
+
+---
+
+## Checklist de Développement
+
+### Phase 1 — MVP (Fonctionnalités essentielles)
+- [ ] Configuration serveur (URL + test de connexion)
+- [ ] Navigation principale (TabView iPhone / SplitView iPad+Mac)
+- [ ] Liste des flux et articles
+- [ ] Détail article (résumé, entités, sentiment)
+- [ ] Recherche globale
+- [ ] Alertes (liste + niveaux)
+
+### Phase 2 — Enrichissements
+- [ ] Tableau de bord entités (liste + stats)
+- [ ] Détail entité (articles, co-occurrences)
+- [ ] Synthèse IA streamée (SSE)
+- [ ] Top articles
+- [ ] Sources / crédibilité
+- [ ] Rapport complet article (SSE + Markdown)
+
+### Phase 3 — Fonctionnalités avancées
+- [ ] Carte géographique (MapKit + geocoding)
+- [ ] Galerie images entités
+- [ ] Chronologie entités
+- [ ] Rapport complet entité (SSE multi-phases)
+- [ ] Chatbot IA (SSE)
+- [ ] Planificateur (cron status)
+- [ ] Quotas (sliders + compteurs)
+- [ ] Diagrammes Mermaid (WKWebView)
+
+### Phase 4 — Finalisation
+- [ ] Annotations (notes + tags)
+- [ ] TTS (lecture à voix haute)
+- [ ] Partage natif (Share Sheet)
+- [ ] Export PDF / Markdown
+- [ ] Mode hors ligne (cache)
+- [ ] Tests unitaires (>80% couverture Core/)
+- [ ] Tests UI (parcours principaux)
+- [ ] Accessibilité VoiceOver
+- [ ] Icône app + écran de lancement
+
+---
+
+## Ressources Complémentaires
+
+| Ressource | URL |
+|---|---|
+| Documentation SwiftUI | https://developer.apple.com/documentation/swiftui |
+| Swift Charts | https://developer.apple.com/documentation/charts |
+| MapKit SwiftUI | https://developer.apple.com/documentation/mapkit/mapview |
+| URLSession async/await | https://developer.apple.com/documentation/foundation/urlsession |
+| swift-markdown-ui | https://github.com/gonzalezreal/swift-markdown-ui |
+| Human Interface Guidelines | https://developer.apple.com/design/human-interface-guidelines |
+| App Store Connect | https://appstoreconnect.apple.com |
+
+---
+
+## Conseils Importants
+
+1. **Tester sur device réel dès que possible** — le comportement réseau diffère du simulateur
+2. **L'URL HTTP locale ne fonctionnera pas sur App Store** sans justification — prévoir HTTPS pour la production
+3. **App Transport Security** : pour l'accès à une IP locale, `NSAllowsArbitraryLoads` est nécessaire mais à documenter dans l'App Store review notes
+4. **Background networking** : pour les longues synthèses SSE, utiliser `URLSessionConfiguration.background` si l'app doit continuer à streamer en arrière-plan
+5. **Multitasking iPad** : tester en Split View et Slide Over (le NavigationSplitView gère bien ces cas automatiquement)
+6. **Dynamic Type** : utiliser uniquement `.font(.headline)`, `.font(.body)`, etc. — jamais de tailles fixes en points


### PR DESCRIPTION
Three specification documents covering the WUDD.ai native client app:
- CLIENT_SPEC_FONCTIONNELLE.md: 18 screens, navigation patterns, UX rules
- CLIENT_SPEC_TECHNIQUE.md: MVVM architecture, Swift models, API/SSE clients
- CLIENT_XCODE_GUIDE.md: step-by-step Xcode guide from setup to App Store