### PR TITLE
chore(cron): cross_flux 1×/jour à 8h15 (juste avant le Digest)

### DIFF
--- a/archives/crontab
+++ b/archives/crontab
@@ -8,8 +8,8 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 # Surveillance round-robin des flux RSS WUDD.opml : 1 flux par exécution, toutes les 5 minutes
 # Maintient 48-heures.json à jour, puis rafraîchit la timeline et les temps de lecture (calculs locaux, < 1 s)
 */5 * * * * root cd /app && { python3 scripts/flux_watcher.py 2>&1 | tee -a /app/rapports/cron_flux_watcher.log; python3 scripts/entity_timeline.py >> /app/rapports/cron_flux_watcher.log 2>&1; python3 scripts/enrich_reading_time.py >> /app/rapports/cron_flux_watcher.log 2>&1; }
-# Analyse croisée des flux : une fois par jour à 6h30 — rapports/markdown/_WUDD.AI_/cross_flux_YYYY-MM-DD.md
-30 6 * * * root cd /app && python3 scripts/cross_flux_analysis.py 2>&1 | tee -a /app/rapports/cron_cross_flux.log
+# Analyse croisée des flux : une fois par jour à 8h15, juste avant le Digest (8h20) — rapports/markdown/_WUDD.AI_/cross_flux_YYYY-MM-DD.md
+15 8 * * * root cd /app && python3 scripts/cross_flux_analysis.py 2>&1 | tee -a /app/rapports/cron_cross_flux.log
 # Surveillance des sources web sans RSS (sitemap) : toutes les 2h — max 5 articles par source par run
 # Complète 48-heures.json et data/articles-from-rss/ de façon isolée, sans impacter le pipeline RSS
 0 */2 * * * root cd /app && python3 scripts/web_watcher.py 2>&1 | tee -a /app/rapports/cron_web_watcher.log


### PR DESCRIPTION
Déplace l'analyse croisée des flux de 6h30 à 8h15, juste avant le Digest (8h20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)