### PR TITLE
feat(résumé): génère Résumé_md dès la création de l'article (watchers)

### DIFF
--- a/scripts/Get_data_from_JSONFile_AskSummary_v2.py
+++ b/scripts/Get_data_from_JSONFile_AskSummary_v2.py
@@ -33,6 +33,7 @@ from datetime import datetime
 from utils.logging import print_console, setup_logger, default_logger
 from utils.config import get_config
 from utils.api_client import get_ai_client, get_summary_client
+from utils.summary_formatter import format_summary_markdown
 from utils.http_utils import fetch_and_extract_text, extract_top_n_largest_images
 from utils.date_utils import (
     parse_iso_date,
@@ -344,6 +345,10 @@ def main():
         for _field in ("sentiment", "score_sentiment", "ton_editorial", "score_ton"):
             if _field in _sentiment_data:
                 article[_field] = _sentiment_data[_field]
+        # Résumé Markdown formaté (best-effort ; sinon enrichissement nocturne).
+        _md = format_summary_markdown(resume)
+        if _md:
+            article["Résumé_md"] = _md
         articles_data.append(article)
     
     # Sauvegarde des résultats dans un fichier JSON (dans le sous-répertoire du flux)

--- a/scripts/flux_watcher.py
+++ b/scripts/flux_watcher.py
@@ -33,6 +33,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.api_client import get_ai_client, get_summary_client
+from utils.summary_formatter import format_summary_markdown
 from utils.http_utils import fetch_and_extract_text, extract_top_n_largest_images, RSS_FEED_HEADERS, fetch_rss_feed
 from utils.logging import print_console
 from utils.quota import get_quota_manager
@@ -362,6 +363,11 @@ def main(dry_run: bool = False) -> None:
             }
             if entities:
                 article["entities"] = entities
+            # Résumé Markdown formaté (chapitres/gras) pour l'affichage enrichi.
+            # Best-effort : si l'IA échoue, pas de clé → l'enrichissement nocturne réessaiera.
+            _md = format_summary_markdown(resume)
+            if _md:
+                article["Résumé_md"] = _md
 
             # Relire le fichier cible (peut avoir changé entre deux itérations)
             existing_list: list = []

--- a/scripts/get-keyword-from-rss.py
+++ b/scripts/get-keyword-from-rss.py
@@ -29,6 +29,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.api_client import get_ai_client, get_summary_client
+from utils.summary_formatter import format_summary_markdown
 from utils.article_index import get_article_index
 from utils.date_utils import parse_article_date
 from utils.deduplication import Deduplicator
@@ -346,6 +347,7 @@ for feed_idx, (feed_url, feed_title, bypass_quota) in enumerate(feeds, 1):
                     entities = cached["entities"]
                     images   = cached["images"]
                     resume   = combined.get("resume", "")
+                    resume_md = cached.get("resume_md", "")
                 else:
                     # ── Premier traitement de cet URL : fetch + IA
                     print_console(f"      Extraction du texte de l'article...")
@@ -375,8 +377,11 @@ for feed_idx, (feed_url, feed_title, bypass_quota) in enumerate(feeds, 1):
                         entities = sanitize_entities(entities, validate_person_p31=validate_person_p31)
                     print_console(f"      Extraction de l'image principale...")
                     images = extract_top_n_largest_images(link, n=1, min_width=500)
+                    # Résumé Markdown formaté (best-effort ; sinon enrichissement nocturne)
+                    resume_md = format_summary_markdown(resume)
                     # Mémoriser pour les mots-clés suivants dans ce run
-                    _processed_in_run[link] = {"combined": combined, "entities": entities, "images": images}
+                    _processed_in_run[link] = {"combined": combined, "entities": entities,
+                                               "images": images, "resume_md": resume_md}
 
                 # Vérifier le quota par entité (après détection, avant ajout) — sauf si bypassQuota activé
                 if entities and not bypass_quota:
@@ -406,6 +411,8 @@ for feed_idx, (feed_url, feed_title, bypass_quota) in enumerate(feeds, 1):
                 for _field in ("sentiment", "score_sentiment", "ton_editorial", "score_ton"):
                     if _field in combined:
                         article[_field] = combined[_field]
+                if resume_md:
+                    article["Résumé_md"] = resume_md
                 results[kw][link] = article
                 _seen_titles.add(title.strip().lower())
                 # Pour les flux bypassQuota, on n'incrémente pas les compteurs

--- a/scripts/web_watcher.py
+++ b/scripts/web_watcher.py
@@ -38,6 +38,7 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.api_client import get_ai_client, get_summary_client
+from utils.summary_formatter import format_summary_markdown
 from utils.article_index import get_article_index
 from utils.date_utils import parse_article_date
 from utils.entity_index import get_entity_index
@@ -475,6 +476,10 @@ def _process_article(
         article["entities"] = entities
     if page["title"]:
         article["Titre"] = page["title"]
+    # Résumé Markdown formaté (best-effort ; sinon enrichissement nocturne).
+    _md = format_summary_markdown(resume)
+    if _md:
+        article["Résumé_md"] = _md
 
     quota.record_article(keyword, title_src, entities)
     src_state["processed_urls"].append(url)


### PR DESCRIPTION
## Problème
Les nouveaux articles n'obtenaient leur résumé Markdown (`Résumé_md`) qu'au passage de l'enrichissement nocturne (cron 03h30) — pas à la création.

## Correctif
`Résumé_md` est désormais généré **à la création**, dans tous les scripts de collecte :
- `flux_watcher.py`, `web_watcher.py`, `Get_data_from_JSONFile_AskSummary_v2.py` : reformatage inline après construction de l'article.
- `get-keyword-from-rss.py` : reformatage **mémoïsé** dans `_processed_in_run` (un article matchant plusieurs mots-clés n'est reformaté qu'une fois).

Best-effort : si l'IA échoue, aucune clé n'est posée → `enrich_summary_format` (03h30) réessaie. Reformatage local (Ollama).

## Vérifié
Un article fraîchement créé par `flux_watcher` (« USA: les députés votent la fin de la guerre contre l'Iran », La Liberté) porte bien son `Résumé_md` (chapitres ### En bref/Contexte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)