### PR TITLE
Vue immersive desktop, garde-fou résumés chinois & tableau mots-clés cross-flux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM python:3.14-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     cron \
+    fonts-dejavu-core \
     && rm -rf /var/lib/apt/lists/*
 
 # 2. Création des dossiers de travail

--- a/archives/crontab
+++ b/archives/crontab
@@ -30,7 +30,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # DÉSACTIVÉ 2026-03-31 : génère des doublons avec generate_keyword_reports.py (format Keyword_rapport_YYYY-MM-DD.md)
 # 30 5 28-31 * * root [ "$(date -d tomorrow +\%d)" = "01" ] && cd /app && python3 scripts/articles_rss_to_markdown.py 2>&1 | tee -a /app/rapports/cron_rss_markdown.log
 # Génère le rapport quotidien Top 10 entités des 48h à 23h00 (après la dernière collecte RSS de 22h00)
-0 23 * * * root cd /app && python3 scripts/generate_48h_report.py 2>&1 | tee -a /app/rapports/cron_48h_report.log
+# DÉSACTIVÉ 2026-06-04 : rapport rapport_48h.md jugé inutile par l'utilisateur
+# 0 23 * * * root cd /app && python3 scripts/generate_48h_report.py 2>&1 | tee -a /app/rapports/cron_48h_report.log
 # Détecte les tendances et génère data/alertes.json — matin (7h00) et midi (12h00).
 # Le cooldown (global.cooldown_days) évite de re-notifier les mêmes entités ;
 # le run de midi ne notifie donc que les entités réellement nouvelles ou escaladées.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,6 @@ pytest-cov>=7.1.0,<8.0.0
 
 # Métriques Prometheus (endpoint /metrics pour Grafana/Netdata)
 prometheus_client>=0.21.0
+
+# Rendu d'images (graphique des flux en PNG pour les notifications Discord)
+pillow>=10.0.0

--- a/scripts/articles_rss_to_markdown.py
+++ b/scripts/articles_rss_to_markdown.py
@@ -24,6 +24,7 @@ if str(PROJECT_ROOT) not in sys.path:
 
 from scripts.articles_json_to_markdown import json_to_markdown
 from utils.logging import print_console
+from utils.report_cleanup import cleanup_old_dated_reports
 
 ARTICLES_DIR = PROJECT_ROOT / "data" / "articles-from-rss"
 RAPPORTS_BASE = PROJECT_ROOT / "rapports" / "markdown" / "keyword"
@@ -98,6 +99,7 @@ def process_file(json_file: Path) -> None:
     try:
         print_console(f"Conversion : {json_file.name} ({len(filtered)} articles du {month_start} au {month_end}) → {output_file.relative_to(PROJECT_ROOT)}")
         json_to_markdown(tmp_path, str(output_file))
+        cleanup_old_dated_reports(output_file)
     finally:
         Path(tmp_path).unlink(missing_ok=True)
 

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -104,6 +104,19 @@ def _render_flux_chart_png(counts: dict, top_n: int = 10) -> bytes | None:
             return ImageFont.load_default()
 
     f_title, f_lbl, f_val = _font(18), _font(14), _font(13)
+    # Palette de couleurs (une par barre, cyclique)
+    palette = [
+        (52, 152, 219),   # bleu
+        (46, 204, 113),   # vert
+        (231, 76, 60),    # rouge
+        (155, 89, 182),   # violet
+        (241, 196, 15),   # jaune
+        (26, 188, 156),   # turquoise
+        (230, 126, 34),   # orange
+        (52, 73, 94),     # ardoise
+        (233, 30, 99),    # rose
+        (149, 165, 166),  # gris
+    ]
     mx = sorted_flux[0][1] or 1
     W, pad, label_w, row_h, top_off = 760, 16, 190, 30, 48
     bar_x = pad + label_w + 8
@@ -119,7 +132,7 @@ def _render_flux_chart_png(counts: dict, top_n: int = 10) -> bytes | None:
         short = (short[:21] + "…") if len(short) > 22 else short
         d.text((pad, y + 5), short, fill=(45, 45, 45), font=f_lbl)
         bw = max(3, int(c / mx * bar_max))
-        d.rectangle([bar_x, y + 4, bar_x + bw, y + row_h - 8], fill=(52, 152, 219))
+        d.rectangle([bar_x, y + 4, bar_x + bw, y + row_h - 8], fill=palette[i % len(palette)])
         d.text((bar_x + bw + 6, y + 5), str(c), fill=(45, 45, 45), font=f_val)
 
     import io

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -31,6 +31,68 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 from utils.logging import print_console, default_logger
 from utils.date_utils import parse_article_date
 from utils.report_cleanup import cleanup_old_dated_reports
+from utils.api_client import get_ai_client
+from utils.exporters.webhook import send_text_discord
+
+_CJK_RE = re.compile(r"[一-鿿㐀-䶿豈-﫿]")
+
+
+def _generate_cross_flux_synthesis(cross_entities: list, counts: dict, days: int,
+                                   use_ai: bool = True) -> str:
+    """Génère une synthèse IA des éléments de l'analyse croisée (provider configuré).
+
+    Retourne du Markdown (paragraphes) ou "" si IA désactivée/indisponible.
+    """
+    if not use_ai or (not cross_entities and not counts):
+        return ""
+    ent_lines = [
+        f"- {e['entity_value']} ({e['entity_type']}) : {e['nb_flux']} flux, "
+        f"{e['total_mentions']} mentions"
+        for e in cross_entities[:15]
+    ]
+    ent_block = "\n".join(ent_lines) if ent_lines else "(aucune entité transversale détectée)"
+    top_flux = sorted(counts.items(), key=lambda x: -x[1])[:10]
+    flux_lines = [f"- {n.replace('rss:', '')} : {c} articles" for n, c in top_flux]
+    flux_block = "\n".join(flux_lines) if flux_lines else "(aucun volume disponible)"
+    prompt = (
+        "Tu es analyste de veille informationnelle. Voici une analyse croisée des flux "
+        f"de veille (fenêtre {days} jours) : des entités apparaissant dans plusieurs flux, "
+        "et le volume d'articles par flux. Rédige en français une SYNTHÈSE des éléments.\n"
+        "Règles STRICTES :\n"
+        "- Commence DIRECTEMENT par la synthèse, sans phrase d'introduction, sans mentionner "
+        "ton rôle, ni d'éventuelles données manquantes.\n"
+        "- 2 à 3 paragraphes rédigés (pas de liste) ;\n"
+        "- mets en évidence les convergences entre flux, les entités transversales et les "
+        "tendances de fond ;\n"
+        "- mets en **gras** quelques points-clés, avec parcimonie ;\n"
+        "- n'invente aucun fait : appuie-toi uniquement sur les données fournies.\n\n"
+        "Entités présentes dans plusieurs flux :\n" + ent_block +
+        "\n\nVolume d'articles par flux :\n" + flux_block
+    )
+    try:
+        out = (get_ai_client().ask(prompt, timeout=120, max_tokens=800) or "").strip()
+    except Exception as exc:
+        default_logger.warning(f"[cross-flux] Synthèse IA indisponible : {exc}")
+        return ""
+    low = out.lower()
+    if not out or low.startswith(("erreur", "désolé")) or _CJK_RE.search(out):
+        return ""
+    return out
+
+
+def _flux_bar_chart_text(counts: dict, top_n: int = 10, width: int = 18) -> str:
+    """Représente le top flux en barres Unicode (pour une notification Discord)."""
+    sorted_flux = sorted(counts.items(), key=lambda x: -x[1])[:top_n]
+    if not sorted_flux:
+        return ""
+    mx = sorted_flux[0][1] or 1
+    out = []
+    for name, c in sorted_flux:
+        short = name.replace("rss:", "")
+        short = (short[:19] + "…") if len(short) > 20 else short
+        bar = "█" * max(1, round(c / mx * width))
+        out.append(f"{short:<20} {bar} {c}")
+    return "\n".join(out)
 
 # ── Constantes ───────────────────────────────────────────────────────────────
 
@@ -354,7 +416,9 @@ def collect_entities_by_flux(
         { "nom_flux" : { "TYPE:valeur" : count } }
     """
     result = _collect_entities_from_index(project_root, days)
-    if result is not None:
+    # Un dict vide signifie un index absent/dégradé (ou dominé par les dérivés
+    # _WUDD.AI_ exclus) : on bascule alors sur le scan rglob complet.
+    if result:
         return result
 
     # Fallback : scan rglob complet
@@ -511,6 +575,7 @@ def build_cross_flux_markdown(
     cross_entities: list[dict],
     flux_article_counts: dict[str, int] | None = None,
     project_root: Path | None = None,
+    synthesis: str = "",
 ) -> str:
     """Génère le rapport Markdown de l'analyse croisée."""
     now_str = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
@@ -552,6 +617,11 @@ def build_cross_flux_markdown(
         flux_items.append(f"**{letter}** `{f}` ({nb} article(s))")
     lines.append(", ".join(flux_items))
     lines.append("")
+
+    # Synthèse des éléments (IA) — en encadré, juste après les flux
+    if synthesis.strip():
+        quoted = "\n".join(("> " + l) if l.strip() else ">" for l in synthesis.strip().splitlines())
+        lines += ["## 🧭 Synthèse des éléments", "", quoted, "", "---", ""]
 
     if not cross_entities:
         lines += [
@@ -648,6 +718,14 @@ def parse_args():
         "--dry-run", action="store_true",
         help="Affiche le résultat sans sauvegarder"
     )
+    parser.add_argument(
+        "--no-ai", action="store_true",
+        help="Désactive la synthèse IA"
+    )
+    parser.add_argument(
+        "--no-discord", action="store_true",
+        help="N'envoie pas la notification Discord"
+    )
     return parser.parse_args()
 
 
@@ -689,6 +767,15 @@ def main():
     flux_article_counts = collect_article_counts_by_flux(project_root, days=args.days)
     print_console(f"  → {sum(flux_article_counts.values())} article(s) comptabilisé(s) au total")
 
+    # Synthèse IA des éléments (sautée en dry-run pour éviter un appel API inutile)
+    synthesis = ""
+    if not args.dry_run and not args.no_ai:
+        synthesis = _generate_cross_flux_synthesis(
+            cross_entities, flux_article_counts, args.days, use_ai=True
+        )
+        if synthesis:
+            print_console("  → synthèse IA générée")
+
     report_md = build_cross_flux_markdown(
         date_str=date_str,
         days=args.days,
@@ -696,6 +783,7 @@ def main():
         cross_entities=cross_entities,
         flux_article_counts=flux_article_counts,
         project_root=project_root,
+        synthesis=synthesis,
     )
 
     if args.dry_run:
@@ -717,6 +805,24 @@ def main():
     md_path.write_text(report_md, encoding="utf-8")
     print_console(f"Rapport Markdown sauvegardé : {md_path}")
     cleanup_old_dated_reports(md_path)
+
+    # Notification Discord : uniquement la synthèse + le graphique des flux (barres)
+    if not args.no_discord and (synthesis or flux_article_counts):
+        chart = _flux_bar_chart_text(flux_article_counts, top_n=10)
+        parts = []
+        if synthesis:
+            parts.append(synthesis)
+        if chart:
+            parts.append("**Top flux (articles)**\n```\n" + chart + "\n```")
+        description = "\n\n".join(parts)
+        try:
+            send_text_discord(
+                title=f"🔀 Analyse croisée des flux — {date_str}",
+                description=description,
+                footer=f"{len(cross_entities)} entités multi-flux · {len(flux_names)} flux · WUDD.ai",
+            )
+        except Exception as exc:
+            print_console(f"Notification Discord échouée : {exc}", level="warning")
 
 
 if __name__ == "__main__":

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -41,6 +41,16 @@ _ENTITY_TYPES_PERTINENTS = {
     "PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "DISEASE", "NORP"
 }
 
+# Sous-répertoire des fichiers DÉRIVÉS (agrégats : 48-heures.json, direct.json,
+# merged/…). Ils dupliquent les articles des vrais flux → exclus du rapport pour
+# éviter le double comptage et un faux flux « rss:_WUDD.AI_/… ».
+_DERIVED_SUBDIR = "_WUDD.AI_"
+
+
+def _is_derived_path(parts) -> bool:
+    """Vrai si le chemin (parts) traverse le sous-répertoire dérivé _WUDD.AI_."""
+    return _DERIVED_SUBDIR in parts
+
 # ── Parsing de date ───────────────────────────────────────────────────────────
 
 def _parse_date(date_str: str) -> datetime | None:
@@ -60,6 +70,9 @@ def _file_path_to_flux_name(file_path: str) -> str:
     if not file_path:
         return ""
     parts = Path(file_path).parts
+    # Ignore les agrégats dérivés (_WUDD.AI_/48-heures.json…)
+    if _is_derived_path(parts):
+        return ""
     # data/articles/<flux_dir>/...json
     if len(parts) >= 3 and parts[1] == "articles":
         return parts[2]
@@ -222,7 +235,7 @@ def collect_article_counts_by_flux(
     articles_dir = project_root / "data" / "articles"
     if articles_dir.exists():
         for flux_dir in articles_dir.iterdir():
-            if not flux_dir.is_dir():
+            if not flux_dir.is_dir() or flux_dir.name == _DERIVED_SUBDIR:
                 continue
             flux_name = flux_dir.name
             for json_file in flux_dir.rglob("*.json"):
@@ -233,7 +246,8 @@ def collect_article_counts_by_flux(
     rss_dir = project_root / "data" / "articles-from-rss"
     if rss_dir.exists():
         for json_file in rss_dir.rglob("*.json"):
-            if "cache" in json_file.relative_to(rss_dir).parts:
+            rel_parts = json_file.relative_to(rss_dir).parts
+            if "cache" in rel_parts or _is_derived_path(rel_parts):
                 continue
             flux_name = (
                 f"rss:{json_file.parent.name}/{json_file.stem}"
@@ -270,7 +284,7 @@ def collect_entities_by_flux(
     articles_dir = project_root / "data" / "articles"
     if articles_dir.exists():
         for flux_dir in articles_dir.iterdir():
-            if not flux_dir.is_dir():
+            if not flux_dir.is_dir() or flux_dir.name == _DERIVED_SUBDIR:
                 continue
             flux_name = flux_dir.name
             for json_file in flux_dir.rglob("*.json"):
@@ -282,7 +296,8 @@ def collect_entities_by_flux(
     rss_dir = project_root / "data" / "articles-from-rss"
     if rss_dir.exists():
         for json_file in rss_dir.rglob("*.json"):
-            if "cache" in json_file.relative_to(rss_dir).parts:
+            rel_parts = json_file.relative_to(rss_dir).parts
+            if "cache" in rel_parts or _is_derived_path(rel_parts):
                 continue
             flux_name = f"rss:{json_file.parent.name}/{json_file.stem}" if json_file.parent != rss_dir else f"rss:{json_file.stem}"
             _collect_from_file(json_file, flux_name, cutoff, flux_entities)

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(_PROJECT_ROOT))
 
 from utils.logging import print_console, default_logger
 from utils.date_utils import parse_article_date
+from utils.report_cleanup import cleanup_old_dated_reports
 
 # ── Constantes ───────────────────────────────────────────────────────────────
 
@@ -587,6 +588,7 @@ def main():
     md_path = _OUTPUT_DIR / f"cross_flux_{date_str}.md"
     md_path.write_text(report_md, encoding="utf-8")
     print_console(f"Rapport Markdown sauvegardé : {md_path}")
+    cleanup_old_dated_reports(md_path)
 
 
 if __name__ == "__main__":

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -80,6 +80,54 @@ def _generate_cross_flux_synthesis(cross_entities: list, counts: dict, days: int
     return out
 
 
+def _render_flux_chart_png(counts: dict, top_n: int = 10) -> bytes | None:
+    """Rend un graphique en barres du top flux (PNG via Pillow). None si indisponible."""
+    try:
+        from PIL import Image, ImageDraw, ImageFont
+    except Exception:
+        return None
+    sorted_flux = sorted(counts.items(), key=lambda x: -x[1])[:top_n]
+    if not sorted_flux:
+        return None
+
+    def _font(size: int):
+        for p in ("/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+                  "/System/Library/Fonts/Supplemental/Arial.ttf",
+                  "/Library/Fonts/Arial.ttf"):
+            try:
+                return ImageFont.truetype(p, size)
+            except Exception:
+                continue
+        try:
+            return ImageFont.load_default(size)
+        except Exception:
+            return ImageFont.load_default()
+
+    f_title, f_lbl, f_val = _font(18), _font(14), _font(13)
+    mx = sorted_flux[0][1] or 1
+    W, pad, label_w, row_h, top_off = 760, 16, 190, 30, 48
+    bar_x = pad + label_w + 8
+    bar_max = W - bar_x - 70
+    H = top_off + row_h * len(sorted_flux) + pad
+
+    img = Image.new("RGB", (W, H), (255, 255, 255))
+    d = ImageDraw.Draw(img)
+    d.text((pad, 16), "Top flux — articles", fill=(20, 20, 20), font=f_title)
+    for i, (name, c) in enumerate(sorted_flux):
+        y = top_off + i * row_h
+        short = name.replace("rss:", "")
+        short = (short[:21] + "…") if len(short) > 22 else short
+        d.text((pad, y + 5), short, fill=(45, 45, 45), font=f_lbl)
+        bw = max(3, int(c / mx * bar_max))
+        d.rectangle([bar_x, y + 4, bar_x + bw, y + row_h - 8], fill=(52, 152, 219))
+        d.text((bar_x + bw + 6, y + 5), str(c), fill=(45, 45, 45), font=f_val)
+
+    import io
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def _flux_bar_chart_text(counts: dict, top_n: int = 10, width: int = 18) -> str:
     """Représente le top flux en barres Unicode (pour une notification Discord)."""
     sorted_flux = sorted(counts.items(), key=lambda x: -x[1])[:top_n]
@@ -806,20 +854,23 @@ def main():
     print_console(f"Rapport Markdown sauvegardé : {md_path}")
     cleanup_old_dated_reports(md_path)
 
-    # Notification Discord : uniquement la synthèse + le graphique des flux (barres)
+    # Notification Discord : uniquement la synthèse + le graphique des flux.
+    # Graphique en image PNG (Pillow) ; repli sur barres texte si indisponible.
     if not args.no_discord and (synthesis or flux_article_counts):
-        chart = _flux_bar_chart_text(flux_article_counts, top_n=10)
-        parts = []
-        if synthesis:
-            parts.append(synthesis)
-        if chart:
-            parts.append("**Top flux (articles)**\n```\n" + chart + "\n```")
+        chart_png = _render_flux_chart_png(flux_article_counts, top_n=10)
+        parts = [synthesis] if synthesis else []
+        if not chart_png:
+            bars = _flux_bar_chart_text(flux_article_counts, top_n=10)
+            if bars:
+                parts.append("**Top flux (articles)**\n```\n" + bars + "\n```")
         description = "\n\n".join(parts)
         try:
             send_text_discord(
                 title=f"🔀 Analyse croisée des flux — {date_str}",
                 description=description,
                 footer=f"{len(cross_entities)} entités multi-flux · {len(flux_names)} flux · WUDD.ai",
+                image_bytes=chart_png,
+                image_name="flux.png",
             )
         except Exception as exc:
             print_console(f"Notification Discord échouée : {exc}", level="warning")

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -135,12 +135,25 @@ def _normalize_keyword_stem(kw: str) -> str:
     return kw.strip().lower().replace(' ', '-')
 
 
-def _build_keyword_graph_block(
+def _keyword_sort_key(keyword: str) -> str:
+    """Clé de tri alphabétique : sans accents, en minuscules, sans crochets de tête."""
+    ascii_form = unicodedata.normalize("NFKD", keyword).encode("ascii", "ignore").decode()
+    return ascii_form.lower().lstrip("[](){} ").strip()
+
+
+def _md_cell(terms: list[str]) -> str:
+    """Formate une liste de termes pour une cellule de tableau Markdown."""
+    cleaned = [str(t).strip().replace("|", "\\|") for t in (terms or []) if str(t).strip()]
+    return ", ".join(cleaned) if cleaned else "—"
+
+
+def _build_keyword_table_block(
     project_root: Path,
     active_stems: set[str] | None = None,
 ) -> str:
-    """Génère un bloc ``\`\`\`keyword-graph`` avec le JSON des mots-clés actifs.
-    Ce bloc est rendu par KeywordForceGraph dans le viewer WUDD.ai.
+    """Génère un tableau Markdown des mots-clés de veille, trié alphabétiquement.
+
+    Colonnes : mot-clé, variantes « OU » (au moins une) et termes « ET » (tous requis).
 
     Args:
         project_root  : racine du projet
@@ -166,7 +179,17 @@ def _build_keyword_graph_block(
     if not keywords:
         return ""
 
-    return "```keyword-graph\n" + json.dumps(keywords, ensure_ascii=False) + "\n```"
+    keywords = sorted(keywords, key=lambda e: _keyword_sort_key(e.get("keyword", "")))
+
+    rows = [
+        "| Mot-clé | Variantes (OU) | Termes requis (ET) |",
+        "|---|---|---|",
+    ]
+    for entry in keywords:
+        kw = str(entry.get("keyword", "")).strip().replace("|", "\\|")
+        rows.append(f"| **{kw}** | {_md_cell(entry.get('or'))} | {_md_cell(entry.get('and'))} |")
+
+    return "\n".join(rows)
 
 
 def _count_articles_in_file(json_file: Path, cutoff: datetime | None) -> int:
@@ -483,13 +506,13 @@ def build_cross_flux_markdown(
             for k, v in counts.items()
             if k.startswith("rss:") and v > 0
         } or None  # None si vide = afficher tous (fallback)
-    kw_graph = _build_keyword_graph_block(root, active_stems=active_stems)
-    if kw_graph:
+    kw_table = _build_keyword_table_block(root, active_stems=active_stems)
+    if kw_table:
         lines += [
             "",
-            "## Carte des mots-clés de veille",
+            "## Mots-clés de veille",
             "",
-            kw_graph,
+            kw_table,
             "",
         ]
 

--- a/scripts/cross_flux_analysis.py
+++ b/scripts/cross_flux_analysis.py
@@ -154,24 +154,47 @@ def _keyword_sort_key(keyword: str) -> str:
     return ascii_form.lower().lstrip("[](){} ").strip()
 
 
-def _md_cell(terms: list[str]) -> str:
-    """Formate une liste de termes pour une cellule de tableau Markdown."""
-    cleaned = [str(t).strip().replace("|", "\\|") for t in (terms or []) if str(t).strip()]
-    return ", ".join(cleaned) if cleaned else "—"
+def _md_terms_with_counts(terms: list[str], trigger_counts: dict[str, int]) -> str:
+    """Formate une liste de termes, chacun suivi de son nombre de détections.
+
+    Préfixe la cellule du nombre de termes ; trie par détections décroissantes
+    puis alphabétiquement. ``trigger_counts`` est indexé par terme en minuscules.
+    """
+    items: list[tuple[str, int]] = []
+    for t in (terms or []):
+        t = str(t).strip()
+        if not t:
+            continue
+        items.append((t, trigger_counts.get(t.lower(), 0)))
+    if not items:
+        return "—"
+    items.sort(key=lambda it: (-it[1], it[0].lower()))
+    parts = []
+    for term, count in items:
+        esc = term.replace("|", "\\|")
+        parts.append(f"{esc} ({count})")
+    return f"**{len(items)}** — " + ", ".join(parts)
 
 
 def _build_keyword_table_block(
     project_root: Path,
     active_stems: set[str] | None = None,
+    counts: dict[str, int] | None = None,
+    triggers: dict[str, dict[str, int]] | None = None,
 ) -> str:
     """Génère un tableau Markdown des mots-clés de veille, trié alphabétiquement.
 
-    Colonnes : mot-clé, variantes « OU » (au moins une) et termes « ET » (tous requis).
+    Colonnes : mot-clé, nombre d'articles détectés (sur la période), variantes
+    « OU » et termes « ET », chaque terme suivi de son nombre de détections.
 
     Args:
         project_root  : racine du projet
         active_stems  : si fourni, ne conserve que les mots-clés dont le stem
                         normalisé est dans cet ensemble (mots-clés avec articles).
+        counts        : comptage d'articles par flux (clés ``rss:<stem>``) sur la
+                        période, pour la colonne « Articles détectés ».
+        triggers      : détections par terme et par flux (clés ``rss:<stem>`` →
+                        { terme_minuscule : count }), pour annoter les mots OU/ET.
     """
     kw_file = project_root / "config" / "keyword-to-search.json"
     if not kw_file.exists():
@@ -194,13 +217,22 @@ def _build_keyword_table_block(
 
     keywords = sorted(keywords, key=lambda e: _keyword_sort_key(e.get("keyword", "")))
 
+    counts = counts or {}
+    triggers = triggers or {}
     rows = [
-        "| Mot-clé | Variantes (OU) | Termes requis (ET) |",
-        "|---|---|---|",
+        "| Mot-clé | Articles détectés | Variantes OU (détections) | Termes requis ET (détections) |",
+        "|---|---:|---|---|",
     ]
     for entry in keywords:
         kw = str(entry.get("keyword", "")).strip().replace("|", "\\|")
-        rows.append(f"| **{kw}** | {_md_cell(entry.get('or'))} | {_md_cell(entry.get('and'))} |")
+        stem = _normalize_keyword_stem(entry.get("keyword", ""))
+        n_articles = counts.get(f"rss:{stem}", 0)
+        tc = triggers.get(f"rss:{stem}", {})
+        rows.append(
+            f"| **{kw}** | {n_articles} "
+            f"| {_md_terms_with_counts(entry.get('or'), tc)} "
+            f"| {_md_terms_with_counts(entry.get('and'), tc)} |"
+        )
 
     return "\n".join(rows)
 
@@ -257,6 +289,57 @@ def collect_article_counts_by_flux(
             counts[flux_name] += _count_articles_in_file(json_file, cutoff)
 
     return dict(counts)
+
+
+def collect_trigger_terms_by_flux(
+    project_root: Path,
+    days: int = 30,
+) -> dict[str, dict[str, int]]:
+    """Compte, par flux RSS, le nombre de détections de chaque terme déclencheur.
+
+    Lit le champ ``terme_declencheur`` des articles (clé normalisée en minuscules)
+    dans la fenêtre temporelle. Sert à annoter les mots OU/ET du tableau.
+
+    Returns:
+        { "rss:<stem>" : { "<terme en minuscules>" : nombre de détections } }
+    """
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=days) if days > 0 else None
+    result: dict[str, dict[str, int]] = {}
+
+    rss_dir = project_root / "data" / "articles-from-rss"
+    if not rss_dir.exists():
+        return result
+
+    for json_file in rss_dir.rglob("*.json"):
+        rel_parts = json_file.relative_to(rss_dir).parts
+        if "cache" in rel_parts or _is_derived_path(rel_parts):
+            continue
+        try:
+            data = json.loads(json_file.read_text(encoding="utf-8", errors="replace"))
+            if not isinstance(data, list):
+                continue
+        except (json.JSONDecodeError, OSError):
+            continue
+        flux_name = (
+            f"rss:{json_file.parent.name}/{json_file.stem}"
+            if json_file.parent != rss_dir
+            else f"rss:{json_file.stem}"
+        )
+        bucket = result.setdefault(flux_name, {})
+        for article in data:
+            if not isinstance(article, dict):
+                continue
+            if cutoff is not None:
+                dt = _parse_date(article.get("Date de publication", ""))
+                if dt is None or dt < cutoff:
+                    continue
+            term = article.get("terme_declencheur")
+            if isinstance(term, str) and term.strip():
+                key = term.strip().lower()
+                bucket[key] = bucket.get(key, 0) + 1
+
+    return result
 
 
 def collect_entities_by_flux(
@@ -521,11 +604,18 @@ def build_cross_flux_markdown(
             for k, v in counts.items()
             if k.startswith("rss:") and v > 0
         } or None  # None si vide = afficher tous (fallback)
-    kw_table = _build_keyword_table_block(root, active_stems=active_stems)
+    triggers = collect_trigger_terms_by_flux(root, days=days)
+    kw_table = _build_keyword_table_block(
+        root, active_stems=active_stems, counts=counts, triggers=triggers
+    )
     if kw_table:
         lines += [
             "",
             "## Mots-clés de veille",
+            "",
+            f"> *« Articles détectés » : nombre d'articles collectés par mot-clé sur les {days} derniers jours. "
+            f"Le nombre entre parenthèses après chaque terme OU/ET indique combien de fois ce terme a "
+            f"effectivement déclenché la détection d'un article (champ `terme_declencheur`).*",
             "",
             kw_table,
             "",

--- a/scripts/generate_briefing.py
+++ b/scripts/generate_briefing.py
@@ -34,6 +34,7 @@ from utils.scoring import get_scoring_engine
 from utils.date_utils import parse_article_date
 from utils.article_index import get_article_index
 from utils.scheduler_toggle import should_run_task
+from utils.report_cleanup import cleanup_old_dated_reports
 
 # ── Constantes ───────────────────────────────────────────────────────────────
 
@@ -640,6 +641,7 @@ def main():
     output_path = _BRIEFING_DIR / filename
     output_path.write_text(briefing_md, encoding="utf-8")
     print_console(f"Briefing sauvegardé : {output_path}")
+    cleanup_old_dated_reports(output_path)
 
     # Texte podcast (TTS)
     podcast_md = build_podcast_markdown(
@@ -656,6 +658,7 @@ def main():
     podcast_path = _BRIEFING_DIR / podcast_filename
     podcast_path.write_text(podcast_md, encoding="utf-8")
     print_console(f"Texte podcast sauvegardé : {podcast_path}")
+    cleanup_old_dated_reports(podcast_path)
 
 
 if __name__ == "__main__":

--- a/scripts/generate_data_quality_report.py
+++ b/scripts/generate_data_quality_report.py
@@ -30,6 +30,7 @@ PROJECT_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
 from utils.logging import print_console
+from utils.report_cleanup import cleanup_old_dated_reports
 
 
 def parse_args() -> argparse.Namespace:
@@ -225,6 +226,8 @@ def main() -> None:
     try:
         out_path.write_text(report, encoding="utf-8")
         print_console(f"Rapport sauvegardé : {out_path}", level="info")
+        if not args.output:
+            cleanup_old_dated_reports(out_path)
     except OSError as e:
         print_console(f"Erreur d'écriture : {e}", level="error")
         sys.exit(1)

--- a/scripts/generate_keyword_reports.py
+++ b/scripts/generate_keyword_reports.py
@@ -32,6 +32,7 @@ if str(PROJECT_ROOT) not in sys.path:
 from utils.api_client import get_ai_client
 from utils.logging import print_console
 from utils.date_utils import parse_article_date
+from utils.report_cleanup import cleanup_old_dated_reports
 
 def get_month_period():
     now = datetime.now()
@@ -84,6 +85,7 @@ def main():
             with open(rapport_path, "w", encoding="utf-8") as f:
                 f.write(rapport_md)
             print_console(f"✓ Rapport généré : {rapport_path}")
+            cleanup_old_dated_reports(rapport_path)
         except Exception as e:
             print_console(f"Erreur génération rapport pour {keyword} : {e}", level="error")
 

--- a/scripts/generate_morning_digest.py
+++ b/scripts/generate_morning_digest.py
@@ -37,6 +37,7 @@ from utils.logging import print_console
 from utils.scoring import get_scoring_engine
 from utils.scheduler_toggle import should_run_task
 from utils.date_utils import parse_article_date
+from utils.report_cleanup import cleanup_old_dated_reports
 
 # Types d'entités pertinentes pour le classement
 ENTITY_TYPES_PERTINENTS = {"PERSON", "ORG", "GPE", "PRODUCT", "EVENT", "NORP", "FAC", "LOC"}
@@ -568,6 +569,7 @@ def generate_morning_digest(
     output_file = output_dir / f"digest_{today_iso}.md"
     output_file.write_text(digest_md, encoding="utf-8")
     print_console(f"✓ Digest sauvegardé : {output_file}")
+    cleanup_old_dated_reports(output_file)
 
     # 7. Envoi email (optionnel)
     if send_email:

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -27,6 +28,40 @@ from utils.config import get_config
 from utils.logging import default_logger as LOG
 from utils.date_utils import parse_article_date
 from utils.report_cleanup import cleanup_old_dated_reports
+
+
+def _highlight_entities(text: str, entities: dict) -> str:
+    """Met en **gras** la première occurrence de chaque entité nommée dans le texte.
+
+    Une seule passe regex (alternatives triées par longueur décroissante) pour
+    éviter les imbrications ; chaque entité n'est mise en gras qu'une fois.
+    """
+    if not text or not isinstance(entities, dict):
+        return text
+    values = {
+        v.strip()
+        for vals in entities.values() if isinstance(vals, list)
+        for v in vals
+        if isinstance(v, str) and len(v.strip()) >= 3
+    }
+    if not values:
+        return text
+    ordered = sorted(values, key=len, reverse=True)
+    pattern = re.compile(
+        r"(?<!\*)\b(" + "|".join(re.escape(v) for v in ordered) + r")\b(?!\*)",
+        re.IGNORECASE,
+    )
+    seen: set[str] = set()
+
+    def _repl(m: re.Match) -> str:
+        val = m.group(0)
+        key = val.lower()
+        if key in seen:
+            return val
+        seen.add(key)
+        return f"**{val}**"
+
+    return pattern.sub(_repl, text)
 
 
 def _load_profiles(project_root: Path) -> list[dict]:
@@ -177,32 +212,56 @@ def generate_profile_digest(
             date_pub = _dt_pub.strftime("%d/%m/%Y") if _dt_pub else (art.get("Date de publication") or "")[:10]
             resume = art.get("Résumé", "") or ""
             resume_lines = [l.strip() for l in resume.splitlines() if l.strip()]
-            titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"
-            resume_body = "\n".join(resume_lines[1:4]) if len(resume_lines) > 1 else ""
+            ents = art.get("entities", {}) or {}
+
+            # Titre : champ « Titre » de l'article si présent, sinon 1re ligne du
+            # résumé (et le corps repart alors de la 2e ligne).
+            titre_field = (art.get("Titre") or "").strip()
+            if titre_field:
+                titre = titre_field
+                body_lines = resume_lines
+            else:
+                titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"
+                body_lines = resume_lines[1:]
+
+            # Résumé en paragraphe, avec NER mises en gras
+            resume_body = _highlight_entities(" ".join(body_lines), ents)
 
             sentiment = art.get("sentiment", "")
             sentiment_emoji = {"positif": "🟢", "négatif": "🔴", "neutre": "⚪"}.get(sentiment, "")
 
+            # Image principale (1re image disponible)
+            img_url = ""
+            images = art.get("Images") or []
+            if isinstance(images, list) and images:
+                first_img = images[0]
+                if isinstance(first_img, dict):
+                    # Données hétérogènes : clé « URL » (doc) ou « url » (flux RSS)
+                    img_url = (first_img.get("URL") or first_img.get("url") or "").strip()
+                elif isinstance(first_img, str):
+                    img_url = first_img.strip()
+            titre_alt = titre.replace("[", "(").replace("]", ")")
+
+            # Titre de l'article en titre de niveau 2 (Markdown)
             lines += [
-                f"## {rank}. [{titre}]({url}) {sentiment_emoji}",
+                f"## {rank}. {titre} {sentiment_emoji}".rstrip(),
                 "",
-                f"> **{src}** · {date_pub} · Score profil : {score:.2f}",
+                f"*{src} · {date_pub} · score profil {score:.2f}*",
                 "",
             ]
+            # Image cliquable renvoyant vers l'article
+            if img_url:
+                lines += [f"[![{titre_alt}]({img_url})]({url})", ""]
             if resume_body:
                 lines += [resume_body, ""]
 
-            # Entités clés
-            ents = art.get("entities", {}) or {}
-            ent_list = []
-            for etype, vals in ents.items():
-                if isinstance(vals, list):
-                    ent_list.extend([f"**{v}** ({etype})" for v in vals[:2]])
-            if ent_list:
-                lines += [f"Entités : {', '.join(ent_list[:5])}", ""]
-
-            lines.append("---")
-            lines.append("")
+            # Lien vers l'article en fin d'article
+            lines += [
+                f"[🔗 Lire l'article original]({url})",
+                "",
+                "---",
+                "",
+            ]
 
     lines += [
         "",

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -28,6 +28,7 @@ from utils.config import get_config
 from utils.logging import default_logger as LOG
 from utils.date_utils import parse_article_date
 from utils.report_cleanup import cleanup_old_dated_reports
+from utils.summary_formatter import format_summary_markdown
 
 
 def _highlight_entities(text: str, entities: dict) -> str:
@@ -121,8 +122,75 @@ def _classify_article(art: dict, thematiques: list) -> str | None:
     return best
 
 
-def _render_article_block(art: dict, score: float) -> list[str]:
-    """Rend un article du digest : titre H3, image cliquable, résumé NER, lien."""
+def _demote_headings(md: str) -> str:
+    """Ajoute un niveau (#) à chaque titre pour l'imbriquer sous le titre d'article (###)."""
+    out = []
+    for line in md.splitlines():
+        s = line.lstrip()
+        if s.startswith("#"):
+            n = len(s) - len(s.lstrip("#"))
+            out.append("#" * min(n + 1, 6) + s[n:])
+        else:
+            out.append(line)
+    return "\n".join(out)
+
+
+def _highlight_md_body(md: str, entities: dict) -> str:
+    """Surligne les NER ligne par ligne, en laissant les titres `#` intacts."""
+    return "\n".join(
+        line if line.lstrip().startswith("#") else _highlight_entities(line, entities)
+        for line in md.splitlines()
+    )
+
+
+def _as_blockquote(text: str) -> str:
+    """Transforme un texte multi-lignes en citation Markdown (encadré visuel)."""
+    return "\n".join(("> " + l) if l.strip() else ">" for l in text.splitlines())
+
+
+def _generate_synthesis(top: list, profile_name: str, days: int, use_ai: bool = True) -> str:
+    """Génère une synthèse & mise en perspective via l'IA configurée (EurIA/Claude/Ollama).
+
+    Retourne du Markdown (paragraphes) ou "" si IA désactivée / indisponible.
+    """
+    if not use_ai or not top:
+        return ""
+    items = []
+    for _score, art in top[:15]:
+        titre = (art.get("Titre") or "").strip()
+        if not titre:
+            rl = [l.strip() for l in (art.get("Résumé") or "").splitlines() if l.strip()]
+            titre = rl[0] if rl else (art.get("Sources") or "")
+        src = art.get("Sources", "")
+        extrait = " ".join((art.get("Résumé") or "").split())[:300]
+        items.append(f"- [{src}] {titre} — {extrait}")
+    contexte = "\n".join(items)
+    prompt = (
+        "Tu es analyste de veille informationnelle. À partir de la sélection d'articles "
+        f"ci-dessous (profil « {profile_name} », {days} derniers jours), rédige en français une "
+        "SYNTHÈSE & MISE EN PERSPECTIVE de qualité éditoriale. Règles :\n"
+        "- 2 à 4 paragraphes rédigés (pas de liste, pas de titre) ;\n"
+        "- dégage les tendances de fond, les liens entre sujets et les signaux faibles ;\n"
+        "- mets en **gras** quelques points-clés, avec parcimonie ;\n"
+        "- n'invente aucun fait : appuie-toi uniquement sur les articles fournis ;\n"
+        "- style fluide et soigné (lissage global de la qualité).\n\n"
+        f"Articles :\n{contexte}"
+    )
+    try:
+        from utils.api_client import get_ai_client
+        out = (get_ai_client().ask(prompt, timeout=120, max_tokens=900) or "").strip()
+    except Exception as exc:
+        LOG.warning(f"[digest] Synthèse IA indisponible : {exc}")
+        return ""
+    low = out.lower()
+    if not out or low.startswith("erreur") or low.startswith("désolé"):
+        return ""
+    return out
+
+
+def _render_article_block(art: dict, score: float, use_ai: bool = True) -> list[str]:
+    """Rend un article du digest : titre H3, image cliquable, corps chapitré (Résumé_md
+    ou généré par IA si absent) avec NER, lien en fin."""
     src = art.get("Sources", "Source inconnue")
     url = art.get("URL", "#")
     _dt_pub = parse_article_date(art.get("Date de publication") or "")
@@ -132,14 +200,21 @@ def _render_article_block(art: dict, score: float) -> list[str]:
     ents = art.get("entities", {}) or {}
 
     titre_field = (art.get("Titre") or "").strip()
-    if titre_field:
-        titre = titre_field
-        body_lines = resume_lines
-    else:
-        titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"
-        body_lines = resume_lines[1:]
+    titre = titre_field or (resume_lines[0] if resume_lines else f"{src} — {date_pub}")
 
-    resume_body = _highlight_entities(" ".join(body_lines), ents)
+    # Corps chapitré : Résumé_md si présent, sinon généré par IA, sinon paragraphe brut.
+    md_body = (art.get("Résumé_md") or "").strip()
+    if not md_body and use_ai and resume.strip():
+        try:
+            md_body = (format_summary_markdown(resume) or "").strip()
+        except Exception:
+            md_body = ""
+    if md_body:
+        resume_body = _highlight_md_body(_demote_headings(md_body), ents)
+    else:
+        body_lines = resume_lines if titre_field else resume_lines[1:]
+        resume_body = _highlight_entities(" ".join(body_lines), ents)
+
     sentiment = art.get("sentiment", "")
     sentiment_emoji = {"positif": "🟢", "négatif": "🔴", "neutre": "⚪"}.get(sentiment, "")
 
@@ -270,6 +345,7 @@ def generate_profile_digest(
     profile: dict,
     days: int = 7,
     dry_run: bool = False,
+    use_ai: bool = True,
 ) -> Path | None:
     """Génère le digest Markdown pour un profil donné."""
     profile_id = profile.get("id", "unknown")
@@ -314,6 +390,18 @@ def generate_profile_digest(
     if not top:
         lines.append("*Aucun article pertinent trouvé pour ce profil sur cette période.*")
     else:
+        # Synthèse & mise en perspective IA (en tête, en encadré)
+        synthese = _generate_synthesis(top, profile_name, days, use_ai=use_ai)
+        if synthese:
+            lines += [
+                "## 🧭 Synthèse & mise en perspective",
+                "",
+                _as_blockquote(synthese),
+                "",
+                "---",
+                "",
+            ]
+
         # Regroupe les articles (déjà triés par score) par thématique de veille dominante
         thematiques = _load_thematiques(project_root)
         grouped: dict[str, list] = {}
@@ -336,7 +424,7 @@ def generate_profile_digest(
             emoji = _THEME_EMOJI.get(theme, "🗂️")
             lines += [f"## {emoji} {theme} ({len(arts)})", ""]
             for score, art in arts:
-                lines += _render_article_block(art, score)
+                lines += _render_article_block(art, score, use_ai=use_ai)
 
     lines += [
         "",
@@ -362,6 +450,8 @@ def main() -> None:
     parser.add_argument("--profile", help="ID du profil à générer (tous si absent)")
     parser.add_argument("--days", type=int, default=7, help="Fenêtre en jours (défaut: 7)")
     parser.add_argument("--dry-run", action="store_true", help="Simulation sans écriture")
+    parser.add_argument("--no-ai", action="store_true",
+                        help="Désactive la synthèse IA et la génération des chapitres manquants")
     args = parser.parse_args()
 
     config = get_config()
@@ -377,7 +467,10 @@ def main() -> None:
             return
 
     for profile in profiles:
-        out = generate_profile_digest(config.project_root, profile, days=args.days, dry_run=args.dry_run)
+        out = generate_profile_digest(
+            config.project_root, profile, days=args.days,
+            dry_run=args.dry_run, use_ai=not args.no_ai,
+        )
         if out:
             print(f"Digest généré : {out}")
 

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -28,7 +28,8 @@ from utils.config import get_config
 from utils.logging import default_logger as LOG
 from utils.date_utils import parse_article_date
 from utils.report_cleanup import cleanup_old_dated_reports
-from utils.summary_formatter import format_summary_markdown
+from utils.deduplication import Deduplicator
+from utils.source_credibility import CredibilityEngine
 
 
 def _highlight_entities(text: str, entities: dict) -> str:
@@ -188,9 +189,74 @@ def _generate_synthesis(top: list, profile_name: str, days: int, use_ai: bool = 
     return out
 
 
+_IMG_VALID_CACHE: dict[str, bool] = {}
+
+
+def _image_is_valid(url: str) -> bool:
+    """Vérifie qu'une URL d'image est accessible (pas de lien cassé dans le rapport).
+
+    HEAD puis GET de secours ; exige un statut 200 et un Content-Type image/*.
+    Résultats mis en cache pour la durée du run.
+    """
+    if not url or not url.lower().startswith(("http://", "https://")):
+        return False
+    if url in _IMG_VALID_CACHE:
+        return _IMG_VALID_CACHE[url]
+    ok = False
+    try:
+        import requests
+        headers = {"User-Agent": "Mozilla/5.0"}
+        r = requests.head(url, timeout=5, allow_redirects=True, headers=headers)
+        ctype = r.headers.get("Content-Type", "").lower()
+        if r.status_code >= 400 or r.status_code == 405 or not ctype.startswith("image"):
+            # HEAD non supporté / Content-Type absent → GET de secours
+            r = requests.get(url, timeout=6, stream=True, headers=headers)
+            ctype = r.headers.get("Content-Type", "").lower()
+        ok = (r.status_code == 200) and ctype.startswith("image")
+        r.close()
+    except Exception:
+        ok = False
+    _IMG_VALID_CACHE[url] = ok
+    return ok
+
+
+_CJK_RE = re.compile(r"[一-鿿㐀-䶿豈-﫿]")
+
+
+def _chapter_via_ai(resume: str) -> str:
+    """Reformate le résumé en chapitres Markdown via le provider cloud configuré
+    (EurIA/Claude) — qualité éditoriale, français propre, espaces corrects.
+
+    Retourne "" en cas d'échec ou de dérive de langue (l'appelant garde le brut).
+    """
+    resume = (resume or "").strip()
+    if not resume:
+        return ""
+    prompt = (
+        "Reformate fidèlement le résumé d'article ci-dessous en Markdown, EN FRANÇAIS, "
+        "structuré en chapitres. Règles STRICTES :\n"
+        "- N'invente AUCUN fait ; n'ajoute ni ne retire rien au fond.\n"
+        "- Commence par « ### En bref » (1 à 2 phrases d'accroche), puis ajoute 1 à 3 "
+        "chapitres ### seulement si le contenu le justifie (### Contexte, ### Enjeux, ### Détails).\n"
+        "- Rédige des phrases complètes et bien espacées ; AUCUN mot collé.\n"
+        "- Réponds UNIQUEMENT avec le Markdown, sans préambule ni commentaire.\n\n"
+        f"Résumé :\n{resume}"
+    )
+    try:
+        from utils.api_client import get_ai_client
+        out = (get_ai_client().ask(prompt, timeout=90, max_tokens=700) or "").strip()
+    except Exception as exc:
+        LOG.warning(f"[digest] Chapitrage IA indisponible : {exc}")
+        return ""
+    low = out.lower()
+    if not out or low.startswith(("erreur", "désolé")) or _CJK_RE.search(out):
+        return ""
+    return out
+
+
 def _render_article_block(art: dict, score: float, use_ai: bool = True) -> list[str]:
-    """Rend un article du digest : titre H3, image cliquable, corps chapitré (Résumé_md
-    ou généré par IA si absent) avec NER, lien en fin."""
+    """Rend un article du digest : titre H3, image cliquable (vérifiée), corps chapitré
+    (Résumé_md ou généré par IA si absent) avec NER, lien en fin."""
     src = art.get("Sources", "Source inconnue")
     url = art.get("URL", "#")
     _dt_pub = parse_article_date(art.get("Date de publication") or "")
@@ -202,13 +268,9 @@ def _render_article_block(art: dict, score: float, use_ai: bool = True) -> list[
     titre_field = (art.get("Titre") or "").strip()
     titre = titre_field or (resume_lines[0] if resume_lines else f"{src} — {date_pub}")
 
-    # Corps chapitré : Résumé_md si présent, sinon généré par IA, sinon paragraphe brut.
-    md_body = (art.get("Résumé_md") or "").strip()
-    if not md_body and use_ai and resume.strip():
-        try:
-            md_body = (format_summary_markdown(resume) or "").strip()
-        except Exception:
-            md_body = ""
+    # Corps : chapitrage via le cloud configuré (qualité) si IA activée, sinon
+    # paragraphe à partir du résumé brut (propre, espaces garantis).
+    md_body = _chapter_via_ai(resume) if (use_ai and resume.strip()) else ""
     if md_body:
         resume_body = _highlight_md_body(_demote_headings(md_body), ents)
     else:
@@ -235,7 +297,7 @@ def _render_article_block(art: dict, score: float, use_ai: bool = True) -> list[
         f"*{src} · {date_pub} · score profil {score:.2f}*",
         "",
     ]
-    if img_url:
+    if img_url and _image_is_valid(img_url):
         block += [f"[![{titre_alt}]({img_url})]({url})", ""]
     if resume_body:
         block += [resume_body, ""]
@@ -259,36 +321,67 @@ def _load_profiles(project_root: Path) -> list[dict]:
         return []
 
 
+def _to_utc(dt):
+    """Rend un datetime conscient en UTC (suppose UTC si naïf)."""
+    if dt is not None and dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
 def _collect_articles(project_root: Path, days: int) -> list[dict]:
-    """Collecte les articles récents des N derniers jours."""
+    """Collecte et déduplique les articles publiés dans la fenêtre des N derniers jours.
+
+    - Exclut cache, index et agrégats dérivés `_WUDD.AI_` (évite les doublons).
+    - Ne lit que les fichiers modifiés récemment (perf), puis filtre CHAQUE article
+      par sa date de publication réelle (`parse_article_date`).
+    - Déduplique (URL exacte / résumé / similarité Jaccard).
+    """
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(days=days)
-    articles = []
+    # Un article publié dans la fenêtre a forcément été écrit dans la fenêtre :
+    # on ignore les fichiers non modifiés récemment (marge de sécurité d'1 jour).
+    file_mtime_cutoff = (cutoff - timedelta(days=1)).timestamp()
+    articles: list[dict] = []
 
     for source_dir in [project_root / "data" / "articles-from-rss",
                         project_root / "data" / "articles"]:
         if not source_dir.exists():
             continue
-        for json_file in sorted(source_dir.rglob("*.json"),
-                                key=lambda f: f.stat().st_mtime, reverse=True)[:30]:
-            if "cache" in str(json_file) or "index" in json_file.name:
+        for json_file in source_dir.rglob("*.json"):
+            rel_parts = json_file.relative_to(source_dir).parts
+            if "cache" in rel_parts or "_WUDD.AI_" in rel_parts or "index" in json_file.name:
                 continue
             try:
+                if json_file.stat().st_mtime < file_mtime_cutoff:
+                    continue
                 data = json.loads(json_file.read_text(encoding="utf-8"))
                 if not isinstance(data, list):
                     continue
-                for art in data:
-                    d = art.get("Date de publication", "") or ""
-                    # Accepter les dates récentes
-                    articles.append(art)
             except Exception:
                 continue
+            for art in data:
+                if not isinstance(art, dict):
+                    continue
+                dt = _to_utc(parse_article_date(art.get("Date de publication") or ""))
+                # Dans la fenêtre ; on tolère les dates illisibles (dt None)
+                if dt is not None and dt < cutoff:
+                    continue
+                articles.append(art)
 
+    try:
+        articles = Deduplicator().deduplicate(articles)
+    except Exception as exc:
+        LOG.warning(f"[digest] Déduplication ignorée : {exc}")
     return articles
 
 
-def _score_article_for_profile(article: dict, profile: dict) -> float:
-    """Calcule un score de pertinence d'un article pour un profil (0.0 à 1.0+)."""
+def _score_article_for_profile(article: dict, profile: dict, now=None,
+                               days: int = 7, cred: "CredibilityEngine | None" = None) -> float:
+    """Calcule un score de pertinence d'un article pour un profil (0.0 à 1.0+).
+
+    Ajoute un score de BASE (récence + crédibilité source) afin que les profils sans
+    préférences (ex. « default ») soient tout de même classés de façon pertinente.
+    """
     score = 0.0
     entities = profile.get("entities", [])
     themes = profile.get("themes", [])
@@ -337,7 +430,77 @@ def _score_article_for_profile(article: dict, profile: dict) -> float:
     if existing is not None:
         score += float(existing) / 10.0
 
+    # Score de BASE — récence (0–0.3) : départage même sans préférences
+    if now is not None:
+        dt = _to_utc(parse_article_date(article.get("Date de publication") or ""))
+        if dt is not None:
+            age_days = max(0.0, (now - dt).total_seconds() / 86400.0)
+            score += 0.3 * max(0.0, 1.0 - age_days / max(days, 1))
+
+    # Score de BASE — crédibilité de la source (0–0.2)
+    cred_val = article.get("score_source")
+    if cred_val is None and cred is not None:
+        try:
+            cred_val = cred.get_score(src)
+        except Exception:
+            cred_val = None
+    if cred_val is not None:
+        try:
+            score += 0.2 * (float(cred_val) / 100.0)
+        except (TypeError, ValueError):
+            pass
+
     return score
+
+
+def _select_digest(scored: list, top_n: int, thematiques: list,
+                   max_per_source: int = 2) -> list:
+    """Sélection « vrai digest » : round-robin par thématique pour maximiser la
+    diversité des sujets, en plafonnant chaque source (`max_per_source`).
+
+    `scored` est trié par score décroissant. On groupe par thématique dominante,
+    puis on pioche tour à tour le meilleur article de chaque thème (en sautant les
+    sources saturées). Si la contrainte empêche d'atteindre `top_n`, on complète en
+    relâchant le plafond de source.
+    """
+    from collections import OrderedDict
+    by_theme: "OrderedDict[str, list]" = OrderedDict()
+    for item in scored:
+        theme = _classify_article(item[1], thematiques) or _THEME_AUTRES
+        by_theme.setdefault(theme, []).append(item)
+
+    # Thèmes ordonnés par le meilleur score qu'ils contiennent
+    theme_keys = sorted(by_theme, key=lambda t: by_theme[t][0][0], reverse=True)
+    idx = {t: 0 for t in theme_keys}
+    selected, per_source = [], {}
+    chosen_ids = set()
+
+    progress = True
+    while len(selected) < top_n and progress:
+        progress = False
+        for t in theme_keys:
+            lst = by_theme[t]
+            while idx[t] < len(lst):
+                cand = lst[idx[t]]
+                idx[t] += 1
+                src = str(cand[1].get("Sources", ""))
+                if per_source.get(src, 0) < max_per_source:
+                    selected.append(cand)
+                    chosen_ids.add(id(cand[1]))
+                    per_source[src] = per_source.get(src, 0) + 1
+                    progress = True
+                    break
+            if len(selected) >= top_n:
+                break
+
+    # Complément (sources saturées) : on relâche le plafond pour atteindre top_n
+    if len(selected) < top_n:
+        for item in scored:
+            if len(selected) >= top_n:
+                break
+            if id(item[1]) not in chosen_ids:
+                selected.append(item)
+    return selected[:top_n]
 
 
 def generate_profile_digest(
@@ -359,14 +522,17 @@ def generate_profile_digest(
         LOG.info(f"[digest] Profil '{profile_id}' : aucun article trouvé")
         return None
 
-    # Scorer et filtrer
+    # Scorer (préférences profil + base récence/crédibilité), filtrer, puis
+    # sélectionner en round-robin thématique pour un vrai digest diversifié.
+    cred = CredibilityEngine(project_root)
+    thematiques = _load_thematiques(project_root)
     scored = []
     for art in articles:
-        s = _score_article_for_profile(art, profile)
+        s = _score_article_for_profile(art, profile, now=now, days=days, cred=cred)
         if s >= 0:
             scored.append((s, art))
     scored.sort(key=lambda x: x[0], reverse=True)
-    top = scored[:top_n]
+    top = _select_digest(scored, top_n, thematiques, max_per_source=2)
 
     lines = [
         "---",
@@ -403,7 +569,7 @@ def generate_profile_digest(
             ]
 
         # Regroupe les articles (déjà triés par score) par thématique de veille dominante
-        thematiques = _load_thematiques(project_root)
+        # (thematiques déjà chargées plus haut pour la sélection)
         grouped: dict[str, list] = {}
         for score, art in top:
             theme = _classify_article(art, thematiques) or _THEME_AUTRES

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from utils.config import get_config
 from utils.logging import default_logger as LOG
 from utils.date_utils import parse_article_date
+from utils.report_cleanup import cleanup_old_dated_reports
 
 
 def _load_profiles(project_root: Path) -> list[dict]:
@@ -215,6 +216,7 @@ def generate_profile_digest(
     if not dry_run:
         out_file.write_text("\n".join(lines), encoding="utf-8")
         LOG.info(f"[digest] Rapport créé : {out_file}")
+        cleanup_old_dated_reports(out_file)
     else:
         LOG.info(f"[digest] dry-run — {out_file}")
 

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -566,8 +566,7 @@ def generate_profile_digest(
 
     # Données pour la notification Discord (remplies si articles)
     discord_synthese = ""
-    discord_sections: list = []
-    discord_image = ""
+    discord_articles: list = []
     discord_nb_themes = 0
 
     if not top:
@@ -606,22 +605,29 @@ def generate_profile_digest(
         for theme in theme_order:
             arts = grouped[theme]
             emoji = _THEME_EMOJI.get(theme, "🗂️")
-            lines += [f"## {emoji} {theme} ({len(arts)})", ""]
+            theme_label = f"{emoji} {theme}"
+            lines += [f"## {theme_label} ({len(arts)})", ""]
             for score, art in arts:
                 lines += _render_article_block(art, score, use_ai=use_ai)
-            discord_sections.append(
-                (f"{emoji} {theme}", [(_article_title(a), a.get("URL", "")) for _s, a in arts])
-            )
+                # Données Discord par article : vignette validée + accroche courte
+                img = ""
+                imgs = art.get("Images")
+                if isinstance(imgs, list) and imgs and isinstance(imgs[0], dict):
+                    u = (imgs[0].get("URL") or imgs[0].get("url") or "").strip()
+                    if u and _image_is_valid(u):
+                        img = u
+                snippet = " ".join((art.get("Résumé") or "").split())
+                if len(snippet) > 220:
+                    snippet = snippet[:219].rstrip() + "…"
+                discord_articles.append({
+                    "title": _article_title(art),
+                    "url": art.get("URL", ""),
+                    "image": img,
+                    "theme": theme_label,
+                    "snippet": snippet,
+                })
 
         discord_nb_themes = len(theme_order)
-        # Image bannière : 1re image valide parmi les articles sélectionnés
-        for _s, a in top:
-            imgs = a.get("Images")
-            if isinstance(imgs, list) and imgs and isinstance(imgs[0], dict):
-                u = (imgs[0].get("URL") or imgs[0].get("url") or "").strip()
-                if u and _image_is_valid(u):
-                    discord_image = u
-                    break
 
     lines += [
         "",
@@ -643,9 +649,8 @@ def generate_profile_digest(
                 send_digest_discord(
                     title=f"🗞️ Digest {profile_name} — {now.strftime('%d/%m/%Y')}",
                     synthesis=discord_synthese,
-                    sections=discord_sections,
+                    articles=discord_articles,
                     footer=f"{len(top)} articles · {discord_nb_themes} thématiques · WUDD.ai",
-                    image_url=discord_image,
                 )
             except Exception as exc:
                 LOG.warning(f"[digest] Notification Discord échouée : {exc}")

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -30,6 +30,16 @@ from utils.date_utils import parse_article_date
 from utils.report_cleanup import cleanup_old_dated_reports
 from utils.deduplication import Deduplicator
 from utils.source_credibility import CredibilityEngine
+from utils.exporters.webhook import send_digest_discord
+
+
+def _article_title(art: dict) -> str:
+    """Titre d'un article : champ « Titre », sinon 1re ligne du résumé, sinon source."""
+    t = (art.get("Titre") or "").strip()
+    if t:
+        return t
+    rl = [l.strip() for l in (art.get("Résumé") or "").splitlines() if l.strip()]
+    return rl[0] if rl else (art.get("Sources") or "Article")
 
 
 def _highlight_entities(text: str, entities: dict) -> str:
@@ -509,6 +519,7 @@ def generate_profile_digest(
     days: int = 7,
     dry_run: bool = False,
     use_ai: bool = True,
+    notify_discord: bool = True,
 ) -> Path | None:
     """Génère le digest Markdown pour un profil donné."""
     profile_id = profile.get("id", "unknown")
@@ -553,11 +564,18 @@ def generate_profile_digest(
         "",
     ]
 
+    # Données pour la notification Discord (remplies si articles)
+    discord_synthese = ""
+    discord_sections: list = []
+    discord_image = ""
+    discord_nb_themes = 0
+
     if not top:
         lines.append("*Aucun article pertinent trouvé pour ce profil sur cette période.*")
     else:
         # Synthèse & mise en perspective IA (en tête, en encadré)
         synthese = _generate_synthesis(top, profile_name, days, use_ai=use_ai)
+        discord_synthese = synthese
         if synthese:
             lines += [
                 "## 🧭 Synthèse & mise en perspective",
@@ -591,6 +609,19 @@ def generate_profile_digest(
             lines += [f"## {emoji} {theme} ({len(arts)})", ""]
             for score, art in arts:
                 lines += _render_article_block(art, score, use_ai=use_ai)
+            discord_sections.append(
+                (f"{emoji} {theme}", [(_article_title(a), a.get("URL", "")) for _s, a in arts])
+            )
+
+        discord_nb_themes = len(theme_order)
+        # Image bannière : 1re image valide parmi les articles sélectionnés
+        for _s, a in top:
+            imgs = a.get("Images")
+            if isinstance(imgs, list) and imgs and isinstance(imgs[0], dict):
+                u = (imgs[0].get("URL") or imgs[0].get("url") or "").strip()
+                if u and _image_is_valid(u):
+                    discord_image = u
+                    break
 
     lines += [
         "",
@@ -605,6 +636,19 @@ def generate_profile_digest(
         out_file.write_text("\n".join(lines), encoding="utf-8")
         LOG.info(f"[digest] Rapport créé : {out_file}")
         cleanup_old_dated_reports(out_file)
+
+        # Notification Discord (silencieuse si WEBHOOK_DISCORD non configuré)
+        if notify_discord and top:
+            try:
+                send_digest_discord(
+                    title=f"🗞️ Digest {profile_name} — {now.strftime('%d/%m/%Y')}",
+                    synthesis=discord_synthese,
+                    sections=discord_sections,
+                    footer=f"{len(top)} articles · {discord_nb_themes} thématiques · WUDD.ai",
+                    image_url=discord_image,
+                )
+            except Exception as exc:
+                LOG.warning(f"[digest] Notification Discord échouée : {exc}")
     else:
         LOG.info(f"[digest] dry-run — {out_file}")
 
@@ -618,6 +662,8 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="Simulation sans écriture")
     parser.add_argument("--no-ai", action="store_true",
                         help="Désactive la synthèse IA et la génération des chapitres manquants")
+    parser.add_argument("--no-discord", action="store_true",
+                        help="N'envoie pas la notification Discord du digest")
     args = parser.parse_args()
 
     config = get_config()
@@ -636,6 +682,7 @@ def main() -> None:
         out = generate_profile_digest(
             config.project_root, profile, days=args.days,
             dry_run=args.dry_run, use_ai=not args.no_ai,
+            notify_discord=not args.no_discord,
         )
         if out:
             print(f"Digest généré : {out}")

--- a/scripts/generate_personal_digest.py
+++ b/scripts/generate_personal_digest.py
@@ -64,6 +64,115 @@ def _highlight_entities(text: str, entities: dict) -> str:
     return pattern.sub(_repl, text)
 
 
+# Thématiques de veille (config/thematiques_societales.json) — emoji par thème
+_THEME_EMOJI = {
+    "Intelligence Artificielle & Technologie": "🤖",
+    "Économie & Entreprises": "📈",
+    "Protection des Consommateurs": "🛒",
+    "Politique & Géopolitique": "🌍",
+    "Médias & Information": "📰",
+    "Éthique & Droits": "🧭",
+    "Sécurité & Cybersécurité": "🔒",
+    "Justice & Réglementation": "⚖️",
+    "Santé": "🏥",
+    "Emploi & Travail": "💼",
+    "Éducation & Formation": "🎓",
+    "Environnement": "🌱",
+}
+_THEME_AUTRES = "Autres"
+
+
+def _load_thematiques(project_root: Path) -> list[tuple[str, "re.Pattern"]]:
+    """Charge les thématiques de veille triées par rang.
+
+    Retourne une liste de (nom, regex compilée des mots-clés, bornée par \\b).
+    """
+    path = project_root / "config" / "thematiques_societales.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    them = data.get("thematiques", {})
+    ordered = sorted(them.items(), key=lambda kv: kv[1].get("rang", 999))
+    result: list[tuple[str, "re.Pattern"]] = []
+    for name, info in ordered:
+        mots = [m for m in info.get("mots_cles", []) if isinstance(m, str) and m.strip()]
+        if not mots:
+            continue
+        pattern = re.compile(
+            r"\b(" + "|".join(re.escape(m) for m in mots) + r")\b", re.IGNORECASE
+        )
+        result.append((name, pattern))
+    return result
+
+
+def _classify_article(art: dict, thematiques: list) -> str | None:
+    """Retourne la thématique dominante (plus d'occurrences de mots-clés) ou None."""
+    parts = [str(art.get("Titre") or ""), str(art.get("Résumé") or "")]
+    for vals in (art.get("entities") or {}).values():
+        if isinstance(vals, list):
+            parts.extend(str(v) for v in vals)
+    text = " ".join(parts)
+    best, best_n = None, 0
+    for name, pattern in thematiques:
+        n = len(pattern.findall(text))
+        if n > best_n:
+            best_n, best = n, name
+    return best
+
+
+def _render_article_block(art: dict, score: float) -> list[str]:
+    """Rend un article du digest : titre H3, image cliquable, résumé NER, lien."""
+    src = art.get("Sources", "Source inconnue")
+    url = art.get("URL", "#")
+    _dt_pub = parse_article_date(art.get("Date de publication") or "")
+    date_pub = _dt_pub.strftime("%d/%m/%Y") if _dt_pub else (art.get("Date de publication") or "")[:10]
+    resume = art.get("Résumé", "") or ""
+    resume_lines = [l.strip() for l in resume.splitlines() if l.strip()]
+    ents = art.get("entities", {}) or {}
+
+    titre_field = (art.get("Titre") or "").strip()
+    if titre_field:
+        titre = titre_field
+        body_lines = resume_lines
+    else:
+        titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"
+        body_lines = resume_lines[1:]
+
+    resume_body = _highlight_entities(" ".join(body_lines), ents)
+    sentiment = art.get("sentiment", "")
+    sentiment_emoji = {"positif": "🟢", "négatif": "🔴", "neutre": "⚪"}.get(sentiment, "")
+
+    img_url = ""
+    images = art.get("Images") or []
+    if isinstance(images, list) and images:
+        first_img = images[0]
+        if isinstance(first_img, dict):
+            # Données hétérogènes : clé « URL » (doc) ou « url » (flux RSS)
+            img_url = (first_img.get("URL") or first_img.get("url") or "").strip()
+        elif isinstance(first_img, str):
+            img_url = first_img.strip()
+    titre_alt = titre.replace("[", "(").replace("]", ")")
+
+    block = [
+        f"### {titre} {sentiment_emoji}".rstrip(),
+        "",
+        f"*{src} · {date_pub} · score profil {score:.2f}*",
+        "",
+    ]
+    if img_url:
+        block += [f"[![{titre_alt}]({img_url})]({url})", ""]
+    if resume_body:
+        block += [resume_body, ""]
+    block += [
+        f"[🔗 Lire l'article original]({url})",
+        "",
+        "---",
+        "",
+    ]
+    return block
+
+
 def _load_profiles(project_root: Path) -> list[dict]:
     f = project_root / "config" / "user_profiles.json"
     if not f.exists():
@@ -205,63 +314,29 @@ def generate_profile_digest(
     if not top:
         lines.append("*Aucun article pertinent trouvé pour ce profil sur cette période.*")
     else:
-        for rank, (score, art) in enumerate(top, 1):
-            src = art.get("Sources", "Source inconnue")
-            url = art.get("URL", "#")
-            _dt_pub = parse_article_date(art.get("Date de publication") or "")
-            date_pub = _dt_pub.strftime("%d/%m/%Y") if _dt_pub else (art.get("Date de publication") or "")[:10]
-            resume = art.get("Résumé", "") or ""
-            resume_lines = [l.strip() for l in resume.splitlines() if l.strip()]
-            ents = art.get("entities", {}) or {}
+        # Regroupe les articles (déjà triés par score) par thématique de veille dominante
+        thematiques = _load_thematiques(project_root)
+        grouped: dict[str, list] = {}
+        for score, art in top:
+            theme = _classify_article(art, thematiques) or _THEME_AUTRES
+            grouped.setdefault(theme, []).append((score, art))
 
-            # Titre : champ « Titre » de l'article si présent, sinon 1re ligne du
-            # résumé (et le corps repart alors de la 2e ligne).
-            titre_field = (art.get("Titre") or "").strip()
-            if titre_field:
-                titre = titre_field
-                body_lines = resume_lines
-            else:
-                titre = resume_lines[0] if resume_lines else f"{src} — {date_pub}"
-                body_lines = resume_lines[1:]
+        # Ordre d'affichage : thématiques par rang, « Autres » en dernier
+        theme_order = [name for name, _ in thematiques if name in grouped]
+        if _THEME_AUTRES in grouped:
+            theme_order.append(_THEME_AUTRES)
 
-            # Résumé en paragraphe, avec NER mises en gras
-            resume_body = _highlight_entities(" ".join(body_lines), ents)
+        # Sommaire des thématiques
+        lines += ["**Thématiques :** " + " · ".join(
+            f"{_THEME_EMOJI.get(t, '🗂️')} {t} ({len(grouped[t])})" for t in theme_order
+        ), "", "---", ""]
 
-            sentiment = art.get("sentiment", "")
-            sentiment_emoji = {"positif": "🟢", "négatif": "🔴", "neutre": "⚪"}.get(sentiment, "")
-
-            # Image principale (1re image disponible)
-            img_url = ""
-            images = art.get("Images") or []
-            if isinstance(images, list) and images:
-                first_img = images[0]
-                if isinstance(first_img, dict):
-                    # Données hétérogènes : clé « URL » (doc) ou « url » (flux RSS)
-                    img_url = (first_img.get("URL") or first_img.get("url") or "").strip()
-                elif isinstance(first_img, str):
-                    img_url = first_img.strip()
-            titre_alt = titre.replace("[", "(").replace("]", ")")
-
-            # Titre de l'article en titre de niveau 2 (Markdown)
-            lines += [
-                f"## {rank}. {titre} {sentiment_emoji}".rstrip(),
-                "",
-                f"*{src} · {date_pub} · score profil {score:.2f}*",
-                "",
-            ]
-            # Image cliquable renvoyant vers l'article
-            if img_url:
-                lines += [f"[![{titre_alt}]({img_url})]({url})", ""]
-            if resume_body:
-                lines += [resume_body, ""]
-
-            # Lien vers l'article en fin d'article
-            lines += [
-                f"[🔗 Lire l'article original]({url})",
-                "",
-                "---",
-                "",
-            ]
+        for theme in theme_order:
+            arts = grouped[theme]
+            emoji = _THEME_EMOJI.get(theme, "🗂️")
+            lines += [f"## {emoji} {theme} ({len(arts)})", ""]
+            for score, art in arts:
+                lines += _render_article_block(art, score)
 
     lines += [
         "",

--- a/scripts/generate_watched_report.py
+++ b/scripts/generate_watched_report.py
@@ -28,6 +28,7 @@ from utils.logging import default_logger as LOG
 from utils.entity_index import get_entity_index
 from utils.date_utils import parse_article_date
 from utils.scheduler_toggle import should_run_task
+from utils.report_cleanup import cleanup_old_dated_reports
 
 
 def _load_watched(project_root: Path) -> list[dict]:
@@ -259,6 +260,7 @@ def generate_watched_report(project_root: Path, days: int = 7, dry_run: bool = F
     if not dry_run:
         out_file.write_text("\n".join(lines), encoding="utf-8")
         LOG.info(f"[watched_report] Rapport créé : {out_file}")
+        cleanup_old_dated_reports(out_file)
     else:
         LOG.info(f"[watched_report] dry-run — rapport serait créé : {out_file}")
 

--- a/scripts/radar_wudd.py
+++ b/scripts/radar_wudd.py
@@ -26,6 +26,7 @@ from utils.logging import print_console
 from utils.config import get_config
 from utils.date_utils import parse_article_date
 from utils.api_client import get_ai_client
+from utils.report_cleanup import cleanup_old_dated_reports
 
 # ─── CONFIG ──────────────────────────────────────────────────────────────────
 
@@ -682,6 +683,7 @@ def main():
     radar_md_path = radar_md_dir / radar_md_name
     radar_md_path.write_text(md_content, encoding="utf-8")
     print_console(f"      Radar MD : {radar_md_path.stat().st_size // 1024} KB → rapports/markdown/radar/{radar_md_name}", level="info")
+    cleanup_old_dated_reports(radar_md_path)
 
     print_console(f'✓  open "{output_path.resolve()}"', level="info")
     print_console(f'✓  open "{radar_md_path.resolve()}"', level="info")

--- a/scripts/repair_failed_summaries.py
+++ b/scripts/repair_failed_summaries.py
@@ -1,7 +1,8 @@
 """
 Script : repair_failed_summaries.py
 
-Corrige les articles dont le Résumé contient un message d'erreur API.
+Corrige les articles dont le Résumé contient un message d'erreur API
+ou a dérivé vers le chinois (caractères CJK — typique des modèles Qwen).
 Pour chaque article affecté :
   1. Récupère le texte de l'article depuis son URL
   2. Régénère le résumé via l'API EurIA
@@ -22,7 +23,7 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from utils.api_client import get_ai_client, get_summary_client
+from utils.api_client import get_ai_client, get_summary_client, _contains_chinese_chars
 from utils.http_utils import fetch_and_extract_text
 from utils.logging import print_console
 
@@ -31,6 +32,14 @@ ERROR_PREFIX = "Désolé, je n'ai pas pu obtenir de réponse"
 
 def is_error_summary(resume: str) -> bool:
     return isinstance(resume, str) and resume.startswith(ERROR_PREFIX)
+
+
+def needs_repair(resume: str) -> bool:
+    """Un résumé doit être régénéré s'il contient un message d'erreur API
+    ou s'il a dérivé vers le chinois (caractères CJK — typique de Qwen)."""
+    if not isinstance(resume, str):
+        return False
+    return is_error_summary(resume) or _contains_chinese_chars(resume)
 
 
 def repair_file(path: Path, client, dry_run: bool, delay: float) -> tuple[int, int]:
@@ -54,7 +63,7 @@ def repair_file(path: Path, client, dry_run: bool, delay: float) -> tuple[int, i
         if not isinstance(article, dict):
             continue
         resume = article.get("Résumé", "")
-        if not is_error_summary(resume):
+        if not needs_repair(resume):
             continue
 
         url = article.get("URL", "")
@@ -81,6 +90,11 @@ def repair_file(path: Path, client, dry_run: bool, delay: float) -> tuple[int, i
 
         article["Résumé"] = new_resume
         modified = True
+
+        # Invalider le Résumé_md dérivé (peut être obsolète ou lui aussi en chinois) :
+        # enrich_summary_format.py le régénérera proprement avec le garde-fou langue.
+        if "Résumé_md" in article:
+            del article["Résumé_md"]
 
         # Régénérer les entités NER
         new_entities = client.generate_entities(new_resume)
@@ -155,7 +169,7 @@ def main():
                 data = json.load(f)
             if not isinstance(data, list):
                 continue
-            n = sum(1 for a in data if isinstance(a, dict) and is_error_summary(a.get("Résumé", "")))
+            n = sum(1 for a in data if isinstance(a, dict) and needs_repair(a.get("Résumé", "")))
             if n:
                 total_errors += n
                 affected_files.append((path, n))

--- a/tests/test_report_cleanup.py
+++ b/tests/test_report_cleanup.py
@@ -1,0 +1,135 @@
+"""Tests pour utils.report_cleanup — un seul rapport daté par genre."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utils.report_cleanup import cleanup_old_dated_reports
+
+
+def _touch(directory: Path, name: str) -> Path:
+    p = directory / name
+    p.write_text("x", encoding="utf-8")
+    return p
+
+
+def test_supprime_meme_genre_autres_dates(tmp_path):
+    _touch(tmp_path, "cross_flux_2026-06-01.md")
+    _touch(tmp_path, "cross_flux_2026-06-02.md")
+    current = _touch(tmp_path, "cross_flux_2026-06-03.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert {p.name for p in deleted} == {
+        "cross_flux_2026-06-01.md",
+        "cross_flux_2026-06-02.md",
+    }
+    assert current.exists()
+    restants = sorted(p.name for p in tmp_path.iterdir())
+    assert restants == ["cross_flux_2026-06-03.md"]
+
+
+def test_ne_touche_pas_autres_genres(tmp_path):
+    _touch(tmp_path, "digest_2026-06-02.md")
+    _touch(tmp_path, "data-quality_2026-06-02.md")
+    current = _touch(tmp_path, "cross_flux_2026-06-03.md")
+
+    cleanup_old_dated_reports(current, verbose=False)
+
+    noms = {p.name for p in tmp_path.iterdir()}
+    assert noms == {
+        "digest_2026-06-02.md",
+        "data-quality_2026-06-02.md",
+        "cross_flux_2026-06-03.md",
+    }
+
+
+def test_distingue_suffixe_litteral(tmp_path):
+    # briefing daily ne doit pas supprimer briefing weekly
+    weekly = _touch(tmp_path, "briefing_2026-06-01_weekly.md")
+    _touch(tmp_path, "briefing_2026-06-02_daily.md")
+    current = _touch(tmp_path, "briefing_2026-06-03_daily.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert {p.name for p in deleted} == {"briefing_2026-06-02_daily.md"}
+    assert weekly.exists()
+    assert current.exists()
+
+
+def test_distingue_prefixe_profil(tmp_path):
+    # digest morning (digest_<date>) ne doit pas toucher digest_<profil>_<date>
+    perso = _touch(tmp_path, "digest_macron_2026-06-03.md")
+    _touch(tmp_path, "digest_2026-06-01.md")
+    current = _touch(tmp_path, "digest_2026-06-03.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert {p.name for p in deleted} == {"digest_2026-06-01.md"}
+    assert perso.exists()
+    assert current.exists()
+
+
+def test_plage_de_dates(tmp_path):
+    _touch(tmp_path, "radar_articles_generated_2026-04-01_2026-04-30.md")
+    current = _touch(tmp_path, "radar_articles_generated_2026-05-01_2026-05-31.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert {p.name for p in deleted} == {
+        "radar_articles_generated_2026-04-01_2026-04-30.md"
+    }
+    assert current.exists()
+
+
+def test_genres_mensuels_coexistants_meme_dossier(tmp_path):
+    # generate_keyword_reports : <kw>_rapport_<plage>.md
+    # articles_rss_to_markdown : <kw>_<plage>.md  (même dossier mot-clé)
+    rss_old = _touch(tmp_path, "anthropic_2026-04-01_2026-04-30.md")
+    rss_new = _touch(tmp_path, "anthropic_2026-05-01_2026-05-31.md")
+    rapport_old = _touch(tmp_path, "anthropic_rapport_2026-04-01_2026-04-30.md")
+    rapport_new = _touch(tmp_path, "anthropic_rapport_2026-05-01_2026-05-31.md")
+
+    deleted_rss = cleanup_old_dated_reports(rss_new, verbose=False)
+    deleted_rapport = cleanup_old_dated_reports(rapport_new, verbose=False)
+
+    # Chaque genre ne supprime que SA propre série, pas l'autre.
+    assert {p.name for p in deleted_rss} == {"anthropic_2026-04-01_2026-04-30.md"}
+    assert {p.name for p in deleted_rapport} == {
+        "anthropic_rapport_2026-04-01_2026-04-30.md"
+    }
+    assert rss_new.exists() and rapport_new.exists()
+    assert not rss_old.exists() and not rapport_old.exists()
+
+
+def test_nom_sans_date_ne_fait_rien(tmp_path):
+    _touch(tmp_path, "rapport_48h.md")
+    current = _touch(tmp_path, "notes_lecture.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert deleted == []
+    assert {p.name for p in tmp_path.iterdir()} == {"rapport_48h.md", "notes_lecture.md"}
+
+
+def test_dry_run_ne_supprime_pas(tmp_path):
+    old = _touch(tmp_path, "cross_flux_2026-06-01.md")
+    current = _touch(tmp_path, "cross_flux_2026-06-03.md")
+
+    deleted = cleanup_old_dated_reports(current, dry_run=True, verbose=False)
+
+    assert {p.name for p in deleted} == {"cross_flux_2026-06-01.md"}
+    assert old.exists()  # toujours présent en dry-run
+
+
+def test_ignore_les_repertoires(tmp_path):
+    (tmp_path / "cross_flux_2026-06-01.md").mkdir()  # répertoire homonyme improbable
+    current = _touch(tmp_path, "cross_flux_2026-06-03.md")
+
+    deleted = cleanup_old_dated_reports(current, verbose=False)
+
+    assert deleted == []
+    assert (tmp_path / "cross_flux_2026-06-01.md").is_dir()

--- a/utils/exporters/webhook.py
+++ b/utils/exporters/webhook.py
@@ -250,6 +250,69 @@ def send_article_discord(
         return False
 
 
+def send_digest_discord(
+    *,
+    title: str,
+    synthesis: str = "",
+    sections: Optional[list] = None,
+    footer: str = "",
+    image_url: str = "",
+    webhook_url: Optional[str] = None,
+) -> bool:
+    """Envoie un digest sous forme de notification Discord (un embed).
+
+    Args:
+        title     : titre de l'embed (ex. « 🗞️ Digest WUDD.ai — 04/06/2026 »)
+        synthesis : texte de synthèse/mise en perspective (Markdown) en tête
+        sections  : liste de (libellé_thème, [(titre_article, url), …]) — liens cliquables
+        footer    : pied d'embed (ex. « 10 articles · 9 thématiques »)
+        image_url : image bannière (1re image valide du digest)
+    """
+    url = webhook_url or os.getenv("WEBHOOK_DISCORD", "")
+    if not url:
+        default_logger.debug("WEBHOOK_DISCORD non configuré — digest Discord ignoré")
+        return False
+
+    parts: list[str] = []
+    if synthesis.strip():
+        parts.append(synthesis.strip())
+    for theme_label, arts in (sections or []):
+        if not arts:
+            continue
+        block = [f"**{theme_label}**"]
+        for art_title, art_url in arts:
+            t = " ".join((art_title or "").split())
+            if len(t) > 110:
+                t = t[:109].rstrip() + "…"
+            block.append(f"• [{t}]({art_url})" if art_url else f"• {t}")
+        parts.append("\n".join(block))
+
+    description = "\n\n".join(parts).strip()
+    if len(description) > _DISCORD_DESC_LIMIT:
+        description = description[: _DISCORD_DESC_LIMIT - 1].rstrip() + "…"
+
+    embed: dict = {
+        "title": (title or "Digest WUDD.ai")[:256],
+        "description": description or "_(digest vide)_",
+        "color": _NIVEAU_COLOR["info"],
+    }
+    if footer:
+        embed["footer"] = {"text": footer[:2048]}
+    if image_url.startswith(("http://", "https://")):
+        embed["image"] = {"url": image_url}
+
+    payload = {"embeds": [embed]}
+    try:
+        session = create_session_with_retries(total_retries=3, backoff_factor=0.5)
+        r = session.post(url, json=payload, timeout=10)
+        r.raise_for_status()
+        default_logger.info("Notification Discord digest envoyée")
+        return True
+    except Exception as e:
+        default_logger.warning(f"Erreur Discord (digest) : {e}")
+        return False
+
+
 def send_watched_entity_added(
     entity_type: str,
     value: str,

--- a/utils/exporters/webhook.py
+++ b/utils/exporters/webhook.py
@@ -385,6 +385,41 @@ def send_watched_entity_added(
 
 # ── Slack ─────────────────────────────────────────────────────────────────────
 
+def send_text_discord(
+    *,
+    title: str,
+    description: str,
+    footer: str = "",
+    color: Optional[int] = None,
+    webhook_url: Optional[str] = None,
+) -> bool:
+    """Envoie une notification Discord générique : un embed titre + description Markdown.
+
+    Utilisé p. ex. pour la synthèse du rapport d'analyse croisée des flux.
+    """
+    url = webhook_url or os.getenv("WEBHOOK_DISCORD", "")
+    if not url:
+        default_logger.debug("WEBHOOK_DISCORD non configuré — Discord ignoré")
+        return False
+    embed = {
+        "title": (title or "WUDD.ai")[:256],
+        "description": (description or "")[:_DISCORD_DESC_LIMIT] or "_(vide)_",
+        "color": color if color is not None else _NIVEAU_COLOR["info"],
+    }
+    if footer:
+        embed["footer"] = {"text": footer[:2048]}
+    payload = {"embeds": [embed]}
+    try:
+        session = create_session_with_retries(total_retries=3, backoff_factor=0.5)
+        r = session.post(url, json=payload, timeout=10)
+        r.raise_for_status()
+        default_logger.info("Notification Discord (texte) envoyée")
+        return True
+    except Exception as e:
+        default_logger.warning(f"Erreur Discord (texte) : {e}")
+        return False
+
+
 def send_slack(
     alerts: list,
     webhook_url: Optional[str] = None,

--- a/utils/exporters/webhook.py
+++ b/utils/exporters/webhook.py
@@ -14,6 +14,7 @@ Usage :
     notify_alerts(alerts)  # alerts = liste retournée par trend_detector.py
 """
 
+import json
 import os
 from typing import Optional
 
@@ -391,11 +392,14 @@ def send_text_discord(
     description: str,
     footer: str = "",
     color: Optional[int] = None,
+    image_bytes: Optional[bytes] = None,
+    image_name: str = "chart.png",
     webhook_url: Optional[str] = None,
 ) -> bool:
     """Envoie une notification Discord générique : un embed titre + description Markdown.
 
-    Utilisé p. ex. pour la synthèse du rapport d'analyse croisée des flux.
+    Si `image_bytes` est fourni, l'image est jointe (multipart) et affichée dans
+    l'embed via ``attachment://`` (utilisé pour le graphique des flux en PNG).
     """
     url = webhook_url or os.getenv("WEBHOOK_DISCORD", "")
     if not url:
@@ -408,10 +412,20 @@ def send_text_discord(
     }
     if footer:
         embed["footer"] = {"text": footer[:2048]}
+    if image_bytes:
+        embed["image"] = {"url": f"attachment://{image_name}"}
     payload = {"embeds": [embed]}
     try:
         session = create_session_with_retries(total_retries=3, backoff_factor=0.5)
-        r = session.post(url, json=payload, timeout=10)
+        if image_bytes:
+            r = session.post(
+                url,
+                data={"payload_json": json.dumps(payload)},
+                files={"file": (image_name, image_bytes, "image/png")},
+                timeout=15,
+            )
+        else:
+            r = session.post(url, json=payload, timeout=10)
         r.raise_for_status()
         default_logger.info("Notification Discord (texte) envoyée")
         return True

--- a/utils/exporters/webhook.py
+++ b/utils/exporters/webhook.py
@@ -254,59 +254,68 @@ def send_digest_discord(
     *,
     title: str,
     synthesis: str = "",
-    sections: Optional[list] = None,
+    articles: Optional[list] = None,
     footer: str = "",
-    image_url: str = "",
     webhook_url: Optional[str] = None,
 ) -> bool:
-    """Envoie un digest sous forme de notification Discord (un embed).
+    """Envoie un digest sous forme de notification Discord MULTI-EMBED.
+
+    Un embed « synthèse » en tête, puis un embed par article (vignette de l'image
+    de l'article + titre cliquable + thématique + accroche). Discord limite à 10
+    embeds par message : on garde la synthèse + les premiers articles.
 
     Args:
-        title     : titre de l'embed (ex. « 🗞️ Digest WUDD.ai — 04/06/2026 »)
-        synthesis : texte de synthèse/mise en perspective (Markdown) en tête
-        sections  : liste de (libellé_thème, [(titre_article, url), …]) — liens cliquables
-        footer    : pied d'embed (ex. « 10 articles · 9 thématiques »)
-        image_url : image bannière (1re image valide du digest)
+        title     : titre de l'embed de synthèse (ex. « 🗞️ Digest — 04/06/2026 »)
+        synthesis : texte de synthèse/mise en perspective (Markdown)
+        articles  : liste de dicts {title, url, image, theme, snippet}
+        footer    : pied du dernier embed (ex. « 10 articles · 9 thématiques »)
     """
     url = webhook_url or os.getenv("WEBHOOK_DISCORD", "")
     if not url:
         default_logger.debug("WEBHOOK_DISCORD non configuré — digest Discord ignoré")
         return False
 
-    parts: list[str] = []
+    articles = articles or []
+    embeds: list[dict] = []
+
+    # Embed de tête : titre + synthèse
+    head: dict = {"title": (title or "Digest WUDD.ai")[:256], "color": _NIVEAU_COLOR["info"]}
     if synthesis.strip():
-        parts.append(synthesis.strip())
-    for theme_label, arts in (sections or []):
-        if not arts:
-            continue
-        block = [f"**{theme_label}**"]
-        for art_title, art_url in arts:
-            t = " ".join((art_title or "").split())
-            if len(t) > 110:
-                t = t[:109].rstrip() + "…"
-            block.append(f"• [{t}]({art_url})" if art_url else f"• {t}")
-        parts.append("\n".join(block))
+        head["description"] = synthesis.strip()[:_DISCORD_DESC_LIMIT]
+    embeds.append(head)
 
-    description = "\n\n".join(parts).strip()
-    if len(description) > _DISCORD_DESC_LIMIT:
-        description = description[: _DISCORD_DESC_LIMIT - 1].rstrip() + "…"
+    # Un embed par article (avec sa vignette) — dans la limite des 10 embeds
+    slots = _DISCORD_MAX_EMBEDS - len(embeds)
+    shown = articles[:slots]
+    for art in shown:
+        t = " ".join(str(art.get("title") or "Article").split())
+        e: dict = {"title": t[:256], "color": _NIVEAU_COLOR["info"]}
+        if art.get("url"):
+            e["url"] = art["url"]
+        bits = []
+        if art.get("theme"):
+            bits.append(f"*{art['theme']}*")
+        if art.get("snippet"):
+            bits.append(str(art["snippet"]))
+        if bits:
+            e["description"] = "\n".join(bits)[:_DISCORD_DESC_LIMIT]
+        img = str(art.get("image") or "")
+        if img.startswith(("http://", "https://")):
+            e["thumbnail"] = {"url": img}
+        embeds.append(e)
 
-    embed: dict = {
-        "title": (title or "Digest WUDD.ai")[:256],
-        "description": description or "_(digest vide)_",
-        "color": _NIVEAU_COLOR["info"],
-    }
-    if footer:
-        embed["footer"] = {"text": footer[:2048]}
-    if image_url.startswith(("http://", "https://")):
-        embed["image"] = {"url": image_url}
+    # Mention des articles non affichés (au-delà de la limite d'embeds)
+    overflow = len(articles) - len(shown)
+    foot = footer + (f" · +{overflow} autres" if overflow > 0 else "")
+    if foot:
+        embeds[-1]["footer"] = {"text": foot[:2048]}
 
-    payload = {"embeds": [embed]}
+    payload = {"embeds": embeds}
     try:
         session = create_session_with_retries(total_retries=3, backoff_factor=0.5)
         r = session.post(url, json=payload, timeout=10)
         r.raise_for_status()
-        default_logger.info("Notification Discord digest envoyée")
+        default_logger.info(f"Notification Discord digest envoyée ({len(shown)} articles)")
         return True
     except Exception as e:
         default_logger.warning(f"Erreur Discord (digest) : {e}")

--- a/utils/report_cleanup.py
+++ b/utils/report_cleanup.py
@@ -1,0 +1,97 @@
+"""Nettoyage des rapports datés — un seul fichier par « genre ».
+
+Lorsqu'un rapport daté est généré (date `YYYY-MM-DD` dans le nom de fichier),
+on ne conserve dans le répertoire que le dernier généré et on supprime les
+fichiers frères du même « genre » portant d'autres dates.
+
+Le « genre » d'un fichier est son nom dont chaque portion date (`YYYY-MM-DD`)
+est remplacée par un joker. Ainsi :
+
+    cross_flux_2026-06-03.md         → genre « cross_flux_<date>.md »
+    briefing_2026-06-03_daily.md     → genre « briefing_<date>_daily.md »
+    digest_macron_2026-06-03.md      → genre « digest_macron_<date>.md »
+
+Les parties littérales non-date sont préservées, ce qui évite les faux
+positifs : `briefing_..._daily.md` ne supprime pas `briefing_..._weekly.md`,
+et `digest_<date>.md` ne touche pas `digest_macron_<date>.md`.
+
+Si le nom de fichier ne contient aucune date, la fonction ne fait rien
+(noms fixes type `rapport_48h.md`, `notes_lecture.md`).
+"""
+
+import re
+from pathlib import Path
+from typing import List, Union
+
+from utils.logging import print_console
+
+# Date ISO : YYYY-MM-DD
+_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+
+def cleanup_old_dated_reports(
+    report_path: Union[str, Path],
+    *,
+    dry_run: bool = False,
+    verbose: bool = True,
+) -> List[Path]:
+    """Supprime les rapports du même genre que `report_path`, autres dates.
+
+    Ne conserve que `report_path` (le dernier généré) parmi tous les fichiers
+    du même genre présents dans son répertoire.
+
+    Args:
+        report_path: chemin du rapport qui vient d'être généré.
+        dry_run: si True, ne supprime rien et retourne les fichiers qui le
+            seraient.
+        verbose: si True, loggue chaque suppression via `print_console`.
+
+    Returns:
+        La liste des chemins supprimés (ou qui le seraient en dry-run).
+    """
+    report_path = Path(report_path)
+    directory = report_path.parent
+    name = report_path.name
+
+    matches = list(_DATE_RE.finditer(name))
+    if not matches:
+        # Nom de fichier sans date → pas de nettoyage par genre.
+        return []
+
+    # Construit un motif regex : littéraux échappés + joker date.
+    pattern_parts: List[str] = []
+    last = 0
+    for m in matches:
+        pattern_parts.append(re.escape(name[last:m.start()]))
+        pattern_parts.append(r"\d{4}-\d{2}-\d{2}")
+        last = m.end()
+    pattern_parts.append(re.escape(name[last:]))
+    genre_re = re.compile("^" + "".join(pattern_parts) + "$")
+
+    if not directory.exists():
+        return []
+
+    deleted: List[Path] = []
+    for sibling in sorted(directory.iterdir()):
+        if not sibling.is_file():
+            continue
+        if sibling.name == name:
+            continue
+        if not genre_re.match(sibling.name):
+            continue
+        if dry_run:
+            deleted.append(sibling)
+            if verbose:
+                print_console(f"[dry-run] Supprimerait l'ancien rapport : {sibling.name}")
+            continue
+        try:
+            sibling.unlink()
+            deleted.append(sibling)
+            if verbose:
+                print_console(f"Ancien rapport supprimé : {sibling.name}")
+        except OSError as exc:
+            print_console(
+                f"⚠️  Impossible de supprimer {sibling.name} : {exc}", level="warning"
+            )
+
+    return deleted

--- a/utils/summary_formatter.py
+++ b/utils/summary_formatter.py
@@ -20,7 +20,17 @@ from utils.logging import default_logger
 
 _BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
 
+# Caractères CJK (han) — symptôme de dérive de langue des modèles Qwen.
+_CJK_RE = re.compile(
+    r"[㐀-䶿一-鿿豈-﫿\U00020000-\U0002EBEF]"
+)
+
 __all__ = ["format_summary_markdown", "degrade_overbold"]
+
+
+def _contains_cjk(text: str) -> bool:
+    """Détecte la présence de caractères chinois (CJK Han) dans un texte."""
+    return bool(text) and _CJK_RE.search(text) is not None
 
 
 def degrade_overbold(text: str) -> str:
@@ -104,7 +114,27 @@ def format_summary_markdown(
     prompt = _build_prompt(resume, entity_label, max_chars)
     try:
         from utils.api_client import get_summary_client
-        out = get_summary_client().ask(prompt, timeout=timeout, max_tokens=700)
+        client = get_summary_client()
+        out = client.ask(prompt, timeout=timeout, max_tokens=700)
+
+        # Garde-fou langue : les modèles (Qwen) dérivent parfois vers le chinois.
+        # On régénère une fois avec une consigne corrective, puis on abandonne le
+        # reformatage (l'appelant conserve alors le résumé brut, garanti français).
+        if _contains_cjk(out or ""):
+            default_logger.warning(
+                "Reformatage Markdown contient des caractères chinois — régénération."
+            )
+            retry_prompt = (
+                "Le reformatage précédent contenait des caractères chinois. "
+                "Recommence en produisant un Markdown 100 % en français, "
+                "sans aucun caractère chinois.\n\n" + prompt
+            )
+            out = client.ask(retry_prompt, timeout=timeout, max_tokens=700)
+            if _contains_cjk(out or ""):
+                default_logger.warning(
+                    "Reformatage Markdown toujours en chinois — résumé brut conservé."
+                )
+                return ""
     except Exception as exc:
         default_logger.warning(f"Reformatage Markdown indisponible ({exc}) — résumé brut conservé.")
         return ""

--- a/viewer/routes/files.py
+++ b/viewer/routes/files.py
@@ -253,7 +253,7 @@ def api_article_refresh_resume():
       file_path   (str) — chemin relatif du fichier JSON dans PROJECT_ROOT
       article_url (str) — URL de l'article à rafraîchir
       provider    (str) — 'euria', 'claude', ou 'auto' (utilise AI_PROVIDER depuis .env)
-    Retourne : { ok: bool, resume: str, entities: dict, sentiment: str,
+    Retourne : { ok: bool, resume: str, resume_md: str, entities: dict, sentiment: str,
                  score_sentiment: int, ton_editorial: str, score_ton: int,
                  temps_lecture_minutes: float, temps_lecture_label: str }
     """
@@ -355,8 +355,23 @@ def api_article_refresh_resume():
     except Exception:
         pass
 
+    # Résumé Markdown formaté (affichage enrichi) — via le formateur canonique
+    # (Ollama local privilégié, garde-fou anti-chinois). Chaîne vide si échec.
+    resume_md = ""
+    try:
+        from utils.summary_formatter import format_summary_markdown
+        resume_md = format_summary_markdown(new_resume) or ""
+    except Exception:
+        resume_md = ""
+
     # Mettre à jour l'article avec tous les enrichissements
     article["Résumé"] = new_resume
+    # Régénère le Résumé_md ; si le formatage a échoué, on retire l'ancien
+    # (potentiellement obsolète) pour que l'affichage retombe sur le brut.
+    if resume_md:
+        article["Résumé_md"] = resume_md
+    elif "Résumé_md" in article:
+        del article["Résumé_md"]
     if entities:
         article["entities"] = entities
     for field in ("sentiment", "score_sentiment", "ton_editorial", "score_ton"):
@@ -378,6 +393,7 @@ def api_article_refresh_resume():
     return jsonify({
         "ok": True,
         "resume": new_resume,
+        "resume_md": resume_md,
         "entities": entities,
         "sentiment": sentiment_data.get("sentiment"),
         "score_sentiment": sentiment_data.get("score_sentiment"),

--- a/viewer/src/components/ArticleListViewer.jsx
+++ b/viewer/src/components/ArticleListViewer.jsx
@@ -1,9 +1,9 @@
 import { lazy, Suspense, useMemo, useState, useRef, useCallback, useEffect, forwardRef, useImperativeHandle, Children } from 'react'
 import {
-  ExternalLink, ChevronDown, ChevronUp, Tag, X,
+  ExternalLink, ChevronDown, ChevronUp, ChevronLeft, ChevronRight, Tag, X,
   Filter, Search, ArrowUpDown, Newspaper,
   Download, LayoutGrid, AlignLeft, LayoutList, Maximize2, Clock,
-  Star, Eye, EyeOff, Pencil, Check, RefreshCw, FileText, Scale, BookOpen, GitMerge, FolderOpen, Hash, PlayCircle, Images,
+  Star, Eye, EyeOff, Pencil, Check, RefreshCw, FileText, Scale, BookOpen, GitMerge, FolderOpen, Hash, PlayCircle, Play, Pause, Images,
 } from 'lucide-react'
 import YouTubePanel from './YouTubePanel'
 import ArticleGalleryPanel from './ArticleGalleryPanel'
@@ -369,11 +369,12 @@ function immersiveEntities(entities, max = 8) {
 
 /** Taille de police adaptée à la longueur du titre : court → grande police, long → petite. */
 function immersiveTitleClass(len) {
-  if (len <= 30)  return 'text-[2rem] leading-[1.1]'
-  if (len <= 60)  return 'text-[1.6rem] leading-[1.12]'
-  if (len <= 100) return 'text-[1.3rem] leading-snug'
-  if (len <= 150) return 'text-[1.1rem] leading-snug'
-  return 'text-[0.95rem] leading-snug'
+  // Tailles mobiles + variantes desktop (md:) agrandies pour les grands écrans.
+  if (len <= 30)  return 'text-[2rem] leading-[1.1] md:text-[3.25rem]'
+  if (len <= 60)  return 'text-[1.6rem] leading-[1.12] md:text-[2.5rem]'
+  if (len <= 100) return 'text-[1.3rem] leading-snug md:text-[2rem]'
+  if (len <= 150) return 'text-[1.1rem] leading-snug md:text-[1.6rem]'
+  return 'text-[0.95rem] leading-snug md:text-[1.3rem]'
 }
 
 /** Parse une backgroundPosition "NN% MM%" en [x, y] numériques (défaut 50/35). */
