### PR TITLE
feat(résumé): rendu Markdown (vue normale + immersive) + entités cliquables, écriture merge-safe

### DIFF
--- a/scripts/enrich_summary_format.py
+++ b/scripts/enrich_summary_format.py
@@ -77,13 +77,21 @@ def _save_state(idx: int, total: int, file_path: str, enriched: int) -> None:
 # ── Collecte ─────────────────────────────────────────────────────────────────
 
 def collect_all_json_files(config) -> list[Path]:
-    """Liste triée des fichiers JSON d'articles (rss + flux), hors cache."""
+    """Liste triée des fichiers JSON d'articles (rss + flux), hors cache.
+
+    Exclut `_WUDD.AI_` : ce sont des fichiers DÉRIVÉS (48-heures.json, merged…)
+    reconstruits par flux_watcher — les enrichir est inutile et leur Résumé_md
+    serait immédiatement écrasé. Les articles sources (fichiers par flux/mot-clé)
+    sont enrichis directement.
+    """
     files = []
     rss_dir = config.project_root / "data" / "articles-from-rss"
     if rss_dir.exists():
         for f in sorted(rss_dir.rglob("*.json")):
-            if "cache" not in f.relative_to(rss_dir).parts:
-                files.append(f)
+            parts = f.relative_to(rss_dir).parts
+            if "cache" in parts or "_WUDD.AI_" in parts:
+                continue
+            files.append(f)
     flux_dir = config.project_root / "data" / "articles"
     if flux_dir.exists():
         for f in sorted(flux_dir.rglob("*.json")):
