### PR TITLE
feat(veille): dédup inter-sources + canonicalisation + contrôle qualité des entités surveillées

### DIFF
--- a/config/entity_canonicalization.json
+++ b/config/entity_canonicalization.json
@@ -67,7 +67,11 @@
         { "type": "EVENT", "value": "AI Act" },
         { "type": "PRODUCT", "value": "AI Act" },
         { "type": "PRODUCT", "value": "AI Act européen" },
-        { "type": "ORG", "value": "AI Act European" }
+        { "type": "ORG", "value": "AI Act European" },
+        { "type": "LAW", "value": "l'AI Act" },
+        { "type": "LAW", "value": "l'AI Act européen" },
+        { "type": "ORG", "value": "l'AI Act" },
+        { "type": "EVENT", "value": "l'AI Act" }
       ]
     },
     {

--- a/scripts/watch_entity_articles.py
+++ b/scripts/watch_entity_articles.py
@@ -45,6 +45,8 @@ from utils.logging import default_logger
 from utils.config import get_config
 from utils.date_utils import parse_article_date
 from utils.entity_index import get_entity_index
+from utils.deduplication import Deduplicator
+from utils.entity_canonicalization import get_entity_canonicalizer
 
 _WATCHED_FILE = _PROJECT_ROOT / "data" / "watched_entities.json"
 _STATE_FILE = _PROJECT_ROOT / "data" / "watched_article_state.json"
@@ -52,6 +54,20 @@ _STATE_FILE = _PROJECT_ROOT / "data" / "watched_article_state.json"
 _DEFAULT_MAX_PER_RUN = 1     # 1 article max par passage horaire
 _DEFAULT_WINDOW_DAYS = 2     # ne considérer que les articles récents
 _MAX_STATE_URLS = 1000       # borne la taille du fichier d'état
+
+# Dédup inter-sources / inter-entités d'une MÊME histoire (anti-spam) : deux
+# articles couvrant le même événement depuis des sources différentes ont des
+# titres/résumés distincts (résumés générés par article) mais partagent leurs
+# entités nommées saillantes. On déduplique donc par recouvrement d'entités
+# (Jaccard), persisté entre passages, en complément du Deduplicator (doublons
+# exacts URL/texte). Empêche qu'une même histoire soit notifiée plusieurs fois
+# via plusieurs entités surveillées.
+_STORY_SALIENT_TYPES = {
+    "PERSON", "ORG", "LAW", "GPE", "PRODUCT", "EVENT", "WORK_OF_ART", "NORP", "FAC",
+}
+_STORY_SIM_THRESHOLD = 0.5   # Jaccard d'entités ≥ seuil → même histoire
+_STORY_MIN_ENTITIES = 3      # en deçà, signature trop pauvre pour décider
+_MAX_STATE_SIGS = 300        # borne la mémoire des histoires déjà notifiées
 
 # Fenêtre horaire d'envoi des notifications (heure locale du conteneur).
 # 7h00 inclus → 22h00 exclu (dernière notification possible à 21h59).
@@ -141,17 +157,69 @@ def _load_state() -> dict:
         return {}
 
 
-def _save_state(notified_urls: list[str], entity_daily: dict | None = None) -> None:
+def _save_state(
+    notified_urls: list[str],
+    entity_daily: dict | None = None,
+    notified_sigs: list[list[str]] | None = None,
+) -> None:
     try:
         _STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "notified": notified_urls[-_MAX_STATE_URLS:],
             "entity_daily": entity_daily or {},
+            # Signatures d'entités des histoires déjà notifiées (dédup inter-sources).
+            "notified_sigs": (notified_sigs or [])[-_MAX_STATE_SIGS:],
             "updated_at": datetime.now(timezone.utc).isoformat(),
         }
         _STATE_FILE.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
     except OSError as exc:
         default_logger.warning(f"Impossible d'écrire {_STATE_FILE.name} : {exc}")
