### PR TITLE
fix(dates): restaure l'heure de publication et unifie le parsing des dates

### DIFF
--- a/scripts/check_source_health.py
+++ b/scripts/check_source_health.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.config import get_config
 from utils.logging import default_logger as LOG
+from utils.date_utils import parse_article_date
 
 # Messages d'erreur reconnus dans les résumés (issus de l'API)
 _ERROR_MARKERS = [
@@ -47,25 +48,9 @@ OUTPUT_FILE = PROJECT_ROOT / "data" / "source_health.json"
 
 
 def _parse_date(d: str) -> datetime | None:
-    """Parse les formats de dates courants."""
-    if not d:
-        return None
-    fmts = [
-        "%Y-%m-%dT%H:%M:%S%z",
-        "%Y-%m-%dT%H:%M:%SZ",
-        "%Y-%m-%dT%H:%M:%S",
-        "%d/%m/%Y",
-        "%Y-%m-%d",
-    ]
-    for fmt in fmts:
-        try:
-            dt = datetime.strptime(d[:19] + ("+00:00" if "Z" in d and "+" not in d else ""), fmt) if "T" in d else datetime.strptime(d[:10], fmt)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt
-        except Exception:
-            continue
-    return None
+    """Datetime UTC (tz-aware) ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822."""
+    dt = parse_article_date(d or "")
+    return dt.replace(tzinfo=timezone.utc) if dt is not None else None
 
 
 def _is_error_summary(resume: str) -> bool:

--- a/scripts/cluster_articles.py
+++ b/scripts/cluster_articles.py
@@ -31,6 +31,8 @@ except ImportError:
     def print_console(msg, level="info"):
         print(f"[{level.upper()}] {msg}")
 
+from utils.date_utils import parse_article_date
+
 
 ENTITY_TYPES = {"PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "LOC"}
 
@@ -48,16 +50,9 @@ THEMATIC_KEYWORDS = {
 
 
 def _parse_date(date_str: str):
-    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%d", "%d/%m/%Y"):
-        try:
-            return datetime.strptime(date_str[:19], fmt).replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    try:
-        from email.utils import parsedate_to_datetime
-        return parsedate_to_datetime(date_str).astimezone(timezone.utc)
-    except Exception:
-        return None
+    """Datetime UTC (tz-aware) ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822."""
+    dt = parse_article_date(date_str or "")
+    return dt.replace(tzinfo=timezone.utc) if dt is not None else None
 
 
 def load_articles(project_root: Path, days: int = 7) -> list[dict]:
@@ -149,7 +144,11 @@ def cluster_articles(articles: list[dict], min_similarity: float = 0.15) -> list
         top_entities = sorted(entity_counts.items(), key=lambda x: x[1], reverse=True)[:10]
 
         cluster_articles_list = []
-        for art, _ in sorted(group, key=lambda x: x[0].get("Date de publication", ""), reverse=True)[:20]:
+        for art, _ in sorted(
+            group,
+            key=lambda x: _parse_date(x[0].get("Date de publication", "")) or datetime.min.replace(tzinfo=timezone.utc),
+            reverse=True,
+        )[:20]:
             cluster_articles_list.append({
                 "Date de publication": art.get("Date de publication", ""),
                 "Sources": art.get("Sources", ""),

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -29,6 +29,7 @@ _PROJECT_ROOT = _SCRIPT_DIR.parent
 sys.path.insert(0, str(_PROJECT_ROOT))
 
 from utils.logging import print_console, default_logger
+from utils.date_utils import parse_article_date
 
 # ── Constantes ───────────────────────────────────────────────────────────────
 
@@ -39,29 +40,16 @@ _ENTITY_TYPES_PERTINENTS = {
     "PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "DISEASE", "NORP"
 }
 
-_DATE_FMTS = (
-    "%Y-%m-%dT%H:%M:%SZ",
-    "%Y-%m-%d",
-    "%d/%m/%Y",
-)
-
-
 # ── Parsing de date ───────────────────────────────────────────────────────────
 
 def _parse_date(date_str: str) -> datetime | None:
-    if not date_str:
-        return None
-    for fmt in _DATE_FMTS:
-        try:
-            return datetime.strptime(date_str[:len(fmt)], fmt).replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    try:
-        from email.utils import parsedate_to_datetime
-        return parsedate_to_datetime(date_str).astimezone(timezone.utc)
-    except Exception:
-        pass
-    return None
+    """Datetime UTC (tz-aware) ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822.
+
+    Délègue au parseur canonique (gère l'ISO avec/sans Z et le DD/MM/YYYY) puis
+    réattache UTC pour rester comparable aux datetime tz-aware du script.
+    """
+    dt = parse_article_date(date_str or "")
+    return dt.replace(tzinfo=timezone.utc) if dt is not None else None
 
 
 # ── Collecte par flux ─────────────────────────────────────────────────────────

--- a/scripts/detect_contradictions.py
+++ b/scripts/detect_contradictions.py
@@ -31,6 +31,7 @@ logging.basicConfig(stream=sys.stderr, level=logging.INFO)
 
 from utils.config import get_config
 from utils.api_client import get_ai_client
+from utils.date_utils import parse_article_date
 from utils.claim_extractor import extract_claims
 from utils.contradiction_engine import compare_claims_deterministic, arbitrate_with_llm
 
@@ -94,14 +95,8 @@ def jaccard(text_a: str, text_b: str) -> float:
 # ── Chargement des articles ───────────────────────────────────────────────────
 
 def _parse_date(raw: str) -> datetime | None:
-    if not raw:
-        return None
-    for fmt in ("%d/%m/%Y", "%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S"):
-        try:
-            return datetime.strptime(raw[:19], fmt)
-        except ValueError:
-            continue
-    return None
+    """Datetime naïf ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822."""
+    return parse_article_date(raw or "")
 
 
 def load_articles(days: int = 3, flux: str | None = None) -> list[dict]:

--- a/scripts/entity_timeline.py
+++ b/scripts/entity_timeline.py
@@ -40,6 +40,7 @@ _PROJECT_ROOT = _SCRIPT_DIR.parent
 sys.path.insert(0, str(_PROJECT_ROOT))
 
 from utils.logging import default_logger
+from utils.date_utils import parse_article_date
 from utils.entity_canonicalization import get_entity_canonicalizer
 from utils.entity_index import STRUCTURAL_ENTITY_TYPES
 from utils.entity_matching import (
@@ -58,30 +59,16 @@ _MONITORED_TYPES = {
     "PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "LOC", "FAC", "LAW", "WORK_OF_ART"
 }
 
-_DATE_FMTS = (
-    "%Y-%m-%dT%H:%M:%SZ",
-    "%Y-%m-%d",
-    "%d/%m/%Y",
-)
-
-
 # ── Parsing de date ───────────────────────────────────────────────────────────
 
 def _parse_date(date_str: str) -> datetime | None:
-    """Retourne un datetime UTC ou None."""
-    if not date_str:
-        return None
-    for fmt in _DATE_FMTS:
-        try:
-            return datetime.strptime(date_str[:len(fmt)], fmt).replace(tzinfo=timezone.utc)
-        except ValueError:
-            continue
-    try:
-        from email.utils import parsedate_to_datetime
-        return parsedate_to_datetime(date_str).astimezone(timezone.utc)
-    except Exception:
-        pass
-    return None
+    """Datetime UTC (tz-aware) ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822.
+
+    Délègue au parseur canonique (gère l'ISO avec/sans Z et le DD/MM/YYYY) puis
+    réattache UTC pour rester comparable aux datetime tz-aware du script.
+    """
+    dt = parse_article_date(date_str or "")
+    return dt.replace(tzinfo=timezone.utc) if dt is not None else None
 
 
 # ── Collecte ──────────────────────────────────────────────────────────────────

--- a/scripts/export_obsidian.py
+++ b/scripts/export_obsidian.py
@@ -40,6 +40,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.config import get_config
 from utils.logging import default_logger as LOG
+from utils.date_utils import parse_article_date
 
 # ── Constantes ────────────────────────────────────────────────────────────────
 VEILLE_ROOT = "Veille"          # Dossier racine dans le vault
@@ -106,21 +107,8 @@ def _md5(text: str) -> str:
 
 
 def _parse_date(date_str: str) -> Optional[datetime]:
-    """Tente de parser une date depuis les formats courants WUDD.ai."""
-    if not date_str:
-        return None
-    formats = [
-        "%Y-%m-%dT%H:%M:%SZ",
-        "%d/%m/%Y",
-        "%Y-%m-%d",
-        "%d/%m/%Y %H:%M:%S",
-    ]
-    for fmt in formats:
-        try:
-            return datetime.strptime(date_str.strip(), fmt)
-        except ValueError:
-            continue
-    return None
+    """Datetime naïf ou None — corpus mixte ISO 8601 (avec/sans Z) / DD/MM/YYYY / RFC 2822."""
+    return parse_article_date(date_str or "")
 
 
 def _date_iso(d: datetime) -> str:

--- a/scripts/flux_watcher.py
+++ b/scripts/flux_watcher.py
@@ -36,6 +36,7 @@ from utils.api_client import get_ai_client, get_summary_client
 from utils.http_utils import fetch_and_extract_text, extract_top_n_largest_images, RSS_FEED_HEADERS, fetch_rss_feed
 from utils.logging import print_console
 from utils.quota import get_quota_manager
+from utils.date_utils import parse_article_date
 from utils.article_index import get_article_index
 from utils.entity_index import get_entity_index
 from utils.rolling_window import update_rolling_window
@@ -108,7 +109,10 @@ def _parse_feed_items(xml_root) -> list:
         try:
             pub_dt = datetime.strptime(pub_date[:25], DATE_FORMAT_RSS)
         except Exception:
-            continue
+            # Flux non conformes RFC 2822 (ISO, dates localisées…) : repli robuste.
+            pub_dt = parse_article_date(pub_date)
+            if pub_dt is None:
+                continue
         normalized.append((title, link, pub_date, pub_dt, desc))
 
     for entry in xml_root.findall(f".//{{{ATOM_NS}}}entry"):
@@ -131,9 +135,12 @@ def _parse_feed_items(xml_root) -> list:
         try:
             pub_dt_aware = datetime.fromisoformat(pub_date_iso.replace("Z", "+00:00"))
             pub_dt = pub_dt_aware.replace(tzinfo=None)
-            pub_date_rfc = pub_dt.strftime(DATE_FORMAT_RSS)
         except Exception:
-            continue
+            # Atom non conforme : repli robuste multi-format.
+            pub_dt = parse_article_date(pub_date_iso)
+            if pub_dt is None:
+                continue
+        pub_date_rfc = pub_dt.strftime(DATE_FORMAT_RSS)
         # Atom : description dans <summary> ou <content>
         desc = _strip_html(
             entry.findtext(f"{{{ATOM_NS}}}summary") or
@@ -341,7 +348,10 @@ def main(dry_run: bool = False) -> None:
 
             article = {
                 "Titre": title,
-                "Date de publication": pub_dt.strftime("%d/%m/%Y"),
+                # ISO 8601 avec heure (pub_dt vient du flux RSS/Atom). Les index
+                # (article_index, entity_index) normalisent via parse_article_date,
+                # et le viewer affiche l'heure quand elle est présente.
+                "Date de publication": pub_dt.isoformat(),
                 "Sources": feed_title,
                 "URL": link,
                 "Résumé": resume,

--- a/scripts/generate_48h_report.py
+++ b/scripts/generate_48h_report.py
@@ -26,6 +26,7 @@ from utils.api_client import get_ai_client
 from utils.config import get_config
 from utils.logging import print_console
 from utils.scheduler_toggle import should_run_task
+from utils.date_utils import parse_article_date
 
 # Types d'entités pertinentes pour le classement (personnes, orgs, pays, produits, événements)
 ENTITY_TYPES_PERTINENTS = {"PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "FAC", "LOC"}
@@ -164,13 +165,8 @@ def build_slim_articles(articles: list, top_entities: list, max_per_entity: int 
     # Trier les articles par date (les plus récents d'abord)
     # Supporte les formats RFC 822 (flux_watcher) et DD/MM/YYYY (web_watcher)
     def _safe_date(a: dict):
-        dp = a.get("Date de publication", "")
-        for fmt in (DATE_FORMAT_RSS, "%d/%m/%Y", "%Y-%m-%dT%H:%M:%SZ"):
-            try:
-                return datetime.strptime(dp[:25], fmt)
-            except Exception:
-                continue
-        return datetime.min
+        # Corpus mixte ISO 8601 (avec/sans Z) / DD/MM/YYYY / RFC 2822.
+        return parse_article_date(a.get("Date de publication", "")) or datetime.min
 
     sorted_articles = sorted(articles, key=_safe_date, reverse=True)
 
@@ -373,13 +369,8 @@ def generate_48h_report(dry_run: bool = False) -> None:
         )
 
         def _safe_date_fallback(a: dict):
-            dp = a.get("Date de publication", "")
-            for fmt in (DATE_FORMAT_RSS, "%d/%m/%Y", "%Y-%m-%dT%H:%M:%SZ"):
-                try:
-                    return datetime.strptime(dp[:25], fmt)
-                except Exception:
-                    continue
-            return datetime.min
+            # Corpus mixte ISO 8601 (avec/sans Z) / DD/MM/YYYY / RFC 2822.
+            return parse_article_date(a.get("Date de publication", "")) or datetime.min
 
         slim_articles = sorted(articles, key=_safe_date_fallback, reverse=True)[:50]
         slim_articles = [

--- a/scripts/generate_keyword_reports.py
+++ b/scripts/generate_keyword_reports.py
@@ -31,6 +31,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from utils.api_client import get_ai_client
 from utils.logging import print_console
+from utils.date_utils import parse_article_date
 
 def get_month_period():
     now = datetime.now()
@@ -60,18 +61,8 @@ def main():
         filtered = []
         for article in articles:
             pub_date = article.get("Date de publication", "")
-            pub_dt = None
-            # Essayer ISO 8601 (YYYY-MM-DD...)
-            try:
-                pub_dt = datetime.strptime(pub_date[:10], "%Y-%m-%d")
-            except Exception:
-                pass
-            # Essayer RFC822 (ex: Fri, 20 Feb 2026 04:24:00 +0100)
-            if not pub_dt:
-                try:
-                    pub_dt = parsedate_to_datetime(pub_date)
-                except Exception:
-                    pass
+            # Corpus mixte ISO 8601 (avec/sans Z) / DD/MM/YYYY / RFC 2822.
+            pub_dt = parse_article_date(pub_date)
             if not pub_dt:
                 print_console(f"  Article ignoré (date non reconnue) : {pub_date}", level="warning")
                 continue

--- a/scripts/generate_morning_digest.py
+++ b/scripts/generate_morning_digest.py
@@ -36,6 +36,7 @@ from utils.config import get_config
 from utils.logging import print_console
 from utils.scoring import get_scoring_engine
 from utils.scheduler_toggle import should_run_task
+from utils.date_utils import parse_article_date
 
 # Types d'entités pertinentes pour le classement
 ENTITY_TYPES_PERTINENTS = {"PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "FAC", "LOC"}
@@ -282,18 +283,9 @@ def _format_article_card(article: dict, rank: int) -> str:
 
     sent_emoji = SENTIMENT_EMOJI.get(sentiment.lower(), "") if sentiment else ""
 
-    # Date lisible
-    date_label = ""
-    try:
-        from email.utils import parsedate_to_datetime
-        dt = parsedate_to_datetime(date_raw)
-        date_label = dt.strftime("%-d %b %Y, %Hh%M")
-    except Exception:
-        try:
-            dt = datetime.strptime(date_raw[:19], "%Y-%m-%dT%H:%M:%S")
-            date_label = dt.strftime("%-d %b %Y, %Hh%M")
-        except Exception:
-            date_label = date_raw[:10] if date_raw else ""
+    # Date lisible — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822.
+    _dt_lbl = parse_article_date(date_raw)
+    date_label = _dt_lbl.strftime("%-d %b %Y, %Hh%M") if _dt_lbl else (date_raw[:10] if date_raw else "")
 
     lines = [f"### {rank}. {titre}"]
     meta_parts = []
@@ -440,7 +432,8 @@ def build_digest_markdown(
         lines.append("| Date | Source | URL |")
         lines.append("|------|--------|-----|")
         for article in top_articles:
-            date_raw = article.get("Date de publication", "")[:10]
+            _dt_ref = parse_article_date(article.get("Date de publication", ""))
+            date_raw = _dt_ref.strftime("%d/%m/%Y") if _dt_ref else article.get("Date de publication", "")[:10]
             source = article.get("Sources", "")
             url = article.get("URL", "")
             if url:

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -25,6 +25,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.config import get_config
 from utils.logging import default_logger as LOG
+from utils.date_utils import parse_article_date
 
 
 def _load_profiles(project_root: Path) -> list[dict]:
@@ -171,7 +172,8 @@ def generate_profile_digest(
         for rank, (score, art) in enumerate(top, 1):
             src = art.get("Sources", "Source inconnue")
             url = art.get("URL", "#")
-            date_pub = (art.get("Date de publication") or "")[:10]
+            _dt_pub = parse_article_date(art.get("Date de publication") or "")
+            date_pub = _dt_pub.strftime("%d/%m/%Y") if _dt_pub else (art.get("Date de publication") or "")[:10]
             resume = art.get("Résumé", "") or ""
             resume_lines = [l.strip() for l in resume.splitlines() if l.strip()]
             titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"

--- a/scripts/generate_reading_notes.py
+++ b/scripts/generate_reading_notes.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from utils.article_index import get_article_index
 from utils.config import get_config
 from utils.logging import print_console
+from utils.date_utils import parse_article_date
 from utils.scheduler_toggle import should_run_task
 
 ANNOTATIONS_FILE = PROJECT_ROOT / "data" / "annotations.json"
@@ -64,20 +65,12 @@ def build_article_index(project_root: Path) -> dict:
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 def parse_date(date_str: str) -> datetime | None:
-    if not date_str:
-        return None
-    try:
-        dt = parsedate_to_datetime(date_str)
-        return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-    except Exception:
-        pass
-    for fmt in ("%Y-%m-%dT%H:%M:%SZ", "%Y-%m-%dT%H:%M:%S%z", "%Y-%m-%d"):
-        try:
-            dt = datetime.strptime(date_str[:19], fmt)
-            return dt.replace(tzinfo=timezone.utc) if dt.tzinfo is None else dt
-        except Exception:
-            continue
-    return None
+    """Datetime UTC (tz-aware) ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822.
+
+    L'ancienne version ne gérait pas le DD/MM/YYYY ni l'ISO sans Z.
+    """
+    dt = parse_article_date(date_str or "")
+    return dt.replace(tzinfo=timezone.utc) if dt is not None else None
 
 
 def format_datetime(date_str: str) -> str:

--- a/scripts/generate_watched_report.py
+++ b/scripts/generate_watched_report.py
@@ -226,7 +226,8 @@ def generate_watched_report(project_root: Path, days: int = 7, dry_run: bool = F
             for art in articles:
                 src = art.get("Sources", "")
                 url = art.get("URL", "#")
-                date_pub = art.get("Date de publication", "")[:10]
+                _dt_pub = parse_article_date(art.get("Date de publication", ""))
+                date_pub = _dt_pub.strftime("%d/%m/%Y") if _dt_pub else art.get("Date de publication", "")[:10]
                 resume = art.get("Résumé", "")[:120].replace("\n", " ")
                 lines.append(f"- [{src} — {date_pub}]({url}) : {resume}…")
             lines.append("")

--- a/scripts/get-keyword-from-rss.py
+++ b/scripts/get-keyword-from-rss.py
@@ -30,6 +30,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from utils.api_client import get_ai_client, get_summary_client
 from utils.article_index import get_article_index
+from utils.date_utils import parse_article_date
 from utils.deduplication import Deduplicator
 from utils.entity_index import get_entity_index
 from utils.http_utils import fetch_and_extract_text, extract_top_n_largest_images, RSS_FEED_HEADERS, fetch_rss_feed
@@ -87,7 +88,10 @@ def _parse_feed_items(xml_root) -> list:
         try:
             pub_dt = datetime.strptime(pub_date[:25], "%a, %d %b %Y %H:%M:%S")
         except Exception:
-            continue
+            # Flux non conformes RFC 2822 (ISO, dates localisées…) : repli robuste.
+            pub_dt = parse_article_date(pub_date)
+            if pub_dt is None:
+                continue
         normalized.append((title, link, pub_date, pub_dt, desc))
 
     # ── Atom : balises <entry> ────────────────────────────────────────────────
@@ -113,16 +117,19 @@ def _parse_feed_items(xml_root) -> list:
         try:
             pub_dt_aware = datetime.fromisoformat(pub_date_iso.replace("Z", "+00:00"))
             pub_dt = pub_dt_aware.replace(tzinfo=None)
-            # Plafonner les dates futures à maintenant (certains flux Atom
-            # publient une date de sortie stable planifiée dans le futur,
-            # ex. VS Code utilise <updated> avec la date de release finale)
-            now_naive = datetime.utcnow()
-            if pub_dt > now_naive:
-                pub_dt = now_naive
-            # Convertir en RFC 822 pour cohérence avec le reste du pipeline
-            pub_date_rfc = pub_dt.strftime("%a, %d %b %Y %H:%M:%S")
         except Exception:
-            continue
+            # Atom non conforme : repli robuste multi-format.
+            pub_dt = parse_article_date(pub_date_iso)
+            if pub_dt is None:
+                continue
+        # Plafonner les dates futures à maintenant (certains flux Atom
+        # publient une date de sortie stable planifiée dans le futur,
+        # ex. VS Code utilise <updated> avec la date de release finale)
+        now_naive = datetime.utcnow()
+        if pub_dt > now_naive:
+            pub_dt = now_naive
+        # Convertir en RFC 822 pour cohérence avec le reste du pipeline
+        pub_date_rfc = pub_dt.strftime("%a, %d %b %Y %H:%M:%S")
         # Atom : description dans <summary> ou <content>
         desc = _strip_html(
             entry.findtext(f"{{{ATOM_NS}}}summary") or
@@ -379,7 +386,9 @@ for feed_idx, (feed_url, feed_title, bypass_quota) in enumerate(feeds, 1):
                         continue
                 article = {
                     "Titre": title,
-                    "Date de publication": pub_dt.strftime("%d/%m/%Y"),
+                    # ISO 8601 avec heure (pub_dt vient du flux RSS). Les index
+                    # normalisent via parse_article_date ; le viewer affiche l'heure.
+                    "Date de publication": pub_dt.isoformat(),
                     "Sources": feed_title,
                     "URL": link,
                     "Résumé": resume,

--- a/scripts/radar_wudd.py
+++ b/scripts/radar_wudd.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.logging import print_console
 from utils.config import get_config
+from utils.date_utils import parse_article_date
 from utils.api_client import get_ai_client
 
 # ─── CONFIG ──────────────────────────────────────────────────────────────────
@@ -59,12 +60,11 @@ def load_articles(data_dir):
 
 
 def parse_date(raw):
-    if not raw:
-        return None
-    try:
-        return datetime.fromisoformat(raw.replace("Z", "+00:00"))
-    except Exception:
-        return None
+    """Datetime naïf ou None — corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822.
+
+    L'ancienne version ne gérait que l'ISO (rejetait DD/MM/YYYY des vieux articles).
+    """
+    return parse_article_date(raw or "")
 
 
 def split_periods(articles):

--- a/scripts/scheduler_articles.py
+++ b/scripts/scheduler_articles.py
@@ -26,6 +26,7 @@ PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.logging import print_console, setup_logger, default_logger
+from utils.date_utils import parse_article_date
 
 from utils.config import get_config
 from utils.api_client import get_ai_client
@@ -57,10 +58,15 @@ def get_new_articles_count(json_path: Path, last_run_date: str) -> int:
         return 0
     with open(json_path, 'r', encoding='utf-8') as f:
         articles = json.load(f)
+    # Comparaison datetime (et non lexicographique) : le corpus mêle ISO 8601 et
+    # DD/MM/YYYY, qui ne se trient pas de la même façon en texte brut.
+    cutoff = parse_article_date(last_run_date)
+    if cutoff is None:
+        return 0
     count = 0
     for art in articles:
-        date_pub = art.get("Date de publication", "")
-        if date_pub > last_run_date:
+        dt = parse_article_date(art.get("Date de publication", ""))
+        if dt is not None and dt > cutoff:
             count += 1
     return count
 

--- a/scripts/web_watcher.py
+++ b/scripts/web_watcher.py
@@ -39,6 +39,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from utils.api_client import get_ai_client, get_summary_client
 from utils.article_index import get_article_index
+from utils.date_utils import parse_article_date
 from utils.entity_index import get_entity_index
 from utils.logging import print_console
 from utils.quota import get_quota_manager
@@ -157,6 +158,11 @@ def _parse_date(date_str: str, langue: str = "en") -> datetime:
         except (ValueError, TypeError):
             continue
 
+    # Dernier recours multi-format (RFC 2822, ISO avec offset…) avant de se
+    # rabattre sur l'heure courante.
+    dt = parse_article_date(date_str)
+    if dt is not None:
+        return dt
     return datetime.now()
 
 
@@ -427,7 +433,9 @@ def _process_article(
     # Date de publication
     pub_date_str = page["pub_date_str"] or lastmod
     pub_dt = _parse_date(pub_date_str, langue=langue)
-    pub_date_fmt = _fmt_ddmmyyyy(pub_dt)
+    # ISO 8601 avec heure — cohérent avec flux_watcher / get-keyword-from-rss
+    # (mêmes fichiers articles-from-rss/). Le viewer affiche l'heure si présente.
+    pub_date_fmt = pub_dt.isoformat()
 
     # Résumé via API IA
     lang_label = "français" if langue == "fr" else "français (article source en anglais)"
@@ -497,8 +505,8 @@ def _save_and_index_articles(
     """
     existing_articles.sort(
         key=lambda a: (
-            datetime.strptime(a.get("Date de publication", ""), "%d/%m/%Y")
-            if a.get("Date de publication") else datetime.min
+            # parse_article_date gère ISO 8601 (avec heure), DD/MM/YYYY et RFC 2822.
+            parse_article_date(a.get("Date de publication", "")) or datetime.min
         ),
         reverse=True,
     )

--- a/tests/test_newsletter.py
+++ b/tests/test_newsletter.py
@@ -228,11 +228,13 @@ class TestGenerateNewsletterHtml:
         result = self._fn()([article])
         assert "https://img.com/photo.jpg" in result
 
-    def test_date_truncated_to_10_chars(self):
+    def test_date_displayed_as_ddmmyyyy(self):
+        # Le corpus mêle ISO 8601 et DD/MM/YYYY : l'affichage est normalisé en
+        # DD/MM/YYYY (format français) au lieu de tronquer la chaîne ISO brute.
         article = self._make_article(**{"Date de publication": "2026-03-06T10:00:00Z"})
         result = self._fn()([article])
-        assert "2026-03-06" in result
-        # Full ISO string should NOT appear
+        assert "06/03/2026" in result
+        # La chaîne ISO complète (heure) ne doit pas apparaître
         assert "T10:00:00" not in result
 
     def test_article_url_defaults_to_hash(self):

--- a/utils/db.py
+++ b/utils/db.py
@@ -170,7 +170,7 @@ class ArticleDB:
                 "temps_lecture_label"
             FROM read_json_auto('{glob}', ignore_errors=true)
             WHERE
-                "Date de publication" >= '{cutoff}'
+                {self._date_key_expr()} >= '{cutoff}'
                 AND (
                     json_extract_string(entities, '$.PERSON') LIKE '%{entity_name}%'
                     OR json_extract_string(entities, '$.ORG') LIKE '%{entity_name}%'
@@ -178,7 +178,7 @@ class ArticleDB:
                     OR json_extract_string(entities, '$.PRODUCT') LIKE '%{entity_name}%'
                     OR json_extract_string(entities, '$.EVENT') LIKE '%{entity_name}%'
                 )
-            ORDER BY "Date de publication" DESC
+            ORDER BY {self._date_key_expr()} DESC
             LIMIT 100
         """
         return self._exec(sql)
@@ -197,9 +197,9 @@ class ArticleDB:
                 "Sources" AS source,
                 COUNT(*) AS article_count,
                 ROUND(AVG(TRY_CAST("score_sentiment" AS DOUBLE)), 2) AS avg_score_sentiment,
-                MAX("Date de publication") AS last_article
+                MAX({self._date_key_expr()}) AS last_article
             FROM read_json_auto('{glob}', ignore_errors=true)
-            WHERE "Date de publication" >= '{cutoff}'
+            WHERE {self._date_key_expr()} >= '{cutoff}'
             GROUP BY "Sources"
             ORDER BY article_count DESC
             LIMIT 50
@@ -216,11 +216,11 @@ class ArticleDB:
         glob = self._glob_pattern("articles-from-rss/*.json")
         sql = f"""
             SELECT
-                LEFT("Date de publication", 10) AS date,
+                {self._date_key_expr()} AS date,
                 COUNT(*) AS article_count
             FROM read_json_auto('{glob}', ignore_errors=true)
-            WHERE "Date de publication" >= '{cutoff}'
-            GROUP BY LEFT("Date de publication", 10)
+            WHERE {self._date_key_expr()} >= '{cutoff}'
+            GROUP BY {self._date_key_expr()}
             ORDER BY date ASC
         """
         return self._exec(sql)
@@ -237,7 +237,7 @@ class ArticleDB:
             WITH base AS (
                 SELECT "sentiment"
                 FROM read_json_auto('{glob}', ignore_errors=true)
-                WHERE "Date de publication" >= '{cutoff}'
+                WHERE {self._date_key_expr()} >= '{cutoff}'
                     AND "sentiment" IS NOT NULL
                     AND "sentiment" != ''
             )
@@ -265,7 +265,7 @@ class ArticleDB:
                 COUNT(*) AS article_count,
                 ROUND(AVG(TRY_CAST("score_source" AS DOUBLE)), 1) AS avg_score_source
             FROM read_json_auto('{glob}', ignore_errors=true)
-            WHERE "Date de publication" >= '{cutoff}'
+            WHERE {self._date_key_expr()} >= '{cutoff}'
                 AND "score_source" IS NOT NULL
             GROUP BY "Sources"
             HAVING COUNT(*) >= 3
@@ -288,7 +288,7 @@ class ArticleDB:
                 ROUND(MEDIAN(TRY_CAST("temps_lecture_minutes" AS DOUBLE)), 1) AS median_minutes,
                 COUNT(*) AS total_articles
             FROM read_json_auto('{glob}', ignore_errors=true)
-            WHERE "Date de publication" >= '{cutoff}'
+            WHERE {self._date_key_expr()} >= '{cutoff}'
                 AND "temps_lecture_minutes" IS NOT NULL
         """
         rows = self._exec(sql)
@@ -344,7 +344,7 @@ class ArticleDB:
                     END
                 ) AS ok_status
             FROM read_json_auto('{glob}', ignore_errors=true)
-            WHERE "Date de publication" >= '{cutoff}'
+            WHERE {self._date_key_expr()} >= '{cutoff}'
         """
         rows = self._exec(sql)
         return rows[0] if rows else {
@@ -546,9 +546,9 @@ class ArticleDB:
                 "temps_lecture_label"
             FROM read_json_auto('{glob}', ignore_errors=true)
             WHERE
-                "Date de publication" >= '{cutoff}'
+                {self._date_key_expr()} >= '{cutoff}'
                 AND LOWER("Résumé") LIKE LOWER('%{safe_query}%')
-            ORDER BY "Date de publication" DESC
+            ORDER BY {self._date_key_expr()} DESC
             LIMIT {int(limit)}
         """
         return self._exec(sql)

--- a/utils/exporters/atom_feed.py
+++ b/utils/exporters/atom_feed.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+from ..date_utils import parse_article_date
 from ..logging import default_logger
 
 
@@ -183,7 +184,11 @@ def generate_atom_from_flux(project_root: Path, flux: str, max_entries: int = 50
             except Exception:
                 continue
 
-    articles.sort(key=lambda a: a.get("Date de publication", ""), reverse=True)
+    # Tri chronologique robuste (corpus mixte ISO 8601 / DD/MM/YYYY / RFC 2822).
+    articles.sort(
+        key=lambda a: parse_article_date(a.get("Date de publication", "")) or datetime.min,
+        reverse=True,
+    )
     return generate_atom_feed(
         articles,
         feed_title=f"WUDD.ai · {flux}",

--- a/utils/exporters/newsletter.py
+++ b/utils/exporters/newsletter.py
@@ -23,7 +23,21 @@ from email.mime.text import MIMEText
 from pathlib import Path
 from typing import Optional
 
+from ..date_utils import parse_article_date
 from ..logging import default_logger
+
+
+def _display_date_fr(raw: str) -> str:
+    """Formate une date article (ISO 8601, DD/MM/YYYY, RFC 2822) en DD/MM/YYYY.
+
+    Le corpus mélange les formats ; on normalise l'affichage pour éviter de
+    montrer « 2026-05-25 » à côté de « 25/05/2026 ». Repli sur la chaîne brute
+    tronquée si non parsable.
+    """
+    dt = parse_article_date(raw or "")
+    if dt is not None:
+        return dt.strftime("%d/%m/%Y")
+    return (raw or "")[:10]
 
 
 # ── Template HTML ─────────────────────────────────────────────────────────────
@@ -153,7 +167,7 @@ def generate_newsletter_html(
     for article in articles_to_render:
         url = article.get("URL", "#")
         source = article.get("Sources", "Source inconnue")
-        date = article.get("Date de publication", "")[:10]
+        date = _display_date_fr(article.get("Date de publication", ""))
         resume = article.get("Résumé", "")
         if not isinstance(resume, str):
             resume = ""
@@ -225,7 +239,10 @@ def generate_newsletter_from_48h(project_root: Path, title: str = None) -> str:
     if articles and "score_pertinence" in articles[0]:
         articles.sort(key=lambda a: a.get("score_pertinence", 0), reverse=True)
     else:
-        articles.sort(key=lambda a: a.get("Date de publication", ""), reverse=True)
+        articles.sort(
+            key=lambda a: parse_article_date(a.get("Date de publication", "")) or datetime.min,
+            reverse=True,
+        )
 
     return generate_newsletter_html(articles, title=title)
 
@@ -339,17 +356,6 @@ def generate_newsletter_auto(
                 if not isinstance(data, list):
                     continue
                 for art in data:
-                    d = art.get("Date de publication", "")
-                    try:
-                        dt = datetime.fromisoformat(d.replace("Z", "+00:00").replace("/", "-")
-                                                    if "T" in d
-                                                    else datetime.strptime(d, "%d/%m/%Y")
-                                                    .replace(tzinfo=timezone.utc)
-                                                    .isoformat())
-                        if hasattr(dt, "tzinfo"):
-                            pass
-                    except Exception:
-                        pass
                     url = art.get("URL", "")
                     if url and url not in sent_urls:
                         articles.append(art)
@@ -367,7 +373,11 @@ def generate_newsletter_auto(
         scored.sort(key=lambda a: a.get("score_pertinence", 0), reverse=True)
     except Exception as e:
         default_logger.warning(f"[newsletter_auto] ScoringEngine indisponible ({e}), tri par date")
-        scored = sorted(articles, key=lambda a: a.get("Date de publication", ""), reverse=True)
+        scored = sorted(
+            articles,
+            key=lambda a: parse_article_date(a.get("Date de publication", "")) or datetime.min,
+            reverse=True,
+        )
 
     top_articles = scored[:top_n]
     default_logger.info(f"[newsletter_auto] {len(top_articles)} articles sélectionnés sur {len(articles)} éligibles")

--- a/viewer/routes/api_v1.py
+++ b/viewer/routes/api_v1.py
@@ -38,6 +38,7 @@ from urllib.parse import urlparse
 
 from flask import Blueprint, jsonify, request
 
+from utils.date_utils import parse_article_date
 from viewer.helpers import PROJECT_ROOT, require_json_body
 
 api_v1_bp = Blueprint("api_v1", __name__, url_prefix="/api/v1")
@@ -440,13 +441,11 @@ def keyword_articles(keyword_id: str):
             cutoff = datetime.now() - timedelta(days=int(days))
             kept: list[dict] = []
             for a in articles:
-                date_str = str(a.get("Date de publication", "")).strip()
-                try:
-                    dt = datetime.strptime(date_str, "%d/%m/%Y")
-                    if dt >= cutoff:
-                        kept.append(a)
-                except ValueError:
-                    continue
+                # Corpus mixte ISO 8601 / DD/MM/YYYY : parsing robuste, sinon
+                # l'ancien strptime("%d/%m/%Y") rendait les articles ISO invisibles.
+                dt = parse_article_date(str(a.get("Date de publication", "")).strip())
+                if dt is not None and dt >= cutoff:
+                    kept.append(a)
             articles = kept
         except ValueError:
             return jsonify({"error": "days doit être un entier"}), 400

--- a/viewer/routes/export.py
+++ b/viewer/routes/export.py
@@ -25,6 +25,7 @@ from viewer.helpers import PROJECT_ROOT
 from viewer.state import _annotations_lock, _invalidate_files_manifest_cache
 from utils.article_index import get_article_index
 from utils.scoring import get_scoring_engine
+from utils.date_utils import parse_article_date
 
 export_bp = Blueprint("export", __name__)
 
@@ -301,7 +302,10 @@ def api_export_atom():
             if not kw_file.exists():
                 return jsonify({"error": "Fichier keyword introuvable"}), 404
             articles = json.loads(kw_file.read_text(encoding="utf-8"))
-            articles.sort(key=lambda a: a.get("Date de publication", ""), reverse=True)
+            articles.sort(
+                key=lambda a: parse_article_date(a.get("Date de publication", "")) or datetime.datetime.min,
+                reverse=True,
+            )
             from utils.exporters.atom_feed import _FEED_ID_BASE
             xml = generate_atom_feed(
                 articles, feed_title=f"WUDD.ai · {keyword}",
@@ -348,7 +352,10 @@ def api_export_atom():
                                 all_articles.extend(data)
                         except Exception:
                             continue
-            all_articles.sort(key=lambda a: a.get("Date de publication", ""), reverse=True)
+            all_articles.sort(
+                key=lambda a: parse_article_date(a.get("Date de publication", "")) or datetime.datetime.min,
+                reverse=True,
+            )
             xml = generate_atom_feed(all_articles, feed_title="WUDD.ai · Veille complète",
                                      self_url=actual_self_url,
                                      max_entries=max_entries)

--- a/viewer/routes/files.py
+++ b/viewer/routes/files.py
@@ -19,6 +19,7 @@ from flask import Blueprint, jsonify, request, abort, send_file, Response, strea
 from pathlib import Path
 
 from viewer.helpers import safe_path, collect_files, PROJECT_ROOT, require_json_body
+from utils.date_utils import parse_article_date
 from viewer.state import (
     _get_files_manifest,
     _invalidate_bias_cache,
@@ -171,11 +172,15 @@ def api_search():
                     src = art.get("Sources", "").lower()
                     if filter_source not in src:
                         continue
-                date_str = art.get("Date de publication", "")[:10]
-                if filter_from and date_str and date_str < filter_from:
-                    continue
-                if filter_to and date_str and date_str > filter_to:
-                    continue
+                if filter_from or filter_to:
+                    _dt = parse_article_date(art.get("Date de publication", ""))
+                    # Normalisé en YYYY-MM-DD → comparaison fiable avec date_from/
+                    # date_to (corpus mixte ISO 8601 / DD/MM/YYYY).
+                    _day = _dt.strftime("%Y-%m-%d") if _dt else ""
+                    if filter_from and _day and _day < filter_from:
+                        continue
+                    if filter_to and _day and _day > filter_to:
+                        continue
                 # Vérifier si la requête textuelle matche
                 resume = art.get("Résumé", "") or ""
                 if pattern.search(resume) or pattern.search(art.get("URL", "") or "") or pattern.search(art.get("Sources", "") or ""):


### PR DESCRIPTION
## Problème

L'explorateur d'articles du viewer n'affichait plus l'**heure de publication**. Cause : depuis le commit `6c26c24` (25 mai), les feeders stockaient `"Date de publication"` au format `%d/%m/%Y` (sans heure) pour contourner un souci d'indexation — désormais résolu par la normalisation des index (`4d0172b`). Le viewer (`formatTime`) n'affiche l'heure que si la chaîne en contient une.

## Approche

Restauration de l'**ISO 8601 avec heure** dans les feeders, puis unification de **tout** le parsing de date sur le parseur canonique `utils.date_utils.parse_article_date` (gère ISO ±Z, ISO avec offset, `DD/MM/YYYY`, `YYYY-MM-DD`, RFC 2822). Le corpus étant désormais **hétérogène** (anciens articles DD/MM, nouveaux ISO), l'audit a révélé de nombreux consommateurs cassés — y compris des bugs **pré-existants** sur le DD/MM.

## Changements

**Feeders** (`flux_watcher`, `get-keyword-from-rss`, `web_watcher`)
- Émettent l'ISO 8601 avec heure (`pub_dt.isoformat()`)
- Parsing d'entrée RSS/Atom rendu robuste aux formats non conformes (fallback `parse_article_date`)

**Helpers de parsing re-câblés sur `parse_article_date`** (cassaient sur ISO-sans-Z et/ou DD/MM, contrat tz préservé)
`cluster_articles`, `cross_flux_analysis`, `entity_timeline`, `export_obsidian`, `radar_wudd`, `generate_reading_notes`, `check_source_health`, `detect_contradictions`, `generate_48h_report`

**Tris lexicographiques → tri datetime**
`newsletter`, `atom_feed`, `cluster_articles`, `scheduler_articles`

**Affichages `[:10]` → `DD/MM/YYYY` normalisé**
`newsletter`, `generate_personal_digest`, `generate_watched_report`, `generate_morning_digest`

**Bugs de filtrage corrigés**
- `generate_keyword_reports` : le filtre de période ignorait silencieusement les articles DD/MM
- `utils/db.py` (DuckDB) : comparaisons/`ORDER BY`/`LEFT`/`MAX` brutes → `_date_key_expr()` (normalise ISO et DD/MM)

**Backend exposé par le serveur MCP**
- `/api/search` (`files.py`) : filtre `date_from/date_to` lexicographique cassé sur DD/MM
- `/api/keywords/<id>/articles` (`api_v1.py`) : filtre `?days=N` en `strptime("%d/%m/%Y")` strict → articles ISO invisibles
- `/api/export/atom` (`export.py`) : tri lexicographique → ordre faux sur corpus mixte

**Divers**
- Nettoyage d'un bloc de code mort dans `newsletter.py`
- Test newsletter mis à jour (affichage `DD/MM/YYYY` au lieu de l'ISO tronqué)

## Notes

- Le **viewer (frontend) ne change pas** : `formatTime`/`parseArticleDate` gèrent déjà l'ISO.
- Non rétroactif : les articles déjà stockés en `DD/MM/YYYY` restent sans heure ; l'heure réapparaît au fil des nouveaux articles.

## Tests

- **1482 passés** ; 2 échecs **pré-existants** confirmés par `git stash` (auth API + canonicalisation d'entité, sans rapport)
- Test fonctionnel DuckDB sur données mixtes ISO+DD/MM : filtrage + normalisation OK
- Les 9 helpers de parsing validés contre 5 formats (ISO ±Z, ±offset, DD/MM, RFC 2822)

## Déploiement

- `scripts/` + `utils/` (baked dans l'image worker) → `docker compose build && up -d`
- `viewer/routes/` (monté en volume) → `docker compose restart analyse-actualites-viewer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)