@@ -146,7 +154,7 @@ def enrich_file(json_file: Path, dry_run: bool, force: bool, delay: float,
 
     enriched = 0
     skipped = 0
-    modified = False
+    results: dict[str, str] = {}   # URL → Résumé_md généré (appliqué en merge à l'écriture)
 
     for article in articles:
         if not _in_period(article, since, until):
@@ -173,36 +181,65 @@ def enrich_file(json_file: Path, dry_run: bool, force: bool, delay: float,
 
         md = format_summary_markdown(resume)
         if md:
-            article["Résumé_md"] = md
-            enriched += 1
-            modified = True
+            url = (article.get("URL") or article.get("url") or "").strip()
+            if url:
+                results[url] = md
+                enriched += 1
+            else:
+                skipped += 1
         else:
             # Échec IA : on n'écrit rien, l'article sera retenté plus tard.
             skipped += 1
 
-        if modified and enriched % SAVE_EVERY == 0:
-            _write_atomic(json_file, articles)
-            default_logger.info(f"  ↳ Sauvegarde intermédiaire ({enriched}) → {json_file.name}")
+        if results and enriched % SAVE_EVERY == 0:
+            n = _merge_write(json_file, results)
+            default_logger.info(f"  ↳ Sauvegarde intermédiaire ({n} appliqués) → {json_file.name}")
 
         if delay > 0:
             time.sleep(delay)
 
-    if modified and not dry_run:
-        _write_atomic(json_file, articles)
-        default_logger.info(f"  Sauvegardé → {json_file.name}")
+    if results and not dry_run:
+        n = _merge_write(json_file, results)
+        default_logger.info(f"  Sauvegardé ({n} appliqués) → {json_file.name}")
 
     return enriched, skipped
 
 
-def _write_atomic(json_file: Path, articles: list) -> None:
+def _merge_write(json_file: Path, results: dict) -> int:
+    """Applique les Résumé_md générés sur la version DISQUE la plus récente.
+
+    Re-lit le fichier juste avant d'écrire et ne pose `Résumé_md` que sur les
+    articles dont l'URL correspond. Évite d'écraser les modifications concurrentes
+    (enrichissements NER/sentiment, ajout d'articles par un watcher) survenues
+    pendant le reformatage. Écriture atomique.
+    """
+    try:
+        current = json.loads(json_file.read_text(encoding="utf-8"))
+        if not isinstance(current, list):
+            return 0
+    except (json.JSONDecodeError, OSError) as e:
+        default_logger.warning(f"  Relecture impossible avant écriture {json_file}: {e}")
+        return 0
+
+    applied = 0
+    for art in current:
+        if not isinstance(art, dict):
+            continue
+        url = (art.get("URL") or art.get("url") or "").strip()
+        if url in results:
+            art["Résumé_md"] = results[url]
+            applied += 1
+
     tmp = json_file.with_suffix(".tmp")
     try:
-        tmp.write_text(json.dumps(articles, ensure_ascii=False, indent=4), encoding="utf-8")
+        tmp.write_text(json.dumps(current, ensure_ascii=False, indent=4), encoding="utf-8")
         tmp.replace(json_file)
     except OSError as e:
         default_logger.error(f"  Erreur d'écriture {json_file}: {e}")
         if tmp.exists():
             tmp.unlink()
+        return 0
+    return applied
 
 
 # ── Main ─────────────────────────────────────────────────────────────────────

--- a/tests/test_enrich_summary_format.py
+++ b/tests/test_enrich_summary_format.py
@@ -1,0 +1,86 @@
+"""Tests pour scripts/enrich_summary_format.py.
+
+Couvre :
+  - _merge_write : application de Résumé_md sur la version disque la plus récente
+    sans écraser les modifications concurrentes (sécurité anti-course)
+  - _in_period : filtre de période
+  - collect_all_json_files : exclusion des fichiers dérivés _WUDD.AI_
+"""
+
+import importlib.util
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+_spec = importlib.util.spec_from_file_location(
+    "enrich_summary_format", PROJECT_ROOT / "scripts" / "enrich_summary_format.py"
+)
+esf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(esf)
+
+
+class TestMergeWrite:
+    def test_applique_sans_ecraser_concurrent(self, tmp_path):
+        f = tmp_path / "kw.json"
+        f.write_text(json.dumps([
+            {"URL": "http://a/1", "Résumé": "x"},
+            {"URL": "http://a/2", "Résumé": "y"},
+        ]), encoding="utf-8")
+        results = {"http://a/1": "### MD1", "http://a/2": "### MD2"}
+        # Écriture concurrente AVANT le merge : sentiment ajouté + nouvel article
+        f.write_text(json.dumps([
+            {"URL": "http://a/1", "Résumé": "x"},
+            {"URL": "http://a/2", "Résumé": "y", "sentiment": "positif"},
+            {"URL": "http://a/3", "Résumé": "z"},
+        ]), encoding="utf-8")
+
+        applied = esf._merge_write(f, results)
+        by = {a["URL"]: a for a in json.loads(f.read_text(encoding="utf-8"))}
+
+        assert applied == 2
+        assert by["http://a/1"]["Résumé_md"] == "### MD1"
+        assert by["http://a/2"]["Résumé_md"] == "### MD2"
+        assert by["http://a/2"]["sentiment"] == "positif"   # changement concurrent préservé
+        assert "http://a/3" in by                            # ajout concurrent préservé
+        assert len(by) == 3
+
+    def test_url_absente_ignoree(self, tmp_path):
+        f = tmp_path / "kw.json"
+        f.write_text(json.dumps([{"URL": "http://a/1", "Résumé": "x"}]), encoding="utf-8")
+        applied = esf._merge_write(f, {"http://absent": "### MD"})
+        assert applied == 0
+        assert "Résumé_md" not in json.loads(f.read_text(encoding="utf-8"))[0]
+
+
+class TestInPeriod:
+    def test_sans_filtre_tout_passe(self):
+        assert esf._in_period({"Date de publication": "01/01/2020"}, None, None) is True
+
+    def test_avant_since_exclu(self):
+        assert esf._in_period({"Date de publication": "2026-05-31"}, date(2026, 6, 1), None) is False
+
+    def test_dans_periode_inclus(self):
+        assert esf._in_period({"Date de publication": "2026-06-02"}, date(2026, 6, 1), None) is True
+
+    def test_date_inexploitable_exclue_si_filtre(self):
+        assert esf._in_period({"Date de publication": ""}, date(2026, 6, 1), None) is False
+
+
+class TestCollectExcludesWudd:
+    def test_wudd_ai_exclu(self, tmp_path, monkeypatch):
+        rss = tmp_path / "data" / "articles-from-rss"
+        (rss / "_WUDD.AI_").mkdir(parents=True)
+        (rss / "openai.json").write_text("[]", encoding="utf-8")
+        (rss / "_WUDD.AI_" / "48-heures.json").write_text("[]", encoding="utf-8")
+
+        class _Cfg:
+            project_root = tmp_path
+        files = esf.collect_all_json_files(_Cfg())
+        names = [f.name for f in files]
+        assert "openai.json" in names
+        assert "48-heures.json" not in names

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useMemo, useState, useRef, useCallback, useEffect, forwardRef, useImperativeHandle } from 'react'
+import { lazy, Suspense, useMemo, useState, useRef, useCallback, useEffect, forwardRef, useImperativeHandle, Children } from 'react'
 import {
   ExternalLink, ChevronDown, ChevronUp, Tag, X,
   Filter, Search, ArrowUpDown, Newspaper,
@@ -7,7 +7,7 @@ import {
 } from 'lucide-react'
 import YouTubePanel from './YouTubePanel'
 import ArticleGalleryPanel from './ArticleGalleryPanel'
-import EntityHighlighter from './EntityHighlighter'
+import EntityHighlighter, { EntityHighlighterSegments } from './EntityHighlighter'
 import ReportMarkdownContent from './ReportMarkdownContent'
 import { openInObsidian } from '../utils/obsidian'
 import TTSButton from './TTSButton'
@@ -308,6 +308,40 @@ const IMMERSIVE_MD_COMPONENTS = {
   li: ({ node, ...p }) => <li className="mb-0.5" {...p} />,
 }
 
+// Styles Markdown du résumé formaté (Résumé_md) dans la carte article (thème clair/sombre).
+const CARD_MD_COMPONENTS = {
+  h1: ({ node, ...p }) => <h3 className="mt-3 mb-1 text-[0.95rem] font-bold text-slate-800 dark:text-slate-100 first:mt-0" {...p} />,
+  h2: ({ node, ...p }) => <h3 className="mt-3 mb-1 text-[0.95rem] font-bold text-slate-800 dark:text-slate-100 first:mt-0" {...p} />,
+  h3: ({ node, ...p }) => <h3 className="mt-3 mb-1 text-sm font-bold text-slate-700 dark:text-slate-200 first:mt-0" {...p} />,
+  p:  ({ node, ...p }) => <p className="mb-2 text-slate-600 dark:text-slate-300" {...p} />,
+  strong: ({ node, ...p }) => <strong className="font-semibold text-slate-800 dark:text-slate-100" {...p} />,
+  em: ({ node, ...p }) => <em className="italic" {...p} />,
+  ul: ({ node, ...p }) => <ul className="mb-2 ml-4 list-disc text-slate-600 dark:text-slate-300" {...p} />,
+  li: ({ node, ...p }) => <li className="mb-0.5" {...p} />,
+}
+
+// Remplace les enfants de type chaîne par des segments surlignant les entités
+// (les enfants éléments — strong/em imbriqués — passent tels quels, leur propre
+// rendu surligne leurs chaînes à son tour → couverture récursive).
+function highlightMdChildren(children, entities, onEntityClick) {
+  return Children.map(children, (child, i) =>
+    typeof child === 'string'
+      ? <EntityHighlighterSegments key={i} text={child} entities={entities} onEntityClick={onEntityClick} />
+      : child
+  )
+}
+
+// Construit des composants Markdown qui surlignent les entités dans le texte,
+// en réutilisant le style de `base` (CARD_MD_COMPONENTS / IMMERSIVE_MD_COMPONENTS).
+function makeEntityMdComponents(base, entities, onEntityClick) {
+  const wrapped = {}
+  for (const [tag, Comp] of Object.entries(base)) {
+    wrapped[tag] = ({ node, children, ...rest }) =>
+      <Comp {...rest}>{highlightMdChildren(children, entities, onEntityClick)}</Comp>
+  }
+  return wrapped
+}
+
 // Types affichés sous le titre, par ordre de priorité ; les types numériques /
 // temporels peu informatifs (DATE, CARDINAL, ORDINAL, QUANTITY…) sont masqués.
 const IMMERSIVE_ENTITY_PRIORITY = ['PERSON', 'ORG', 'GPE', 'PRODUCT', 'EVENT', 'NORP', 'LOC', 'FAC', 'WORK_OF_ART', 'LAW', 'MONEY', 'PERCENT', 'LANGUAGE']
@@ -381,6 +415,13 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
   const source = article['Sources'] || ''
   const date   = formatDate(article['Date de publication'])
   const entityChips = useMemo(() => immersiveEntities(article.entities), [article.entities])
+  // Composants Markdown surlignant les entités dans le résumé (non cliquables ici).
+  const immersiveMdComponents = useMemo(
+    () => (article.entities && Object.keys(article.entities).length > 0
+      ? makeEntityMdComponents(IMMERSIVE_MD_COMPONENTS, article.entities, undefined)
+      : IMMERSIVE_MD_COMPONENTS),
+    [article.entities]
+  )
 
   // Pan horizontal : décale la position X du cadrage pour explorer les parties
   // de l'image masquées par le recadrage (visible uniquement sur la diapo courante).
@@ -450,7 +491,7 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
               onClick={e => e.stopPropagation()}
             >
               {resumeMd
-                ? <ReportMarkdownContent md={resumeMd} components={IMMERSIVE_MD_COMPONENTS} />
+                ? <ReportMarkdownContent md={resumeMd} components={immersiveMdComponents} />
                 : resume}
             </div>
           )}