+
+
+def _entity_signature(article: dict, canonicalizer=None) -> frozenset[str]:
+    """Empreinte d'une histoire = ensemble de ses entités nommées saillantes.
+
+    Robuste entre sources (contrairement au titre/résumé qui varient) : deux
+    articles sur le même événement partagent l'essentiel de leurs entités. Les
+    entités sont canonicalisées (« l'AI Act » → « AI Act ») pour que les
+    variantes ne fassent pas diverger artificiellement la signature.
+    """
+    ents = article.get("entities") or {}
+    if not isinstance(ents, dict):
+        return frozenset()
+    tokens: set[str] = set()
+    for etype, values in ents.items():
+        if etype not in _STORY_SALIENT_TYPES or not isinstance(values, list):
+            continue
+        for v in values:
+            if not isinstance(v, str) or not v.strip():
+                continue
+            if canonicalizer is not None:
+                ctype, cval = canonicalizer.canonicalize(etype, v)
+                tokens.add(f"{ctype}:{cval.strip().lower()}")
+            else:
+                tokens.add(f"{etype}:{v.strip().lower()}")
+    return frozenset(tokens)
+
+
+def _same_story(sig: frozenset[str], seen_sigs: list[frozenset[str]]) -> bool:
+    """Vrai si la signature recouvre fortement (Jaccard ≥ seuil) une histoire vue.
+
+    Ignore les signatures trop pauvres (< _STORY_MIN_ENTITIES) pour éviter de
+    fusionner à tort des articles peu annotés.
+    """
+    if len(sig) < _STORY_MIN_ENTITIES:
+        return False
+    for seen in seen_sigs:
+        if len(seen) < _STORY_MIN_ENTITIES:
+            continue
+        inter = len(sig & seen)
+        if inter == 0:
+            continue
+        union = len(sig | seen)
+        if union and inter / union >= _STORY_SIM_THRESHOLD:
+            return True
+    return False
 
 
 def _article_sort_key(article: dict):
