### PR TITLE
fix(viewer): défilement du résumé immersif sans le fermer sur mobile

### DIFF
--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -443,9 +443,11 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
           )}
           {isCurrent && showSummary && resume && (
             <div
-              className="mt-3 max-h-[40vh] overflow-y-auto overscroll-contain touch-pan-y rounded-xl bg-black/40 p-3 text-[0.9rem] leading-relaxed text-white/95"
+              className="mt-3 max-h-[55vh] overflow-y-auto overscroll-contain touch-pan-y rounded-xl bg-black/40 p-3 text-[0.9rem] leading-relaxed text-white/95"
               onTouchStart={e => e.stopPropagation()}
               onTouchMove={e => e.stopPropagation()}
+              onTouchEnd={e => e.stopPropagation()}
+              onClick={e => e.stopPropagation()}
             >
               {resumeMd
                 ? <ReportMarkdownContent md={resumeMd} components={IMMERSIVE_MD_COMPONENTS} />


### PR DESCRIPTION
## Problème
En vue immersive plein écran (mobile), avec le nouveau résumé Markdown (`Résumé_md`) plus long, faire défiler le texte **fermait le résumé**.

## Cause
Le conteneur du résumé stoppait `onTouchStart`/`onTouchMove` mais **pas `onTouchEnd`**. Au relâchement, le `onTouchEnd` de l'overlay s'exécutait avec `axis=null` et `moved=false` → `setShowSummary(s => !s)` → fermeture.

## Correctif
- Stoppe aussi `onTouchEnd` et `onClick` sur le bloc résumé. Le défilement natif reste actif (`touch-pan-y` n'est pas affecté par `stopPropagation`, qui n'appelle pas `preventDefault`).
- `max-h` 40vh → 55vh pour le résumé formaté plus long.

Fichier : `viewer/src/components/ArticleListViewer.jsx`. Vérifié sur mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)