@@ -870,8 +911,14 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, o
 
   const titre    = article['Titre']?.trim() || ''
   const resume   = displayArticle['Résumé'] ?? ''
+  const resumeMd = displayArticle['Résumé_md'] ?? ''
   const entities = displayArticle.entities ?? null
   const hasEntities = entities && Object.keys(entities).length > 0
+  // Composants Markdown surlignant les entités (déplié) ; sinon styles simples.
+  const summaryMdComponents = useMemo(
+    () => (hasEntities ? makeEntityMdComponents(CARD_MD_COMPONENTS, entities, onEntityClick) : CARD_MD_COMPONENTS),
+    [hasEntities, entities, onEntityClick]
+  )
   const imgUrl   = firstImage(article['Images'])
   const date     = formatDate(article['Date de publication'])
   const time     = formatTime(article['Date de publication'])
@@ -1131,9 +1178,11 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, o
           onMouseEnter={hasEntities ? onWarmEntityDialog : undefined}
           onFocus={hasEntities ? onWarmEntityDialog : undefined}
         >
-          {hasEntities
-            ? <EntityHighlighter text={resume} entities={entities} onEntityClick={onEntityClick} />
-            : <SearchHighlighter text={resume} query={highlight} />
+          {expanded && resumeMd
+            ? <ReportMarkdownContent md={resumeMd} components={summaryMdComponents} />
+            : hasEntities
+              ? <EntityHighlighter text={resume} entities={entities} onEntityClick={onEntityClick} />
+              : <SearchHighlighter text={resume} query={highlight} />
           }
         </div>
         {(url || resume.length > 300) && (


### PR DESCRIPTION
## Affichage du résumé Markdown
- **Vue article normale** : en mode **déplié**, rendu Markdown de `Résumé_md` (chapitres, gras, italique) **avec entités surlignées et cliquables**. Aperçu **replié** inchangé (texte + entités + surlignage recherche, pour le scan).
- **Vue immersive** : `Résumé_md` rendu en Markdown avec entités surlignées (non cliquables, lecture).
- Helper partagé `makeEntityMdComponents()` qui réinjecte `EntityHighlighterSegments` dans les nœuds *texte* du Markdown (récursif, couvre aussi `**gras**`/*italique*). Liens non surlignés (évite `<button>` dans `<a>`).

## Robustesse de l'enrichissement — corrige « le Résumé_md disparaît »
Le `Résumé_md` était écrasé en production par des écritures concurrentes :
- **Exclusion des fichiers dérivés `_WUDD.AI_`** (`48-heures.json`…) : reconstruits par `flux_watcher` toutes les 5 min → enrichir leur copie était inutile et immédiatement écrasé (grosse source de perte).
- **Écriture merge-safe** (`_merge_write`) : relit la version disque la plus récente juste avant d'écrire et n'applique `Résumé_md` que par URL → n'écrase plus les modifications concurrentes (NER/sentiment, ajouts d'articles par un watcher). Vérifié par test.

## Tests
+7 (`_merge_write` anti-course, `_in_period`, exclusion `_WUDD.AI_`). Suite verte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)