@@ -196,7 +264,12 @@ def collect_candidates(project_root: Path, watched: list[dict], window_days: int
         if not etype or not value:
             continue
         try:
-            arts = eidx.load_articles(etype, value, max_articles=20, cutoff_date=cutoff)
+            # canonicalize=True : fusionne les variantes d'une même entité
+            # (ex. « l'AI Act » → « AI Act ») via config/entity_canonicalization.json,
+            # pour une couverture et un plafond/dédup cohérents.
+            arts = eidx.load_articles(
+                etype, value, max_articles=20, cutoff_date=cutoff, canonicalize=True
+            )
         except Exception as exc:
             default_logger.debug(f"load_articles({etype}:{value}) a échoué : {exc}")
             continue
@@ -377,7 +450,14 @@ def main():
 
     # Sélection : on écarte les articles promotionnels et on limite à
     # 1 notification par entité et par jour (jour calendaire local).
-    entity_daily = dict(_load_state().get("entity_daily", {}))
+    _state = _load_state()
+    entity_daily = dict(_state.get("entity_daily", {}))
+    # Signatures d'entités des histoires déjà notifiées (dédup inter-sources) :
+    # conservées en listes pour la persistance JSON, dérivées en frozensets pour
+    # la comparaison de recouvrement.
+    persisted_sigs: list[list[str]] = [
+        s for s in _state.get("notified_sigs", []) if isinstance(s, list)
+    ]
     today = now.strftime("%Y-%m-%d")
 
     eligible: list[dict] = []
@@ -419,16 +499,37 @@ def main():
     eligible.sort(key=_presence_of)
 
     # Au plus 1 article par entité, même au sein d'un passage à --max > 1.
+    # + Dédup d'une MÊME histoire entre sources/entités : on n'envoie pas un
+    #   article qui couvre un événement déjà notifié (signature d'entités), ni un
+    #   doublon exact (URL/texte via Deduplicator). seen_sigs est amorcé avec les
+    #   histoires déjà notifiées lors des passages précédents (anti-répétition).
     a_notifier: list[dict] = []
     seen_ekeys: set[str] = set()
+    seen_sigs: list[frozenset[str]] = [frozenset(s) for s in persisted_sigs]
+    run_dedup = Deduplicator()
+    canonicalizer = get_entity_canonicalizer(project_root)
+    skipped_story = 0
     for c in eligible:
         if len(a_notifier) >= max(1, args.max):
             break
         ek = c.get("entity_key", "")
         if ek in seen_ekeys:
             continue
+        art = c["article"]
+        sig = _entity_signature(art, canonicalizer)
+        if not args.force and (run_dedup.is_duplicate(art) or _same_story(sig, seen_sigs)):
+            skipped_story += 1
+            continue
         seen_ekeys.add(ek)
+        seen_sigs.append(sig)
+        run_dedup.register(art)
+        c["_story_sig"] = sorted(sig)
         a_notifier.append(c)
+
+    if skipped_story:
+        default_logger.info(
+            f"{skipped_story} article(s) écarté(s) (même histoire déjà notifiée — dédup inter-sources)."
+        )
 
     if a_notifier:
         choix = ", ".join(
@@ -446,7 +547,7 @@ def main():
                     notified.append(url)
                     notified_set.add(url)
             entity_daily = {k: v for k, v in entity_daily.items() if v == today}
-            _save_state(notified, entity_daily)
+            _save_state(notified, entity_daily, persisted_sigs)
         return
 
     default_logger.info(
@@ -478,6 +579,10 @@ def main():
         if ok:
             sent += 1
             entity_daily[ekey] = today
+            # Mémorise la signature de l'histoire notifiée (dédup inter-sources).
+            story_sig = c.get("_story_sig")
+            if story_sig:
+                persisted_sigs.append(story_sig)
             if url and url not in notified_set:
                 notified.append(url)
                 notified_set.add(url)
@@ -491,7 +596,7 @@ def main():
     if not args.dry_run and not args.force:
         # On ne conserve que les entrées du jour : reset quotidien implicite.
         entity_daily = {k: v for k, v in entity_daily.items() if v == today}
-        _save_state(notified, entity_daily)
+        _save_state(notified, entity_daily, persisted_sigs)
 
     default_logger.info(f"{sent} notification(s) envoyée(s).")
 

--- a/tests/test_viewer_app.py
+++ b/tests/test_viewer_app.py
@@ -662,8 +662,15 @@ class TestEntityRoutes:
 
         watched_file = tmp_path / "watched_entities.json"
         entities_module._watched_cache.clear()
+        # Date récente (dans la fenêtre 7j) pour que le test ne dépende pas du
+        # jour d'exécution.
+        from datetime import datetime, timezone, timedelta
+        recent = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
         mock_idx = MagicMock()
-        mock_idx.get_canonical_refs.return_value = [{"date": "2026-05-09"}]
+        mock_idx.get_canonical_refs.return_value = [{"date": recent}]
+        # Auto-correction (entity_index) : 0 mention détectée → conserve le type
+        # déjà canonicalisé par config (LAW:AI Act), sans le modifier.
+        mock_idx.get_refs.return_value = []
 
         with patch.object(entities_module, "_WATCHED_FILE", watched_file), \
              patch("viewer.routes.entities.get_entity_index", return_value=mock_idx):
@@ -682,6 +689,56 @@ class TestEntityRoutes:
         assert watched[0]["value"] == "AI Act"
         assert watched[0]["mentions_7d"] == 1
         mock_idx.get_canonical_refs.assert_called_with("LAW", "AI Act")
+
+    def test_watched_entities_post_autocorrects_type_and_caps_from_index(self, client, tmp_path):
+        """Contrôle qualité à la création : le type et la casse sont auto-corrigés
+        d'après la liste des entités détectées (entity_index)."""
+        from viewer.routes import entities as entities_module
+
+        watched_file = tmp_path / "watched_entities.json"
+        entities_module._watched_cache.clear()
+        mock_idx = MagicMock()
+        # "anthropic" est détecté comme ORG (5 mentions), jamais comme PERSON.
+        mock_idx.get_refs.side_effect = lambda t, v: ([{"date": "2026-06-01"}] * 5) if t == "ORG" else []
+        mock_idx.get_display_name.return_value = "Anthropic"
+        mock_idx.get_canonical_refs.return_value = []
+
+        with patch.object(entities_module, "_WATCHED_FILE", watched_file), \
+             patch("viewer.routes.entities.get_entity_index", return_value=mock_idx):
+            resp = client.post(
+                "/api/watched-entities",
+                json={"type": "PERSON", "value": "anthropic"},
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "ORG"            # type auto-corrigé PERSON → ORG
+        assert data["value"] == "Anthropic"     # casse auto-corrigée
+        assert data["requested_type"] == "PERSON"
+
+    def test_watched_entities_post_keeps_unknown_entity_as_is(self, client, tmp_path):
+        """Une entité absente du corpus (0 mention) est conservée telle quelle."""
+        from viewer.routes import entities as entities_module
+
+        watched_file = tmp_path / "watched_entities.json"
+        entities_module._watched_cache.clear()
+        mock_idx = MagicMock()
+        mock_idx.get_refs.return_value = []          # inconnue partout
+        mock_idx.get_canonical_refs.return_value = []
+
+        with patch.object(entities_module, "_WATCHED_FILE", watched_file), \
+             patch("viewer.routes.entities.get_entity_index", return_value=mock_idx):
+            resp = client.post(
+                "/api/watched-entities",
+                json={"type": "ORG", "value": "Entité Inexistante XYZ"},
+                content_type="application/json",
+            )
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["type"] == "ORG"
+        assert data["value"] == "Entité Inexistante XYZ"
 
     def test_watched_entities_counts_date_only_yesterday_in_24h_window(self, client, tmp_path):
         from datetime import datetime, timedelta, timezone

--- a/viewer/routes/entities.py
+++ b/viewer/routes/entities.py
@@ -194,6 +194,43 @@ def _canonicalize_watched_entity(entity_type: str, entity_value: str) -> tuple[s
     return canonicalizer.canonicalize(entity_type, entity_value)
 
 
+# Types retenus pour l'auto-correction d'une entité surveillée. On ne corrige
+# pas vers des types « bruit » (DATE, CARDINAL, PERCENT, MONEY, TIME…).
+_WATCH_CANDIDATE_TYPES = (
+    "PERSON", "ORG", "GPE", "LOC", "PRODUCT", "EVENT",
+    "DISEASE", "NORP", "FAC", "LAW", "WORK_OF_ART",
+)
+
+
+def _autocorrect_watched_entity(entity_type: str, entity_value: str) -> tuple[str, str]:
+    """Auto-corrige (silencieusement) le type et la casse d'une entité surveillée
+    d'après la liste des entités réellement détectées (``entity_index``).
+
+    - Type : retient celui qui compte le plus de mentions pour cette valeur
+      (corrige p. ex. ``ORG:AI Act`` → ``LAW:AI Act`` si le corpus l'atteste).
+    - Casse : applique la forme canonique d'affichage (``caps``) du corpus.
+    - Si la valeur est absente du corpus (0 mention, tous types confondus), on
+      conserve le type/valeur fournis (on ne devine pas une entité inexistante).
+
+    Robuste : toute erreur (index absent, etc.) renvoie l'entrée d'origine.
+    """
+    try:
+        idx = get_entity_index(PROJECT_ROOT)
+        best_type = entity_type
+        best_count = len(idx.get_refs(entity_type, entity_value))
+        for t in _WATCH_CANDIDATE_TYPES:
+            if t == entity_type:
+                continue
+            cnt = len(idx.get_refs(t, entity_value))
+            if cnt > best_count:
+                best_type, best_count = t, cnt
+        if best_count == 0:
+            return entity_type, entity_value
+        return best_type, idx.get_display_name(best_type, entity_value)
+    except Exception:
+        return entity_type, entity_value
+
+
 def _watched_file_stamp() -> tuple:
     """Empreinte filesystem du fichier watchlist (mtime_ns, taille, inode).
 
@@ -2866,6 +2903,10 @@ def api_watched_post():
     if not requested_type or not requested_value:
         return jsonify({"error": "Champs type et value requis"}), 400
     etype, value = _canonicalize_watched_entity(requested_type, requested_value)
+    # Contrôle qualité : auto-correction silencieuse du type et de la casse
+    # d'après la liste des entités réellement détectées (entity_index). Appliqué
+    # aussi côté suppression pour retrouver l'entrée stockée sous sa forme corrigée.
+    etype, value = _autocorrect_watched_entity(etype, value)
 
     with _watched_lock:
         watched = _load_watched()
@@ -2924,6 +2965,10 @@ def api_watched_delete():
     if not requested_type or not requested_value:
         return jsonify({"error": "Paramètres type et value requis"}), 400
     etype, value = _canonicalize_watched_entity(requested_type, requested_value)
+    # Contrôle qualité : auto-correction silencieuse du type et de la casse
+    # d'après la liste des entités réellement détectées (entity_index). Appliqué
+    # aussi côté suppression pour retrouver l'entrée stockée sous sa forme corrigée.
+    etype, value = _autocorrect_watched_entity(etype, value)
 
     with _watched_lock:
         watched = _load_watched()


### PR DESCRIPTION
## Contexte

Notifications Discord perçues comme répétées « concernant AI Act ». Après vérification : **ce n'est pas un bug de plafond** (le cap 1 notif/entité/jour fonctionne). La cause réelle : une **même actualité couverte par plusieurs sources** (URLs distinctes) était notifiée plusieurs fois, chaque source étant réclamée par une **entité surveillée différente** (Anthropic, OpenAI, AI Act…). Le plafond par entité ne peut rien dans ce cas (entités + URLs différentes). Diagnostic secondaire : fragmentation d'index `LAW:ai act` vs `LAW:l'ai act`.

## A — Dédup inter-sources d'une même histoire · `scripts/watch_entity_articles.py`

- **Signature d'histoire = ensemble des entités nommées canonicalisées**. Robuste entre sources (les titres/résumés sont générés par article et varient), là où le `Deduplicator` (seuil titre 0.80) ne capte que les doublons quasi-identiques.
- Deux articles avec **Jaccard d'entités ≥ 0.5** = même histoire → un seul notifié.
- Signatures **persistées** dans l'état (`notified_sigs`) → anti-répétition d'un passage/jour à l'autre, **y compris via des entités surveillées différentes**.
- Complété par le `Deduplicator` existant (doublons exacts URL/texte).
- Le watcher charge en `canonicalize=True` (couverture + plafond/dédup cohérents).

## B — Canonicalisation `l'AI Act` → `AI Act`

- `config/entity_canonicalization.json` : variantes élidées (`l'AI Act`, `l'AI Act européen`…) ajoutées à la règle `AI Act` existante.
- Vérifié : `get_canonical_refs("LAW","AI Act")` fusionne désormais les refs (5 → 6), sans rebuild d'index.

## Contrôle qualité **à la création** d'une entité surveillée · `viewer/routes/entities.py`

`_autocorrect_watched_entity` : **auto-correction silencieuse** du type et de la casse d'après la liste des entités réellement détectées (`entity_index`). Vérifié sur le corpus réel :

| Entrée | Résultat |
|---|---|
| `ORG:AI Act` | `LAW:AI Act` (type corrigé) |
| `PERSON:anthropic` | `ORG:Anthropic` (type + casse) |
| `ORG:openai` | `ORG:OpenAI` (casse) |
| entité absente du corpus | **conservée telle quelle** (pas de devinette) |

- Choisit le type le **plus mentionné** pour la valeur ; applique la forme canonique (`caps`).
- Appliqué au **POST et au DELETE** (cohérence des clés stockées). Couvre l'outil **MCP `add`** (il passe par cette route). Robuste (`try/except` → entrée d'origine si index absent).

## Tests

- 2 nouveaux tests : auto-correction type/casse + entité inconnue conservée.
- Corrige un test sensible à la date (`test_watched_entities_post_canonicalizes_entity` : `mentions_7d`, date figée `2026-05-09` devenue hors fenêtre 7j → date relative).
- Suite : **1485 passés**, 1 échec **pré-existant sans rapport** (`test_api_v1::TestSources::test_list_empty`, 401 auth).

## Déploiement

- `scripts/` + `utils/` (image worker) → `docker compose build && up -d`
- `viewer/routes/` + `config/` (volumes) → `docker compose restart analyse-actualites-viewer`

> PR indépendante du #239 (formats de dates) — fichiers disjoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)