@@ -383,7 +384,7 @@ function parsePosition(pos) {
 }
 
 /** Une diapositive plein écran du mode immersif (image cover recadrée sur le sujet + titre overlay). */
-function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummary, panX = 0 }) {
+function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummary, panX = 0, isDesktop = false }) {
   const imgUrl = firstImage(article['Images'])
   // Cadrage agrandi sur le visage dominant (yeux au tiers supérieur), calculé
   // pour le ratio du viewport et recalculé à la rotation/redimensionnement.
@@ -455,12 +456,12 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
       {/* Scrim bas pour garantir le contraste du texte sans masquer l'image */}
       <div className="absolute inset-x-0 bottom-0 h-2/3 bg-gradient-to-t from-black/85 via-black/30 to-transparent pointer-events-none" />
 
-      {/* Bloc texte cadré en bas à gauche */}
+      {/* Bloc texte cadré en bas à gauche (largeur contrainte sur grand écran) */}
       <div
-        className="absolute left-0 right-0 bottom-0 px-4"
-        style={{ paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))' }}
+        className="absolute left-0 right-0 bottom-0 px-4 md:px-12 lg:px-16"
+        style={{ paddingBottom: isDesktop ? '3rem' : 'max(1.5rem, env(safe-area-inset-bottom))' }}
       >
-        <div className="inline-block max-w-[94%] rounded-2xl bg-black/35 backdrop-blur-md px-4 py-3 shadow-xl shadow-black/30">
+        <div className="inline-block max-w-[94%] md:max-w-2xl lg:max-w-3xl rounded-2xl bg-black/35 backdrop-blur-md px-4 py-3 md:px-6 md:py-5 shadow-xl shadow-black/30">
           {(source || date) && (
             <div className="mb-1.5 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-white/85 min-w-0">
               {source && <span className="bg-white/15 px-2.5 py-0.5 rounded-full truncate max-w-[60%]">{source}</span>}
@@ -484,10 +485,11 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
           )}
           {isCurrent && showSummary && resume && (
             <div
-              className="mt-3 max-h-[55vh] overflow-y-auto overscroll-contain touch-pan-y rounded-xl bg-black/40 p-3 text-[0.9rem] leading-relaxed text-white/95"
+              className="mt-3 max-h-[55vh] md:max-h-[60vh] overflow-y-auto overscroll-contain touch-pan-y rounded-xl bg-black/40 p-3 md:p-4 text-[0.9rem] md:text-[1rem] leading-relaxed text-white/95"
               onTouchStart={e => e.stopPropagation()}
               onTouchMove={e => e.stopPropagation()}
               onTouchEnd={e => e.stopPropagation()}
+              onWheel={e => e.stopPropagation()}
               onClick={e => e.stopPropagation()}
             >
               {resumeMd
@@ -497,7 +499,9 @@ function ImmersiveSlide({ article, offset, drag, dragging, isCurrent, showSummar
           )}
           {isCurrent && resume && (
             <div className="mt-2 text-[11px] text-white/55">
-              {showSummary ? 'Appuyez pour masquer le résumé' : 'Appuyez pour afficher le résumé'}
+              {isDesktop
+                ? (showSummary ? 'Cliquez pour masquer le résumé' : 'Cliquez pour afficher le résumé')
+                : (showSummary ? 'Appuyez pour masquer le résumé' : 'Appuyez pour afficher le résumé')}
             </div>
           )}
         </div>
@@ -519,13 +523,19 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
   const [panX, setPanX]         = useState(0)   // pan horizontal validé (points de %)
   const [dragging, setDragging] = useState(false)
   const [showSummary, setShowSummary] = useState(false)
+  const [slideshow, setSlideshow] = useState(false)   // diaporama auto (10 s)
+  // Desktop : souris/clavier + vrai plein écran ; mobile : tactile. Figé à l'ouverture.
+  const [isDesktop] = useState(() => typeof window !== 'undefined' && window.innerWidth >= 768)
   const startY = useRef(0)
   const startX = useRef(0)
   const axis   = useRef(null)   // 'h' (pan image) | 'v' (navigation) — verrouillé au 1er mouvement
   const moved  = useRef(false)
+  const wheelLock = useRef(0)   // anti-rebond molette (desktop)
 
   const goNext = useCallback(() => setCurrent(c => Math.min(c + 1, last)), [last])
   const goPrev = useCallback(() => setCurrent(c => Math.max(c - 1, 0)), [])
+  // Diaporama : défile comme la flèche droite, en bouclant à la fin.
+  const advanceLoop = useCallback(() => setCurrent(c => (c >= last ? 0 : c + 1)), [last])
 
   // On remonte l'index courant à la fermeture pour que la liste sous-jacente
   // se synchronise sur le dernier article consulté (cf. ArticleListViewer).
@@ -549,16 +559,44 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
     return () => { document.body.style.overflow = prev }
   }, [])
 
-  // Raccourcis clavier (desktop / debug)
+  // Raccourcis clavier : ↑/↓ et ←/→ changent d'article, Échap ferme, Espace (dé)plie le résumé.
   useEffect(() => {
     const onKey = e => {
       if (e.key === 'Escape') handleClose()
-      else if (e.key === 'ArrowDown') goNext()
-      else if (e.key === 'ArrowUp') goPrev()
+      else if (e.key === 'ArrowDown' || e.key === 'ArrowRight') goNext()
+      else if (e.key === 'ArrowUp'   || e.key === 'ArrowLeft')  goPrev()
+      else if (e.key === ' ') { e.preventDefault(); setShowSummary(s => !s) }
     }
     window.addEventListener('keydown', onKey)
     return () => window.removeEventListener('keydown', onKey)
   }, [handleClose, goNext, goPrev])
+
+  // Diaporama : avance automatiquement toutes les 10 s (en bouclant). Le timer est
+  // ré-armé à chaque changement d'article — une navigation manuelle relance le délai.
+  useEffect(() => {
+    if (!slideshow) return
+    const id = setTimeout(advanceLoop, 10000)
+    return () => clearTimeout(id)
+  }, [slideshow, current, advanceLoop])
+
+  // Plein écran réel (desktop) : si l'utilisateur quitte le plein écran (Échap
+  // navigateur, F11…), on ferme aussi le viewer pour rester cohérent.
+  useEffect(() => {
+    const onFsChange = () => { if (!document.fullscreenElement) handleClose() }
+    document.addEventListener('fullscreenchange', onFsChange)
+    return () => document.removeEventListener('fullscreenchange', onFsChange)
+  }, [handleClose])
+
+  // Molette (desktop) : équivalent du swipe vertical — change d'article, anti-rebond.
+  const onWheel = e => {
+    if (Math.abs(e.deltaY) < 20) return
+    const now = e.timeStamp || performance.now()
+    if (now - wheelLock.current < 500) return
+    wheelLock.current = now
+    if (e.deltaY > 0) goNext(); else goPrev()
+  }
+  // Clic (desktop, hors gestes tactiles) : (dé)plie le résumé.
+  const onClick = () => { if (isDesktop) setShowSummary(s => !s) }
 
   const onTouchStart = e => {
     startY.current = e.touches[0].clientY
@@ -607,6 +645,8 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
       onTouchStart={onTouchStart}
       onTouchMove={onTouchMove}
       onTouchEnd={onTouchEnd}
+      onWheel={onWheel}
+      onClick={onClick}
     >
       {articles.map((a, i) =>
         Math.abs(i - current) <= 1 ? (
@@ -619,6 +659,7 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
             isCurrent={i === current}
             showSummary={showSummary}
             panX={i === current ? appliedPan : 0}
+            isDesktop={isDesktop}
           />
         ) : null
       )}
@@ -631,9 +672,24 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
         {current + 1} / {articles.length}
       </div>
 
+      {/* Diaporama (haut, centré) : défile comme la flèche droite toutes les 10 s */}
+      <button
+        onClick={e => { e.stopPropagation(); setSlideshow(s => !s) }}
+        onTouchStart={e => e.stopPropagation()}
+        aria-label={slideshow ? 'Arrêter le diaporama' : 'Lancer le diaporama (10 s)'}
+        aria-pressed={slideshow}
+        className={`absolute left-1/2 -translate-x-1/2 z-10 flex items-center gap-1.5 px-3.5 py-1.5 rounded-full backdrop-blur-md text-xs font-semibold transition-colors active:scale-95 ${
+          slideshow ? 'bg-emerald-500/80 text-white' : 'bg-black/45 text-white/85 hover:bg-black/60'
+        }`}
+        style={{ top: 'max(1rem, env(safe-area-inset-top))' }}
+      >
+        {slideshow ? <Pause size={15} /> : <Play size={15} />}
+        <span>Diaporama</span>
+      </button>
+
       {/* Fermer */}
       <button
-        onClick={handleClose}
+        onClick={e => { e.stopPropagation(); handleClose() }}
         onTouchStart={e => e.stopPropagation()}
         aria-label="Fermer le mode plein écran"
         className="absolute right-4 z-10 w-10 h-10 rounded-full bg-black/45 backdrop-blur-md flex items-center justify-center text-white active:scale-90 transition-transform"
@@ -641,6 +697,26 @@ function ImmersiveViewer({ articles, startIndex, onClose }) {
       >
         <X size={20} />
       </button>
+
+      {/* Flèches de navigation (desktop) : haut = précédent, bas = suivant */}
+      <div className="hidden md:flex flex-col gap-3 absolute right-5 top-1/2 -translate-y-1/2 z-10">
+        <button
+          onClick={e => { e.stopPropagation(); goPrev() }}
+          disabled={current === 0}
+          aria-label="Article précédent"
+          className="w-12 h-12 rounded-full bg-black/45 backdrop-blur-md flex items-center justify-center text-white hover:bg-black/65 disabled:opacity-30 disabled:cursor-default transition-colors active:scale-90"
+        >
+          <ChevronUp size={26} />
+        </button>
+        <button
+          onClick={e => { e.stopPropagation(); goNext() }}
+          disabled={current === last}
+          aria-label="Article suivant"
+          className="w-12 h-12 rounded-full bg-black/45 backdrop-blur-md flex items-center justify-center text-white hover:bg-black/65 disabled:opacity-30 disabled:cursor-default transition-colors active:scale-90"
+        >
+          <ChevronDown size={26} />
+        </button>
+      </div>
     </div>
   )
 }
@@ -981,7 +1057,7 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, o
       })
       const d = await r.json()
       if (d.ok) {
-        const enriched = { 'Résumé': d.resume }
+        const enriched = { 'Résumé': d.resume, 'Résumé_md': d.resume_md || '' }
         if (d.entities && Object.keys(d.entities).length > 0) enriched.entities = d.entities
         if (d.sentiment)               enriched.sentiment              = d.sentiment
         if (d.score_sentiment != null) enriched.score_sentiment        = d.score_sentiment
@@ -1029,9 +1105,16 @@ function ArticleCard({ article, index, highlight, onEntityClick, onFullReport, o
           ref={heroRef}
           type="button"
           onClick={() => {
-            // Sur mobile : ouvre le mode immersif plein écran (toute la liste) ; sinon lightbox classique
-            if (onImmersive && typeof window !== 'undefined' && window.innerWidth < 768) onImmersive(index)
-            else setLightbox(true)
+            // Clic image → mode immersif plein écran (mobile ET desktop). Sur desktop,
+            // on bascule en vrai plein écran (Fullscreen API) dans le geste utilisateur.
+            if (onImmersive) {
+              if (typeof window !== 'undefined' && window.innerWidth >= 768) {
+                document.documentElement.requestFullscreen?.().catch(() => {})
+              }
+              onImmersive(index)
+            } else {
+              setLightbox(true)
+            }
           }}
           className={`group relative w-full ${isLarge ? 'h-[432px] sm:h-[576px]' : 'h-44 sm:h-52'} overflow-hidden bg-slate-100 dark:bg-slate-900 block text-left`}
           title="Agrandir l'image"
@@ -2279,6 +2362,10 @@ const ArticleListViewer = forwardRef(function ArticleListViewer({ content, annot
           articles={displayedArticles}
           startIndex={immersiveIndex}
           onClose={(lastIndex) => {
+            // Sort du vrai plein écran (desktop) si actif
+            if (typeof document !== 'undefined' && document.fullscreenElement) {
+              document.exitFullscreen?.().catch(() => {})
+            }
             setImmersiveIndex(null)
             if (typeof lastIndex === 'number' && lastIndex >= 0 && lastIndex < displayedArticles.length) {
               const url = displayedArticles[lastIndex]?.['URL']

--- a/viewer/src/components/MarkdownViewer.jsx
+++ b/viewer/src/components/MarkdownViewer.jsx
@@ -188,7 +188,7 @@ const mdComponents = {
             <h2 className="text-xl font-semibold text-slate-900 dark:text-slate-100 mt-7 mb-3">{children}</h2>
           ),
           h3: ({ children }) => (
-            <h3 className="text-4xl font-bold text-slate-900 dark:text-slate-100 mt-8 mb-4 leading-tight">{children}</h3>
+            <h3 className="text-lg font-semibold text-slate-900 dark:text-slate-100 mt-6 mb-2 leading-snug">{children}</h3>
           ),
           h4: ({ children }) => (
             <h4 className="text-sm font-semibold text-slate-700 dark:text-slate-300 mt-4 mb-1">{children}</h4>

--- a/viewer/src/components/TopArticlesPanel.jsx
+++ b/viewer/src/components/TopArticlesPanel.jsx
@@ -392,7 +392,7 @@ function ArticleCard({ article, rank, onEntityClick, isCurrentPodcast, annotatio
       })
       const d = await r.json()
       if (d.ok) {
-        const enriched = { 'Résumé': d.resume }
+        const enriched = { 'Résumé': d.resume, 'Résumé_md': d.resume_md || '' }
         if (d.entities && Object.keys(d.entities).length > 0) enriched.entities = d.entities
         if (d.sentiment)               enriched.sentiment              = d.sentiment
         if (d.score_sentiment != null) enriched.score_sentiment        = d.score_sentiment


### PR DESCRIPTION
## Résumé

Lot de correctifs et fonctionnalités issus d'une session de veille WUDD.ai.

### 🈲 Garde-fou anti-chinois sur les résumés (`b39e4ea`)
- Les modèles Qwen dérivaient parfois du français vers le chinois. `utils/summary_formatter.py` (qui produit le `Résumé_md`) n'avait aucun garde-fou : ajout de `_contains_cjk` + une régénération corrective, sinon repli sur le `Résumé` brut français.
- `repair_failed_summaries.py` détecte désormais aussi le CJK (`needs_repair`) et invalide le `Résumé_md` dérivé.
- `/api/article/refresh-resume` génère enfin le `Résumé_md` (via `format_summary_markdown`) en plus du résumé brut, l'écrit et le renvoie ; le frontend l'applique immédiatement.

### 🖥️ Vue immersive plein écran sur desktop (`322aea5`)
- Le clic sur l'image d'un article ouvre la vue immersive sur desktop (plus seulement mobile), en vrai plein écran (Fullscreen API), adaptée aux grands écrans.
- Navigation : flèches ←/→ et ↑/↓, Espace (dé)plie le résumé, molette, clic ; bouton **diaporama** auto toutes les 10 s.

### 📊 Rapport « Analyse croisée des flux » — tableau des mots-clés
- Remplace le graphe `keyword-graph` par un tableau Markdown trié alphabétiquement (`bcc32ac`).
- Exclut les agrégats dérivés `_WUDD.AI_` (48-heures.json, direct.json, merged) du comptage — corrige un faux flux et le double comptage (`4a2724d`).
- Ajoute le nombre d'**articles détectés** par mot-clé et, pour chaque terme OU/ET, le nombre de fois où il a réellement déclenché une détection (`terme_declencheur`) (`eef8667`).

### 🧹 Un seul rapport daté par genre (`234d14a`)
- `utils/report_cleanup.py` : après écriture d'un rapport daté, supprime les fichiers frères du même genre portant d'autres dates. Câblé dans les générateurs quotidiens et mensuels. 9 tests.

## Tests
- `tests/test_report_cleanup.py` (9 tests), `tests/test_summary_formatter.py` (existant, non cassé).

## Déploiement
Images Docker worker + viewer déjà reconstruites en local avec ce code (`utils/` étant *baked*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)